### PR TITLE
feat: add --replace flag to brigade gateway for in-place restart

### DIFF
--- a/src/cli/commands/gateway.ts
+++ b/src/cli/commands/gateway.ts
@@ -67,13 +67,15 @@ export function registerGatewayCommand(program: import("commander").Command): vo
 		.option("-v, --verbose", "raise log level to debug")
 		.option("-q, --quiet", "disable the console stream entirely")
 		.option("--log-level <level>", "trace|debug|info|warn|error|fatal")
-		.action(async (opts: { port?: number; host?: string; verbose?: boolean; quiet?: boolean; logLevel?: string }) => {
+		.option("--replace", "stop an existing gateway before starting (avoids 'already running' errors)")
+		.action(async (opts: { port?: number; host?: string; verbose?: boolean; quiet?: boolean; logLevel?: string; replace?: boolean }) => {
 			await runGatewayCommand({
 				port: opts.port,
 				host: opts.host,
 				verbose: opts.verbose,
 				quiet: opts.quiet,
 				logLevel: opts.logLevel as LogLevel | undefined,
+				replace: opts.replace,
 			});
 			await new Promise<void>(() => {});
 		});
@@ -85,13 +87,15 @@ export function registerGatewayCommand(program: import("commander").Command): vo
 		.option("-v, --verbose", "raise log level to debug")
 		.option("-q, --quiet", "disable the console stream entirely")
 		.option("--log-level <level>", "trace|debug|info|warn|error|fatal")
-		.action(async (opts: { port?: number; host?: string; verbose?: boolean; quiet?: boolean; logLevel?: string }) => {
+		.option("--replace", "stop an existing gateway before starting (avoids 'already running' errors)")
+		.action(async (opts: { port?: number; host?: string; verbose?: boolean; quiet?: boolean; logLevel?: string; replace?: boolean }) => {
 			await runGatewayCommand({
 				port: opts.port,
 				host: opts.host,
 				verbose: opts.verbose,
 				quiet: opts.quiet,
 				logLevel: opts.logLevel as LogLevel | undefined,
+				replace: opts.replace,
 			});
 			await new Promise<void>(() => {});
 		});
@@ -534,6 +538,8 @@ export interface GatewayCommandOptions {
 	quiet?: boolean;
 	/** Explicit log level override. Wins over both --verbose and the default. */
 	logLevel?: LogLevel;
+	/** Stop an existing gateway before starting. Avoids lock/port conflicts. */
+	replace?: boolean;
 }
 
 /**
@@ -600,10 +606,26 @@ export async function runGatewayCommand(opts: GatewayCommandOptions = {}): Promi
 		// shape is `Gateway failed to start: ...\nIf the gateway is
 		// supervised, stop it with: brigade gateway stop`.
 		if (isGatewayLockError(err)) {
+			// --replace: stop the existing gateway and retry once.
+			if (opts.replace) {
+				process.stderr.write(
+					chalk.yellow(`brigade-gateway: replacing existing gateway (pid ${err.holderPid ?? "unknown"})…\n`),
+				);
+				const stopCode = await runGatewayStopCommand({ port, timeout: 5000 });
+				if (stopCode !== 0) {
+					process.stderr.write(chalk.red(`brigade-gateway: failed to stop the existing gateway.\n`));
+					process.exit(EXIT_FAILURE);
+				}
+				// Brief pause to let the OS release the port (TIME_WAIT).
+				await new Promise((resolve) => setTimeout(resolve, 500));
+				// Retry — call ourselves WITHOUT --replace to avoid infinite loops.
+				return await runGatewayCommand({ ...opts, replace: false });
+			}
 			const listeners = inspectPortListeners(port);
 			let body =
 				`brigade-gateway: failed to start: ${chalk.red(msg)}\n` +
 				chalk.dim(`  If the gateway is supervised, stop it with: ${chalk.bold("brigade gateway stop")}\n`) +
+				chalk.dim(`  Or restart in-place with: ${chalk.bold("brigade gateway --replace")}\n`) +
 				`Port ${port} is already in use.\n`;
 			if (listeners.length > 0) {
 				for (const l of listeners) {


### PR DESCRIPTION
When a gateway is already running, `brigade gateway` fails with a lock timeout error, requiring the operator to manually run `brigade gateway stop` first. The new `--replace` flag automates this: it catches the GatewayLockError, gracefully stops the existing gateway (reusing the existing stop logic with WS shutdown handshake + SIGTERM fallback), waits briefly for the port to release, then retries startup.

Usage:
  brigade gateway --replace
  brigade gateway run --replace

The retry passes `replace: false` to prevent infinite loops. Without the flag, the existing error message now also hints at `--replace` as a recovery option alongside `brigade gateway stop`.

<!--
Thanks for contributing to Brigade! Please fill out the sections below.
Use a Conventional Commit style title (e.g. `feat(cron): ...`, `fix(channels): ...`).
-->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `test` / `chore` / `ci`

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` compiles
- [ ] Added/updated tests for the change
- [ ] No secrets, real personal data, or local absolute paths in the diff
- [ ] PR title follows Conventional Commits

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs, follow-ups, etc. -->
