### PR TITLE
fix(storage): factory-reset must not uninstall the CLI or erase the local Convex DB

### DIFF
--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -80,6 +80,29 @@ export async function runOnboardCommand(opts: OnboardCommandOptions = {}): Promi
 	// stdin is still ours — decides animated vs static chrome. ≤150 ms once.
 	await probeTerminalAnimationSupport();
 
+	// Stop any running gateway BEFORE the wizard touches local state. The
+	// factory-reset primitive (behind a "Clear it" / "Start fresh" pick) requires
+	// it: a live daemon holds open handles under ~/.brigade, and on Windows
+	// deleting an open file throws EPERM and aborts the wizard mid-wipe (POSIX
+	// silently allows it — which is why this bit Windows and not macOS/Linux).
+	// Lazy-imported so onboard's boot stays light; best-effort + quiet when
+	// nothing is running. Onboard already tells the user to (re)start the gateway
+	// at the end, so stopping a stale one here changes nothing they didn't expect.
+	try {
+		const { readPid, isProcessAlive } = await import("../../core/gateway-probe.js");
+		const pid = await readPid();
+		if (pid && isProcessAlive(pid)) {
+			process.stdout.write(
+				chalk.dim("Stopping the running gateway so onboarding can reset state cleanly…\n"),
+			);
+			const { runGatewayStopCommand } = await import("./gateway.js");
+			await runGatewayStopCommand({ json: false });
+		}
+	} catch {
+		// If we can't stop it, continue anyway — the wipe now preserves the runtime
+		// + convex store, so a reset still can't uninstall the CLI or lose data.
+	}
+
 	const tui = new TUI(new ProcessTerminal());
 	tui.start();
 

--- a/src/cli/commands/store-cmd.ts
+++ b/src/cli/commands/store-cmd.ts
@@ -10,7 +10,6 @@
 // where Brigade will read/write on next boot. `brigade store migrate` (a
 // later PR) handles the data copy.
 
-import * as fs from "node:fs";
 import readline from "node:readline/promises";
 
 import chalk from "chalk";
@@ -389,7 +388,9 @@ export async function runStoreReset(opts: StoreResetOptions = {}): Promise<numbe
 	let purgedLocal = false;
 	if (opts.purgeLocal) {
 		try {
-			fs.rmSync(resolveStateDir(), { recursive: true, force: true });
+			// Preserve the bundled runtime (Node + `brigade` binary can live under
+			// the state dir); a raw rm -rf ~/.brigade would uninstall the CLI.
+			wipeLocalBrigadeState();
 			purgedLocal = true;
 		} catch (err) {
 			return fail(`backend erased, but couldn't remove the local folder — ${(err as Error).message}`);

--- a/src/storage/factory-reset.test.ts
+++ b/src/storage/factory-reset.test.ts
@@ -4,13 +4,19 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
-import { wipeLocalBrigadeState } from "./factory-reset.js";
+import { computePreservedEntries, wipeLocalBrigadeState } from "./factory-reset.js";
 
 /**
  * The factory-reset primitive — the one destructive op behind "Start fresh" /
- * `store reset`. Tested in isolation so the dangerous part is pinned: it wipes
- * the WHOLE local state dir (so a re-onboard is virgin), is idempotent, and
- * NEVER reaches outside the state dir (the encryption key lives there).
+ * `store reset`. Tested in isolation so the dangerous part is pinned: it clears
+ * the local state (so a re-onboard is virgin), is idempotent, NEVER reaches
+ * outside the state dir (the encryption key lives there), and PRESERVES the two
+ * things under the state dir that aren't disposable state: the running install
+ * (bundled Node + `brigade` binary — wiping it uninstalls the CLI mid-reset,
+ * "command not found" afterward; detected NAME-AGNOSTICALLY so the Windows
+ * `node`-named dir is caught as well as the Unix `runtime` one) and `convex/`
+ * (the local backend's binary + its authoritative database — wiping it is
+ * irreversible data loss). Both must survive.
  */
 
 let dir: string;
@@ -26,7 +32,7 @@ afterEach(() => {
 });
 
 describe("wipeLocalBrigadeState", () => {
-	it("removes the entire local state dir — workspace, skills, sessions, facts, sentinel", () => {
+	it("clears local state — workspace, skills, sessions, facts, sentinel", () => {
 		fs.mkdirSync(path.join(dir, "workspace", "memory"), { recursive: true });
 		fs.writeFileSync(path.join(dir, "workspace", "AGENTS.md"), "persona edits");
 		fs.writeFileSync(path.join(dir, "workspace", "memory", "facts.jsonl"), '{"memoryId":"x"}\n');
@@ -37,7 +43,56 @@ describe("wipeLocalBrigadeState", () => {
 
 		const cleared = wipeLocalBrigadeState(dir);
 		assert.equal(cleared, dir);
-		assert.equal(fs.existsSync(dir), false, "whole state dir gone — next onboard starts virgin");
+		for (const entry of ["workspace", "skills", "sessions", "mode.sentinel"]) {
+			assert.equal(fs.existsSync(path.join(dir, entry)), false, `${entry} cleared — next onboard starts virgin`);
+		}
+	});
+
+	it("PRESERVES runtime/ — the bundled Node + brigade binary are not uninstalled by a reset", () => {
+		// Simulate the packaging/install/install.sh layout: a private Node runtime
+		// AND the brigade launcher live under <stateDir>/runtime, with
+		// <stateDir>/runtime/bin on PATH. A blind rm -rf here is the "command not
+		// found: brigade" bug — so runtime/ must survive alongside cleared state.
+		fs.mkdirSync(path.join(dir, "runtime", "bin"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "runtime", "bin", "node"), "#!/bin/sh\n");
+		fs.writeFileSync(path.join(dir, "runtime", "bin", "brigade"), "#!/usr/bin/env node\n");
+		fs.mkdirSync(path.join(dir, "workspace"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "mode.sentinel"), '{"mode":"filesystem"}');
+
+		wipeLocalBrigadeState(dir);
+
+		assert.equal(fs.existsSync(path.join(dir, "workspace")), false, "state still cleared");
+		assert.equal(fs.existsSync(path.join(dir, "mode.sentinel")), false, "sentinel still cleared");
+		assert.equal(
+			fs.existsSync(path.join(dir, "runtime", "bin", "brigade")),
+			true,
+			"the brigade binary survives — the CLI is not uninstalled by a reset",
+		);
+		assert.equal(fs.existsSync(path.join(dir, "runtime", "bin", "node")), true, "the bundled node survives");
+	});
+
+	it("PRESERVES convex/ — the local self-hosted backend binary + database are not erased by a reset", () => {
+		// Global installs run the local Convex backend from <stateDir>/convex:
+		// its binary under convex/bin and — critically — its sqlite DATABASE under
+		// convex/data. In convex mode that db IS the authoritative store, so a
+		// blind rm -rf here is irreversible user-data loss. It must survive.
+		fs.mkdirSync(path.join(dir, "convex", "bin"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "convex", "bin", "convex-local-backend"), "ELF");
+		fs.mkdirSync(path.join(dir, "convex", "data"), { recursive: true });
+		fs.writeFileSync(path.join(dir, "convex", "data", "convex_local_backend.sqlite3"), "SQLite format 3\0");
+		fs.writeFileSync(path.join(dir, "convex", "data", "identity.json"), '{"name":"brigade-local"}');
+		fs.mkdirSync(path.join(dir, "workspace"), { recursive: true });
+
+		wipeLocalBrigadeState(dir);
+
+		assert.equal(fs.existsSync(path.join(dir, "workspace")), false, "filesystem-mode state still cleared");
+		assert.equal(
+			fs.existsSync(path.join(dir, "convex", "data", "convex_local_backend.sqlite3")),
+			true,
+			"the convex database survives — a reset is not data loss",
+		);
+		assert.equal(fs.existsSync(path.join(dir, "convex", "data", "identity.json")), true, "backend identity survives");
+		assert.equal(fs.existsSync(path.join(dir, "convex", "bin", "convex-local-backend")), true, "backend binary survives");
 	});
 
 	it("is idempotent — wiping a missing dir does not throw", () => {
@@ -55,5 +110,49 @@ describe("wipeLocalBrigadeState", () => {
 		} finally {
 			fs.rmSync(osConfig, { recursive: true, force: true });
 		}
+	});
+});
+
+describe("computePreservedEntries — name-agnostic self-preservation", () => {
+	// Detection uses the host's path separator; on this POSIX test host we build
+	// paths with that same separator, so a dir literally named "node" under the
+	// state dir faithfully stands in for the Windows install layout.
+	const state = path.join(path.sep, "home", "u", ".brigade");
+
+	it("preserves the dir holding the running node — Unix `runtime` layout", () => {
+		const set = computePreservedEntries(state, path.join(state, "runtime", "bin", "node"), null);
+		assert.equal(set.has("runtime"), true);
+	});
+
+	it("preserves the running node's dir even when it's named `node` — Windows layout", () => {
+		// THE regression guard for the Windows report: a static ["runtime"]
+		// allowlist would miss the Windows-installer name and the wipe would delete
+		// the interpreter → "command not found". Detection catches it by content.
+		const set = computePreservedEntries(state, path.join(state, "node", "node.exe"), null);
+		assert.equal(set.has("node"), true, "the interpreter's dir is preserved regardless of its name");
+	});
+
+	it("preserves the dir holding the installed brigade package", () => {
+		const pkg = path.join(state, "runtime", "lib", "node_modules", "@spinabot", "brigade");
+		const set = computePreservedEntries(state, path.join(path.sep, "usr", "bin", "node"), pkg);
+		assert.equal(set.has("runtime"), true);
+	});
+
+	it("adds NOTHING extra when the runtime lives OUTSIDE the state dir (system / Windows %LOCALAPPDATA% node)", () => {
+		const set = computePreservedEntries(
+			state,
+			path.join(path.sep, "Users", "u", "AppData", "Local", "Brigade", "node", "node.exe"),
+			path.join(path.sep, "Users", "u", "AppData", "Local", "Brigade", "node", "node_modules", "brigade"),
+		);
+		assert.deepEqual([...set].sort(), ["convex", "runtime"], "only the static names — no false preserve");
+	});
+
+	it("keeps convex/ (static), tolerates a null package root, and never preserves the state dir or a sibling", () => {
+		const base = computePreservedEntries(state, path.join(path.sep, "usr", "bin", "node"), null);
+		assert.equal(base.has("convex"), true);
+		// execPath == stateDir (degenerate) and a sibling dir must both add nothing.
+		assert.deepEqual([...computePreservedEntries(state, state, null)].sort(), ["convex", "runtime"]);
+		const sibling = path.join(path.dirname(state), "other", "node");
+		assert.deepEqual([...computePreservedEntries(state, sibling, null)].sort(), ["convex", "runtime"]);
 	});
 });

--- a/src/storage/factory-reset.ts
+++ b/src/storage/factory-reset.ts
@@ -9,12 +9,36 @@
 // workspace-setup stamp) always survived and was re-mirrored / re-read on the
 // next boot, so "Start fresh" was NOT a fresh start. This wipes it.
 //
-// What is intentionally NOT touched:
-//   • The encryption key — it lives OUTSIDE the state dir (OS config dir) and is
-//     retired-to-`.bak` separately, never destroyed, so an OLD backup of the
-//     erased data stays readable.
-//   • The Convex backend — the caller erases that explicitly (it's a different
-//     store); this helper only clears the LOCAL side.
+// This clears filesystem-mode STATE only. It is NOT an uninstaller and NOT a
+// convex-backend eraser, so two classes of thing under the state dir survive —
+// removing either turns a routine reset into an outage or data loss:
+//
+//   • The RUNNING install — the interpreter + the `brigade` CLI itself. The
+//     bundled-install path drops a private Node runtime AND the brigade package
+//     UNDER the state dir, then puts it on PATH. A blind `rm -rf ~/.brigade`
+//     deletes the very node/binary that are executing, so the next
+//     `brigade`/`node`/`npm` in a new shell is "command not found" — the reset
+//     silently UNINSTALLS Brigade. This is preserved by DETECTION, not by name:
+//     the installers disagree on the dir name (Unix install.sh → `runtime`,
+//     Windows install.ps1 → `node`), so a name allowlist would miss one and
+//     uninstall the CLI. We instead keep whatever top-level entry contains
+//     `process.execPath` or the installed package (see computePreservedEntries).
+//     When the runtime lives OUTSIDE the state dir (Windows' %LOCALAPPDATA%, or a
+//     system/nvm node), nothing under the state dir matches, so it's a no-op.
+//   • `convex/` — the self-hosted Convex backend a GLOBAL install runs locally:
+//     its binary at `~/.brigade/convex/bin` and, critically, its DATABASE at
+//     `~/.brigade/convex/data`. In convex mode that sqlite IS the authoritative
+//     store — wiping it is total, irreversible user-data loss (and if the
+//     backend is running, pulls its binary + db out from under it mid-flight,
+//     which on Windows also throws EPERM and aborts the reset). Callers that DO
+//     want a virgin backend erase it through the admin API (resetConvexInstance
+//     clears documents, keeping the dir + identity); this helper must not delete
+//     the dir. (In-repo dev keeps convex under `<root>/.convex-data`, outside
+//     the state dir — no entry here, no-op.)
+//
+// Also intentionally safe: the encryption key lives OUTSIDE the state dir (OS
+// config dir) and is retired-to-`.bak` separately, never destroyed, so an OLD
+// backup of the erased data stays readable.
 //
 // Caller contract: the gateway MUST be stopped first (open file handles +
 // write-behind chains would otherwise race a directory removal), and the mode
@@ -22,15 +46,87 @@
 // onboard wizard pins it after this runs; `store reset` deletes it on purpose).
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 
-import { resolveStateDir } from "../config/paths.js";
+import { resolvePackageRoot, resolveStateDir } from "../config/paths.js";
 
 /**
- * Remove the entire local Brigade state dir (`~/.brigade` by default) so the
- * next onboard/boot re-seeds defaults. Idempotent (`force` — a missing dir is
- * fine). Returns the path that was cleared.
+ * Top-level entry names that are never disposable filesystem-mode state:
+ *   • "convex" — the local self-hosted backend's binary AND its authoritative
+ *     sqlite database (same dir name on every OS); wiping it is data loss.
+ *   • "runtime" — the Unix installer's bundled-Node dir. Belt-and-suspenders:
+ *     the name-agnostic detection below already covers it because the running
+ *     `node` lives there, but naming it keeps the intent legible.
+ * Installs that keep these elsewhere (system node; in-repo convex) simply won't
+ * have the entry, so preserving the name is a harmless no-op for them.
+ */
+const STATIC_PRESERVE = ["convex", "runtime"] as const;
+
+/**
+ * The set of top-level entries under `stateDir` a wipe must KEEP.
+ *
+ * Beyond the static names, this preserves — NAME-AGNOSTICALLY — whatever
+ * top-level dir (if any) contains the running Node binary (`execPath`) or the
+ * installed brigade package (`packageRoot`). That is the load-bearing
+ * guarantee: a reset must never delete the interpreter/CLI executing it,
+ * whatever the installer named its dir (`runtime` on Unix, `node` on Windows,
+ * anything tomorrow). When the runtime lives outside `stateDir`, neither path
+ * is under it and nothing extra is preserved.
+ *
+ * Pure over its inputs — exported so the detection is unit-tested directly
+ * (simulating the Windows `node`-named layout without needing Windows).
+ */
+export function computePreservedEntries(
+	stateDir: string,
+	execPath: string,
+	packageRoot: string | null,
+): Set<string> {
+	const preserved = new Set<string>(STATIC_PRESERVE);
+	for (const target of [execPath, packageRoot]) {
+		const entry = topLevelEntryUnder(stateDir, target);
+		if (entry) preserved.add(entry);
+	}
+	return preserved;
+}
+
+/**
+ * The first path segment of `target` relative to `stateDir`, or null when
+ * `target` is absent, IS `stateDir`, or lies outside it. Guards against `..`
+ * escapes and absolute-relative results (different drive on Windows).
+ */
+function topLevelEntryUnder(stateDir: string, target: string | null): string | null {
+	if (!target) return null;
+	const rel = path.relative(stateDir, target);
+	if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+	const [first] = rel.split(path.sep);
+	return first && first !== ".." ? first : null;
+}
+
+/**
+ * Clear the local Brigade state dir (`~/.brigade` by default) so the next
+ * onboard/boot re-seeds defaults, while preserving the running install + the
+ * local convex store (see computePreservedEntries). Removes the CONTENTS rather
+ * than the dir itself so the preserved entries can stay put. Idempotent (a
+ * missing dir is fine). Returns the path that was cleared.
  */
 export function wipeLocalBrigadeState(stateDir: string = resolveStateDir()): string {
-	fs.rmSync(stateDir, { recursive: true, force: true });
+	let packageRoot: string | null = null;
+	try {
+		packageRoot = resolvePackageRoot();
+	} catch {
+		packageRoot = null;
+	}
+	const preserve = computePreservedEntries(stateDir, process.execPath, packageRoot);
+
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(stateDir, { withFileTypes: true });
+	} catch {
+		return stateDir; // nothing to wipe (missing dir) — matches the old `force` behaviour
+	}
+	for (const entry of entries) {
+		if (preserve.has(entry.name)) continue;
+		fs.rmSync(path.join(stateDir, entry.name), { recursive: true, force: true });
+	}
 	return stateDir;
 }


### PR DESCRIPTION
## Problem

`wipeLocalBrigadeState()` did a blunt `rm -rf ~/.brigade`. But two things live under that dir that must not be destroyed by a state reset:

- **The running install.** The no-Node bundled install puts Brigade's own Node runtime **and the `brigade` binary** under `~/.brigade/runtime` (Unix installer), so **"Clear it" / "Start fresh" / `store reset --purge-local` deleted the interpreter that was running** → `brigade`/`node`/`npm` become `command not found` in every new shell.
- **The local Convex DB.** A global install keeps the self-hosted backend's database at `~/.brigade/convex/data`. The same wipe was **silent, irreversible data loss** — and on Windows an **EPERM crash** mid-wipe while the backend held its sqlite open.

## Fix

- `wipeLocalBrigadeState` now clears state **contents** while preserving, **name-agnostically**, whatever top-level entry holds the running `node` (`process.execPath`) or the installed package — so it holds whether the installer named the dir `runtime` (Unix) or `node` (Windows), and is a no-op when the runtime lives outside the state dir. Plus the local `convex/` store.
- `store reset --purge-local` routed through the same primitive (it had its own raw `rm -rf`).
- `onboard` stops a running gateway before the wizard wipes — honoring the factory-reset "gateway must be stopped first" contract (a live daemon's open handles otherwise EPERM-abort the wizard on Windows).

## Tests

- `factory-reset.test.ts`: replaced the old "removes the entire dir" assertion (which pinned the bug); added runtime-preservation, convex-preservation, and name-agnostic detection tests — including the Windows `node`-named layout. **12/12** storage tests pass.
- Typecheck + build clean.
