### PR TITLE
fix: route generic custom provider through ensureCustomProvider to wr…

### DIFF
--- a/src/ui/onboarding-custom-url.test.ts
+++ b/src/ui/onboarding-custom-url.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the generic "Custom (OpenAI-compatible)" onboarding fix.
+ *
+ * The bug: picking the generic custom provider during onboarding skipped the
+ * `ensureCustomProvider` path (which writes `models.json`) because the gate
+ * checked `providerInfo?.custom && providerInfo.baseUrl` — but the generic
+ * custom catalog entry has no `baseUrl`. After the fix, the gate is
+ * `providerInfo?.custom`, and `ensureCustomProvider` prompts for the URL
+ * when it's absent.
+ *
+ * These tests verify:
+ *   1. The catalog routing condition now matches the generic custom entry.
+ *   2. `writeCustomProviderToModelsJson` produces a models.json that
+ *      `resolveModelNeverMiss` can resolve — the exact failure path a
+ *      gateway sees on boot.
+ */
+
+import { strict as assert } from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { findProvider } from "../providers/catalog.js";
+import { writeCustomProviderToModelsJson } from "../integrations/custom-provider.js";
+import { resolveModelNeverMiss } from "../agents/model-resolution.js";
+
+describe("generic custom provider onboarding", () => {
+	describe("catalog routing", () => {
+		it("the generic 'custom' catalog entry has custom: true", () => {
+			const provider = findProvider("custom");
+			assert.ok(provider, "expected a 'custom' entry in the provider catalog");
+			assert.strictEqual(provider.custom, true);
+		});
+
+		it("the generic 'custom' catalog entry has no baseUrl (user provides it)", () => {
+			const provider = findProvider("custom");
+			assert.ok(provider);
+			assert.ok(
+				!provider.baseUrl,
+				`expected no baseUrl on the generic custom entry, got: ${provider.baseUrl}`,
+			);
+		});
+
+		it("the routing condition `providerInfo?.custom` matches the generic entry", () => {
+			// This test exists to prevent regressions: the old condition
+			// (`custom && baseUrl`) excluded this entry. The fix widened it
+			// to `custom` only. If someone adds `&& baseUrl` back, this test
+			// surfaces the regression with a clear explanation.
+			const provider = findProvider("custom");
+			assert.ok(provider);
+			const wouldRoute = !!provider.custom;
+			assert.ok(
+				wouldRoute,
+				"the generic custom provider must be routed to ensureCustomProvider",
+			);
+		});
+	});
+
+	describe("writeCustomProviderToModelsJson → resolveModelNeverMiss round-trip", () => {
+		let tmpDir: string;
+		let modelsJsonPath: string;
+
+		beforeEach(() => {
+			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-custom-onboard-"));
+			modelsJsonPath = path.join(tmpDir, "models.json");
+		});
+
+		afterEach(() => {
+			try {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			} catch {
+				/* best-effort cleanup */
+			}
+		});
+
+		it("a custom provider written by onboarding is resolvable by the gateway", async () => {
+			// Simulate what ensureCustomProvider does after the user enters a
+			// URL and API key during onboarding.
+			await writeCustomProviderToModelsJson(modelsJsonPath, {
+				id: "custom",
+				baseUrl: "https://integrate.api.nvidia.com/v1",
+				api: "openai-completions",
+				apiKey: "test-key-placeholder",
+				models: ["z-ai/glm-5.2"],
+			});
+
+			// Verify the file was written.
+			assert.ok(fs.existsSync(modelsJsonPath), "models.json must exist after write");
+
+			// Parse and check the shape.
+			const written = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8"));
+			assert.ok(written.providers?.custom, "expected a 'custom' provider block");
+			assert.strictEqual(
+				written.providers.custom.baseUrl,
+				"https://integrate.api.nvidia.com/v1",
+			);
+			assert.strictEqual(written.providers.custom.api, "openai-completions");
+			assert.deepStrictEqual(written.providers.custom.models, [
+				{ id: "z-ai/glm-5.2", name: "z-ai/glm-5.2" },
+			]);
+
+			// Now verify the model resolver can find it — this is the exact
+			// code path the gateway uses at startup (server.ts L580-591).
+			const registry = {
+				find: () => undefined, // no built-in match
+				getAvailable: () => [],
+				refresh: () => {},
+			};
+			const model = (await resolveModelNeverMiss({
+				modelRegistry: registry,
+				provider: "custom",
+				modelId: "z-ai/glm-5.2",
+				modelsFile: modelsJsonPath,
+			})) as Record<string, unknown>;
+
+			assert.ok(model, "expected the model to be resolvable after models.json is written");
+			assert.strictEqual(model.id, "z-ai/glm-5.2");
+			assert.strictEqual(model.provider, "custom");
+			assert.strictEqual(model.baseUrl, "https://integrate.api.nvidia.com/v1");
+			assert.strictEqual(model.api, "openai-completions");
+		});
+
+		it("without models.json the custom model is unresolvable (regression guard)", async () => {
+			// Before the fix, this was the state after onboarding with the
+			// generic custom provider — no models.json existed.
+			const registry = {
+				find: () => undefined,
+				getAvailable: () => [],
+				refresh: () => {},
+			};
+			const model = await resolveModelNeverMiss({
+				modelRegistry: registry,
+				provider: "custom",
+				modelId: "z-ai/glm-5.2",
+				modelsFile: modelsJsonPath, // file doesn't exist
+			});
+			assert.strictEqual(
+				model,
+				undefined,
+				"without models.json the custom model must not resolve (this was the bug)",
+			);
+		});
+	});
+});

--- a/src/ui/onboarding.ts
+++ b/src/ui/onboarding.ts
@@ -315,7 +315,12 @@ export async function runOnboarding(
 			// Custom (catalog-defined) providers — a key + a known
 			// Anthropic-compatible endpoint (GLM, Kimi, Qwen, MiniMax, DeepSeek).
 			// Paste the key, register the endpoint + models into models.json, done.
-			if (providerInfo?.custom && providerInfo.baseUrl) {
+			// Also handles the generic "Custom (OpenAI-compatible)" entry, which
+			// has `custom: true` but no pre-set `baseUrl`. `ensureCustomProvider`
+			// prompts for the URL when it's missing. Without this, the generic
+			// custom path falls through to `ensureApiKey`, which never writes
+			// `models.json` — leaving the model unresolvable at gateway startup.
+			if (providerInfo?.custom) {
 				const r = await ensureCustomProvider(tui, authStorage, modelRegistry, providerInfo);
 				if (r === "back") {
 					step = "provider";
@@ -1309,6 +1314,45 @@ async function ensureCustomProvider(
 	modelRegistry: ModelRegistry,
 	provider: ProviderInfo,
 ): Promise<"ok" | "back"> {
+	// Generic custom provider — the catalog entry has `custom: true` but no
+	// pre-set `baseUrl` (it varies per user). Prompt for the URL before the
+	// key-entry loop, then attach it to a shallow copy so the downstream
+	// write path sees a fully resolved provider without mutating the catalog.
+	if (!provider.baseUrl) {
+		while (true) {
+			renderScreen(tui, `Step 3 of 5 · ${provider.name}`);
+			tui.addChild(new Text(`  Enter your OpenAI-compatible base URL.`, 0, 0));
+			tui.addChild(new Text(brand.dim("  Example: https://api.example.com/v1"), 0, 0));
+			tui.addChild(new Text(brand.dim("  Enter to continue  ·  Esc to go back"), 0, 0));
+			tui.addChild(new Text("", 0, 0));
+			const urlInput = new Input();
+			tui.addChild(urlInput);
+			tui.setFocus(urlInput);
+			tui.requestRender();
+			let rawUrl: string;
+			try {
+				rawUrl = await new Promise<string>((resolve, reject) => {
+					urlInput.onSubmit = (value: string) => resolve(value.trim());
+					urlInput.onEscape = () => reject(new Error("back"));
+				});
+			} catch {
+				return "back";
+			}
+			if (!rawUrl) {
+				// Empty submit — re-render with a hint.
+				continue;
+			}
+			// Minimal URL sanity check — must start with http(s)://.
+			if (!/^https?:\/\//i.test(rawUrl)) {
+				renderScreen(tui, `Step 3 of 5 · ${provider.name}`);
+				tui.addChild(new Text(`  ${brand.error("✗")} ${brand.error("URL must start with http:// or https://")}`, 0, 0));
+				tui.addChild(new Text("", 0, 0));
+				continue;
+			}
+			provider = { ...provider, baseUrl: rawUrl, api: provider.api ?? "openai-completions" };
+			break;
+		}
+	}
 	let lastError: string | null = null;
 	// If the operator already has this provider's key in their environment (e.g.
 	// NVIDIA_API_KEY), OFFER it — confirm-then-validate, never silent-adopt. A


### PR DESCRIPTION
…ite models.json

Picking "Custom (OpenAI-compatible)" during onboarding stored the API key and provider/model choice but never wrote the models.json catalog entry that the model resolver reads at gateway startup. The gateway then failed with "model not in registry", surfaced as the opaque "this gateway hasn't been set up yet" message.

Root cause: the routing condition in runOnboarding checked `providerInfo?.custom && providerInfo.baseUrl`, but the generic custom catalog entry has no pre-set baseUrl (the user provides it). This caused the code to fall through to ensureApiKey, which never writes models.json.

Fix:
- Widen the gate to `providerInfo?.custom` so the generic entry is no longer skipped.
- Add a base-URL prompt at the top of ensureCustomProvider when provider.baseUrl is absent. The URL is attached to a shallow copy of the provider info (not the catalog singleton), so the downstream write path sees a fully resolved provider.

Named custom providers (NVIDIA NIM, GLM, DeepSeek, etc.) that already have baseUrl in the catalog are unaffected -- the new prompt only fires when baseUrl is missing.

<!--
Thanks for contributing to Brigade! Please fill out the sections below.
Use a Conventional Commit style title (e.g. `feat(cron): ...`, `fix(channels): ...`).
-->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `test` / `chore` / `ci`

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` compiles
- [ ] Added/updated tests for the change
- [ ] No secrets, real personal data, or local absolute paths in the diff
- [ ] PR title follows Conventional Commits

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs, follow-ups, etc. -->
