### PR TITLE
fix(security): recognise Google AQ. prefix in redactor and secrets audit

### DIFF
--- a/src/cli/commands/secrets-audit.ts
+++ b/src/cli/commands/secrets-audit.ts
@@ -26,6 +26,7 @@ const PATTERNS: { name: string; re: RegExp }[] = [
 	{ name: "anthropic-key", re: /sk-ant-[a-z0-9-_]{30,}/i },
 	{ name: "openai-key", re: /sk-(?:proj-)?[A-Za-z0-9]{32,}/ },
 	{ name: "google-key", re: /AIza[0-9A-Za-z\-_]{30,}/ },
+	{ name: "google-key-aq", re: /\bAQ\.[0-9A-Za-z\-_]{30,}/ },
 	{ name: "aws-access-key", re: /AKIA[0-9A-Z]{16}/ },
 	{ name: "bearer-token-long", re: /Bearer\s+[A-Za-z0-9._-]{30,}/i },
 	{ name: "generic-secret-line", re: /\b(?:secret|api[_-]?key|token|password)\s*[:=]\s*['"]?[A-Za-z0-9._\-+/=]{24,}/i },

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -15,8 +15,10 @@
  *   - AWS access keys (`AKIA…`, `ASIA…`) → `<redacted:aws-key>`
  *   - GitHub PATs (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_` + 36 alnum) →
  *     `<redacted:github-token>`
- *   - OpenAI / Anthropic / Google AI keys (`sk-…`, `sk-ant-…`, `AIza…`) →
- *     `<redacted:provider-key>`
+ *   - OpenAI / Anthropic / Google AI keys (`sk-…`, `sk-ant-…`, `AIza…`) , 
+ *     AQ.…) → <redacted:provider-key>. Google issues both the legacy 
+ *     AIza… and the newer AQ.… prefixes for Gemini / AI Studio keys; 
+ *     both shapes must be caught so a fresh key doesn't leak into logs. 
  *   - Phone numbers in `+CCNNNNNNNNNN` form (≥10 digits after `+`) →
  *     `<redacted:phone>`
  *   - Email addresses → `<redacted:email>`
@@ -32,6 +34,7 @@ const PATTERNS: Array<{ re: RegExp; replacement: string }> = [
 	{ re: /\bgh[opusr]_[A-Za-z0-9]{36}\b/g, replacement: "<redacted:github-token>" },
 	{ re: /\bsk-(?:ant-)?[A-Za-z0-9_\-]{20,}\b/g, replacement: "<redacted:provider-key>" },
 	{ re: /\bAIza[A-Za-z0-9_\-]{35}\b/g, replacement: "<redacted:provider-key>" },
+	{ re: /\bAQ\.[A-Za-z0-9_\-]{30,}\b/g, replacement: "<redacted:provider-key>" },
 	{ re: /\+\d{10,15}\b/g, replacement: "<redacted:phone>" },
 	{ re: /\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b/g, replacement: "<redacted:email>" },
 ];


### PR DESCRIPTION
<!--
Thanks for contributing to Brigade! Please fill out the sections below.
Use a Conventional Commit style title (e.g. `feat(cron): ...`, `fix(channels): ...`).
-->

## Summary

Adds AQ. prefix recognition to Brigade's Google Gemini key detection in 
the two places that still hardcoded only AIza. Google's newer AI Studio / 
Gemini keys use the AQ. prefix without this change, a fresh AQ. key 
sitting in state files silently passes the leak scanner, and one appearing 
in a log line is passed through unredacted. 

## Context 

- The onboarding entry check (validateApiKey in src/ui/onboarding.ts) 
 was already fixed in 41592f4  it now accepts any prefix and defers 
 to live validation. This PR closes the parallel gap in the log redactor 
 and the brigade secrets audit scanner, which were missed at the time. 


## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `test` / `chore` / `ci`

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` compiles
- [x] Added/updated tests for the change
- [ ] No secrets, real personal data, or local absolute paths in the diff
- [ ] PR title follows Conventional Commits

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs, follow-ups, etc. -->
