### PR TITLE
fix(copilot): route enterprise Copilot seats to the right endpoint and host

### DIFF
--- a/src/agents/agent-loop.ts
+++ b/src/agents/agent-loop.ts
@@ -78,6 +78,11 @@ import { cleanProviderError } from "../core/model-caps.js";
 import { adoptNewerClaudeCliLogin, healDeadSubscriptionLogin } from "../auth/auth-health.js";
 import { persistentAuthBackend } from "../core/auth-bridge.js";
 import { billingSafeContextWindow, resolveModelNeverMiss } from "./model-resolution.js";
+import {
+  applyGitHubCopilotRouting,
+  GITHUB_COPILOT_PROVIDER,
+  wrapStreamFnWithCopilotEndpointHeal,
+} from "./github-copilot-transport.js";
 import { buildAutoRecallBlock, resolveAutoRecallOrigin } from "./memory/auto-recall.js";
 import { runPreCompactionExtraction } from "./memory/extract.js";
 import type { MemoryRecordOrigin } from "./memory/records.js";
@@ -488,6 +493,32 @@ export async function runSingleTurn(args: RunSingleTurnArgs): Promise<RunSingleT
         `  • Verify your auth profile is configured: ` +
         `\`cat ${resolveAuthProfilesPath(args.agentId)}\``,
     );
+  }
+
+  // GitHub Copilot transport correction — the ONE choke point both the
+  // catalogued and the synthesized model pass through before Pi opens the
+  // session. A Copilot seat's endpoint (`/responses` vs `/chat/completions`)
+  // and API host (individual vs business vs enterprise) are account- and
+  // model-family-specific; getting either wrong is the `421 Misdirected
+  // Request` every turn on a Copilot Business/Enterprise login. See
+  // `applyGitHubCopilotRouting`.
+  if (args.provider === GITHUB_COPILOT_PROVIDER) {
+    const copilotToken = await (authStorage as { getApiKey?: (p: string) => Promise<string | undefined> })
+      .getApiKey?.(args.provider)
+      .catch(() => undefined);
+    const routed = applyGitHubCopilotRouting(model, args.modelId, copilotToken);
+    if (routed !== model) {
+      const before = model as { api?: string; baseUrl?: string };
+      const after = routed as { api?: string; baseUrl?: string };
+      if (before.api !== after.api || before.baseUrl !== after.baseUrl) {
+        log.debug("github-copilot routing corrected", {
+          model: args.modelId,
+          api: `${before.api ?? "?"} → ${after.api ?? "?"}`,
+          baseUrl: `${before.baseUrl ?? "?"} → ${after.baseUrl ?? "?"}`,
+        });
+      }
+      model = routed;
+    }
   }
 
   // Cross-process lock to prevent two `brigade agent` runs from interleaving
@@ -1116,7 +1147,21 @@ async function runSingleTurnLocked(p: RunSingleTurnLockedArgs): Promise<RunSingl
     const dispatchStreamFn = makeTransportDispatch(baseStreamFn);
     const wrappedStreamFn = wrapStreamFnWithIdleTimeout(
       wrapStreamFnWithStopReasonRecovery(
-        wrapStreamFnWithToolCallRepair(dispatchStreamFn),
+        // Copilot endpoint self-heal wraps the dispatch layer directly, so the
+        // re-issued request still goes through tool-call repair and stays under
+        // the idle timeout, while the outer wrappers never observe the
+        // healed-away failure at all. A Copilot model whose endpoint we guessed
+        // wrong (a family GitHub ships after this release) corrects itself on the
+        // first request, and every later turn starts on the right one.
+        wrapStreamFnWithCopilotEndpointHeal(
+          wrapStreamFnWithToolCallRepair(dispatchStreamFn),
+          (info) =>
+            log.warn("github-copilot endpoint corrected mid-request", {
+              model: info.modelId,
+              from: info.from,
+              to: info.to,
+            }),
+        ),
       ),
       { timeoutMs: idleTimeoutMs },
     );

--- a/src/agents/error-classifier.test.ts
+++ b/src/agents/error-classifier.test.ts
@@ -220,3 +220,37 @@ test("classifyErrorDetailed: 'out of extra usage' → subscription_limit, no sam
   assert.equal(r.class, "subscription_limit");
   assert.equal(r.retryableOnSameModel, false);
 });
+
+// ── 421 Misdirected Request (GitHub Copilot endpoint/host mismatch) ──────────
+// Pi surfaces this as a BARE `421 Misdirected Request` with no `status` field.
+// It used to fall through to `unknown`, which is transient — so the loop burned
+// three identical attempts and the TUI printed "last reason=unknown". The same
+// request can never succeed: it's a routing problem, not a blip.
+
+test("classifyError: bare '421 Misdirected Request' → model_not_found (not unknown)", () => {
+  assert.equal(classifyErrorReason(new Error("421 Misdirected Request")), "model_not_found");
+});
+
+test("classifyError: HTTP 421 with a status field → model_not_found", () => {
+  const err = Object.assign(new Error("Misdirected Request"), { status: 421 });
+  assert.equal(classifyErrorReason(err), "model_not_found");
+});
+
+test("classifyError: Copilot's chat-completions rejection → model_not_found", () => {
+  const err = new Error('400 model "gpt-5.6-luna" is not accessible via the /chat/completions endpoint');
+  assert.equal(classifyErrorReason(err), "model_not_found");
+});
+
+test("classifyErrorDetailed: 421 → model_not_found with an actionable endpoint message", () => {
+  const r = classifyErrorDetailed(new Error("421 Misdirected Request"));
+  assert.equal(r.class, "model_not_found");
+  assert.equal(r.retryableOnSameModel, false);
+  assert.match(r.message, /endpoint\/host/i);
+  assert.match(r.message, /\/responses/);
+});
+
+test("classifyError: a bare 421 inside an unrelated token count is not misread", () => {
+  // The status path only fires on a real status; "421 tokens" must not classify
+  // as a routing failure.
+  assert.equal(classifyErrorReason(new Error("prompt is too long: 421 tokens over the limit")), "context_overflow");
+});

--- a/src/agents/error-classifier.ts
+++ b/src/agents/error-classifier.ts
@@ -210,11 +210,29 @@ const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
   /truncating\s+input.*too\s+long/i, // Ollama native /api/chat overflow phrasing
 ];
 
+// Endpoint mismatch — the model exists, but not on the API surface we asked
+// for. GitHub Copilot is the loud case: it serves GPT-5+ / codex ONLY on
+// `/responses` and answers `421 Misdirected Request` (or a 400 "not accessible
+// via the /chat/completions endpoint") for a chat-completions request, and it
+// answers 421 just the same when a business/enterprise token is pointed at the
+// individual API host. Retrying the identical request is guaranteed to re-fail,
+// so this must NOT collapse into `unknown` (2 pointless retries, "last
+// reason=unknown" in the TUI) — it's a model-routing problem, so it rides the
+// `model_not_found` policy: fail fast, advance to the fallback chain.
+// (The bare status code is deliberately NOT matched here — `421` can appear in
+// an unrelated message as a token count. The status path below catches it.)
+export const ENDPOINT_MISMATCH_PATTERNS: RegExp[] = [
+  /misdirected request/i,
+  /not accessible via the \/\S+ endpoint/i,
+  /not supported (?:on|by) (?:the )?\/\S+ endpoint/i,
+];
+
 const MODEL_NOT_FOUND_PATTERNS: RegExp[] = [
   /model[_ ]?not[_ ]?found/i,
   /unknown model/i,
   /model .*?(?:does not exist|is not available)/i,
   /no such model/i,
+  ...ENDPOINT_MISMATCH_PATTERNS,
 ];
 
 const SESSION_EXPIRED_PATTERNS: RegExp[] = [
@@ -247,6 +265,12 @@ function classifyByStatus(status: number, message: string): RetryReason | null {
       return "timeout";
     case 410:
       return matchAny(message, SESSION_EXPIRED_PATTERNS) ? "session_expired" : "timeout";
+    case 421:
+      // Misdirected Request — the request reached a host/endpoint that won't
+      // serve this model (GitHub Copilot: GPT-5+ is `/responses`-only; a
+      // business/enterprise token must use its own API host). Same request,
+      // same result — fail fast and let the model-fallback chain move on.
+      return "model_not_found";
     case 422:
       return matchAny(message, FORMAT_PATTERNS) ? "format" : null;
     case 429:
@@ -627,6 +651,11 @@ export function classifyErrorDetailed(err: unknown): ClassifiedError {
     if (status === 404) {
       return { class: "model_not_found", message, retryableOnSameModel: false };
     }
+    if (status === 421) {
+      // Misdirected Request — right credential, wrong endpoint/host for this
+      // model. Retrying the identical request re-fails; advance to fallback.
+      return { class: "model_not_found", message: endpointMismatchMessage(message), retryableOnSameModel: false };
+    }
   }
 
   if (CONTEXT_OVERFLOW_PATTERNS_DETAILED.some((p) => p.test(message))) {
@@ -649,11 +678,33 @@ export function classifyErrorDetailed(err: unknown): ClassifiedError {
   if (CONTENT_FILTER_PATTERNS_DETAILED.some((p) => p.test(message))) {
     return { class: "content_filter", message, retryableOnSameModel: false };
   }
+  if (ENDPOINT_MISMATCH_PATTERNS.some((p) => p.test(message))) {
+    return {
+      class: "model_not_found",
+      message: endpointMismatchMessage(message),
+      retryableOnSameModel: false,
+    };
+  }
   if (MODEL_NOT_FOUND_PATTERNS_DETAILED.some((p) => p.test(message))) {
     return { class: "model_not_found", message, retryableOnSameModel: false };
   }
 
   return { class: "unknown", message, retryableOnSameModel: false };
+}
+
+/**
+ * Operator-facing text for an endpoint/host mismatch. A bare "421 Misdirected
+ * Request" tells the user nothing and reads like a network blip they should
+ * retry; this names the actual cause and the two things that fix it.
+ */
+function endpointMismatchMessage(message: string): string {
+  return (
+    `${message} — the provider won't serve this model on the endpoint/host the request used. ` +
+    `On GitHub Copilot this means the model is served only on a different API surface ` +
+    `(GPT-5+/codex are \`/responses\`-only) or your Copilot seat is on a business/enterprise ` +
+    `host. Pick another model with /model, or re-run \`brigade login copilot\` to refresh the ` +
+    `account's endpoint.`
+  );
 }
 
 /* ─────────────────────────── retry policy ─────────────────────────── */
@@ -757,7 +808,9 @@ function extractStatusDetailed(err: unknown): number | undefined {
   const bareMatch = msg.match(/\b([45]\d{2})\b/);
   if (bareMatch) {
     const n = Number(bareMatch[1]);
-    if ([401, 403, 404, 429, 500, 502, 503, 504].includes(n)) return n;
+    // 421 included: Pi surfaces a Copilot endpoint/host mismatch as a bare
+    // `421 Misdirected Request` with no `status` field to read.
+    if ([401, 403, 404, 421, 429, 500, 502, 503, 504].includes(n)) return n;
   }
   return undefined;
 }

--- a/src/agents/github-copilot-routing.test.ts
+++ b/src/agents/github-copilot-routing.test.ts
@@ -1,0 +1,299 @@
+/**
+ * GitHub Copilot transport routing.
+ *
+ * Regression cover for the "every turn returns 421 Misdirected Request on a
+ * Copilot Business/Enterprise login" bug. Two independent causes, both fixed at
+ * the same choke point:
+ *
+ *   1. ENDPOINT. An enterprise seat's `/models` list carries ids Pi's bundled
+ *      catalog doesn't have yet (the `gpt-5.6-*` family). The never-miss
+ *      resolver synthesized those by cloning the provider's FIRST catalogued
+ *      model — `claude-fable-5`, an `openai-completions` entry — so a GPT-5
+ *      request went to `/chat/completions`, which Copilot serves only on
+ *      `/responses`. Result: 421 on every prompt, whatever the prompt was.
+ *   2. HOST. The bundled catalog hardcodes `api.individual.githubcopilot.com`;
+ *      a business/enterprise token must talk to its own host, which is encoded
+ *      in the token's `proxy-ep` field.
+ */
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import {
+	applyGitHubCopilotRouting,
+	flipCopilotApi,
+	githubCopilotApiForModelId,
+	githubCopilotBaseUrlFromToken,
+	isCopilotEndpointMismatch,
+	resetLearnedGitHubCopilotApis,
+	wrapStreamFnWithCopilotEndpointHeal,
+} from "./github-copilot-transport.js";
+import { pickTemplateForModelId, resolveModelNeverMiss } from "./model-resolution.js";
+
+const INDIVIDUAL_HOST = "https://api.individual.githubcopilot.com";
+
+/** The bundled Copilot catalog's shape + ORDER (claude-fable-5 is first). */
+function copilotCatalog() {
+	return [
+		{ provider: "github-copilot", id: "claude-fable-5", api: "openai-completions", baseUrl: INDIVIDUAL_HOST, contextWindow: 1_000_000, input: ["text", "image"], compat: { supportsStore: false } },
+		{ provider: "github-copilot", id: "claude-haiku-4.5", api: "anthropic-messages", baseUrl: INDIVIDUAL_HOST, contextWindow: 200_000, input: ["text", "image"] },
+		{ provider: "github-copilot", id: "gpt-4.1", api: "openai-completions", baseUrl: INDIVIDUAL_HOST, contextWindow: 128_000, input: ["text"] },
+		{ provider: "github-copilot", id: "gpt-5.2", api: "openai-responses", baseUrl: INDIVIDUAL_HOST, contextWindow: 400_000, input: ["text", "image"] },
+		{ provider: "github-copilot", id: "gpt-5.4-mini", api: "openai-responses", baseUrl: INDIVIDUAL_HOST, contextWindow: 400_000, input: ["text", "image"] },
+		{ provider: "github-copilot", id: "gpt-5.5", api: "openai-responses", baseUrl: INDIVIDUAL_HOST, contextWindow: 400_000, input: ["text", "image"], thinkingLevelMap: { off: null } },
+	];
+}
+
+describe("githubCopilotApiForModelId", () => {
+	it("routes GPT-5+/o-series/codex to the responses API", () => {
+		for (const id of ["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5-mini", "gpt-6", "gpt-10.1", "o3-mini", "gpt-5.3-codex", "some-codex-preview"]) {
+			assert.equal(githubCopilotApiForModelId(id), "openai-responses", id);
+		}
+	});
+
+	it("keeps everything else on chat completions", () => {
+		for (const id of ["gpt-4.1", "claude-opus-4.8", "claude-sonnet-5", "gemini-3.5-flash", "grok-code"]) {
+			assert.equal(githubCopilotApiForModelId(id), "openai-completions", id);
+		}
+	});
+});
+
+describe("githubCopilotBaseUrlFromToken", () => {
+	it("derives the account's API host from the token's proxy-ep", () => {
+		assert.equal(
+			githubCopilotBaseUrlFromToken("tid=abc;exp=123;proxy-ep=proxy.business.githubcopilot.com;st=dotcom"),
+			"https://api.business.githubcopilot.com",
+		);
+		assert.equal(
+			githubCopilotBaseUrlFromToken("tid=abc;proxy-ep=proxy.enterprise.githubcopilot.com;exp=1"),
+			"https://api.enterprise.githubcopilot.com",
+		);
+	});
+
+	it("handles the GitHub Enterprise (GHE) copilot-proxy host shape", () => {
+		assert.equal(
+			githubCopilotBaseUrlFromToken("tid=abc;proxy-ep=copilot-proxy.acme.ghe.com;exp=1"),
+			"https://copilot-api.acme.ghe.com",
+		);
+	});
+
+	it("returns undefined for a token with no proxy-ep, and rejects a junk host", () => {
+		assert.equal(githubCopilotBaseUrlFromToken("tid=abc;exp=123"), undefined);
+		assert.equal(githubCopilotBaseUrlFromToken(undefined), undefined);
+		assert.equal(githubCopilotBaseUrlFromToken("proxy-ep=evil.com/path?x=1"), undefined);
+	});
+});
+
+describe("pickTemplateForModelId", () => {
+	it("picks the newest same-family template, not the first-listed model", () => {
+		const picked = pickTemplateForModelId(copilotCatalog(), "gpt-5.6-sol");
+		assert.equal(picked?.id, "gpt-5.5");
+	});
+
+	it("matches the claude family for a claude id", () => {
+		const picked = pickTemplateForModelId(copilotCatalog(), "claude-haiku-5");
+		assert.equal(picked?.id, "claude-haiku-4.5");
+	});
+
+	it("falls back to the first candidate when nothing shares a family", () => {
+		const picked = pickTemplateForModelId(copilotCatalog(), "zzz-brand-new");
+		assert.equal(picked?.id, "claude-fable-5");
+	});
+});
+
+describe("applyGitHubCopilotRouting", () => {
+	const token = "tid=abc;exp=1;proxy-ep=proxy.business.githubcopilot.com;st=dotcom";
+
+	it("re-points a chat-completions clone of a GPT-5 model at the responses API", () => {
+		const wrong = { provider: "github-copilot", id: "gpt-5.6-sol", api: "openai-completions", baseUrl: INDIVIDUAL_HOST, compat: { supportsStore: false }, thinkingLevelMap: { off: null } };
+		const fixed = applyGitHubCopilotRouting(wrong, "gpt-5.6-sol", token) as Record<string, unknown>;
+		assert.equal(fixed.api, "openai-responses");
+		assert.equal(fixed.baseUrl, "https://api.business.githubcopilot.com");
+		// The template's endpoint-specific quirks must NOT ride along to the other API.
+		assert.equal(fixed.compat, undefined);
+		assert.equal(fixed.thinkingLevelMap, undefined);
+	});
+
+	it("re-points the bundled individual host at the seat's own host", () => {
+		const catalogued = { provider: "github-copilot", id: "gpt-5.5", api: "openai-responses", baseUrl: INDIVIDUAL_HOST };
+		const fixed = applyGitHubCopilotRouting(catalogued, "gpt-5.5", token) as Record<string, unknown>;
+		assert.equal(fixed.baseUrl, "https://api.business.githubcopilot.com");
+		assert.equal(fixed.api, "openai-responses", "already correct — unchanged");
+	});
+
+	it("always carries Copilot's required editor headers", () => {
+		const bare = { provider: "github-copilot", id: "gpt-5.6-sol", api: "openai-completions" };
+		const fixed = applyGitHubCopilotRouting(bare, "gpt-5.6-sol", token) as { headers: Record<string, string> };
+		assert.equal(fixed.headers["Copilot-Integration-Id"], "vscode-chat");
+		assert.equal(fixed.headers["Editor-Version"], "vscode/1.107.0");
+		assert.equal(fixed.headers["Editor-Plugin-Version"], "copilot-chat/0.35.0");
+	});
+
+	it("leaves a deliberately-configured non-Copilot baseUrl alone", () => {
+		const custom = { provider: "github-copilot", id: "gpt-5.5", api: "openai-responses", baseUrl: "https://copilot-gateway.internal.acme.dev" };
+		const fixed = applyGitHubCopilotRouting(custom, "gpt-5.5", token) as Record<string, unknown>;
+		assert.equal(fixed.baseUrl, "https://copilot-gateway.internal.acme.dev");
+	});
+
+	it("is a no-op for other providers", () => {
+		const other = { provider: "openai", id: "gpt-5.6-sol", api: "openai-completions" };
+		assert.equal(applyGitHubCopilotRouting(other, "gpt-5.6-sol", token), other);
+	});
+});
+
+describe("resolveModelNeverMiss — enterprise Copilot model not in the bundled catalog", () => {
+	it("synthesizes gpt-5.6-sol onto /responses instead of cloning the first Claude entry", async () => {
+		const registry = {
+			find: () => undefined,
+			getAvailable: () => copilotCatalog(),
+			refresh: () => {},
+		};
+		const model = (await resolveModelNeverMiss({
+			modelRegistry: registry,
+			provider: "github-copilot",
+			modelId: "gpt-5.6-sol",
+			modelsFile: "/does/not/exist.json",
+			authStorage: {
+				getApiKey: () => "tid=abc;exp=1;proxy-ep=proxy.enterprise.githubcopilot.com",
+			},
+		})) as Record<string, unknown>;
+
+		assert.ok(model, "expected a synthesized model");
+		assert.equal(model.id, "gpt-5.6-sol");
+		assert.equal(model.api, "openai-responses", "the 421 root cause: must not inherit chat-completions");
+		assert.equal(model.baseUrl, "https://api.enterprise.githubcopilot.com", "must not stay on the individual host");
+	});
+});
+
+describe("isCopilotEndpointMismatch", () => {
+	it("recognises both shapes Copilot uses to reject an endpoint", () => {
+		assert.equal(isCopilotEndpointMismatch(new Error("421 Misdirected Request")), true);
+		assert.equal(isCopilotEndpointMismatch(Object.assign(new Error("nope"), { status: 421 })), true);
+		assert.equal(
+			isCopilotEndpointMismatch(new Error('model "gpt-5.6-luna" is not accessible via the /chat/completions endpoint')),
+			true,
+		);
+		// Wrapped one layer deep (Pi surfaces provider errors as a cause chain).
+		assert.equal(isCopilotEndpointMismatch(new Error("stream failed", { cause: new Error("421 Misdirected Request") })), true);
+	});
+
+	it("does not fire on unrelated failures", () => {
+		assert.equal(isCopilotEndpointMismatch(new Error("429 Too Many Requests")), false);
+		assert.equal(isCopilotEndpointMismatch(new Error("socket hang up")), false);
+		assert.equal(isCopilotEndpointMismatch(undefined), false);
+	});
+});
+
+describe("flipCopilotApi", () => {
+	it("swaps between the two Copilot surfaces", () => {
+		assert.equal(flipCopilotApi("openai-completions"), "openai-responses");
+		assert.equal(flipCopilotApi("openai-responses"), "openai-completions");
+		assert.equal(flipCopilotApi(undefined), "openai-responses");
+	});
+});
+
+describe("wrapStreamFnWithCopilotEndpointHeal", () => {
+	/** Minimal stand-in for Pi's EventStream: iterator + result(). */
+	function eventStream(events: unknown[], result: unknown = "ok") {
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				for (const e of events) yield e;
+			},
+			result: async () => result,
+		};
+	}
+
+	function failingStream(err: Error) {
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				throw err;
+			},
+			result: async () => {
+				throw err;
+			},
+		};
+	}
+
+	it("re-issues on the other endpoint when the first one is rejected, and learns it", async () => {
+		resetLearnedGitHubCopilotApis();
+		const calls: string[] = [];
+		const healed: string[] = [];
+		const wrapped = wrapStreamFnWithCopilotEndpointHeal(
+			(model: unknown) => {
+				const api = String((model as { api?: string }).api);
+				calls.push(api);
+				return api === "openai-completions"
+					? failingStream(new Error("421 Misdirected Request"))
+					: eventStream(["event-1"], "final");
+			},
+			(info) => healed.push(`${info.from}→${info.to}`),
+		);
+
+		const model = { provider: "github-copilot", id: "gpt-9-brand-new", api: "openai-completions" };
+		const stream = (await wrapped(model, {}, {})) as {
+			[Symbol.asyncIterator](): AsyncIterator<unknown>;
+			result(): Promise<unknown>;
+		};
+		const seen: unknown[] = [];
+		for await (const ev of { [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator]() }) seen.push(ev);
+
+		assert.deepEqual(seen, ["event-1"], "the healed stream's events reach the caller");
+		assert.equal(await stream.result(), "final", "result() delegates to the healed stream");
+		assert.deepEqual(calls, ["openai-completions", "openai-responses"]);
+		assert.deepEqual(healed, ["openai-completions→openai-responses"]);
+
+		// Learned for every later turn: the same id now resolves to the endpoint
+		// that worked, with no second failure.
+		const routed = applyGitHubCopilotRouting(
+			{ provider: "github-copilot", id: "gpt-9-brand-new", api: "openai-completions" },
+			"gpt-9-brand-new",
+		) as { api?: string };
+		assert.equal(routed.api, "openai-responses");
+		resetLearnedGitHubCopilotApis();
+	});
+
+	it("rethrows a non-endpoint failure untouched (no second request)", async () => {
+		resetLearnedGitHubCopilotApis();
+		let calls = 0;
+		const wrapped = wrapStreamFnWithCopilotEndpointHeal(() => {
+			calls++;
+			return failingStream(new Error("429 Too Many Requests"));
+		});
+		const stream = (await wrapped({ provider: "github-copilot", id: "gpt-5.5", api: "openai-responses" }, {}, {})) as {
+			result(): Promise<unknown>;
+		};
+		await assert.rejects(() => stream.result(), /429/);
+		assert.equal(calls, 1, "no endpoint flip for an unrelated error");
+	});
+
+	it("never replays a stream that already produced events", async () => {
+		resetLearnedGitHubCopilotApis();
+		let calls = 0;
+		const wrapped = wrapStreamFnWithCopilotEndpointHeal(() => {
+			calls++;
+			return {
+				[Symbol.asyncIterator]: async function* () {
+					yield "partial";
+					throw new Error("421 Misdirected Request");
+				},
+				result: async () => "unused",
+			};
+		});
+		const stream = (await wrapped({ provider: "github-copilot", id: "gpt-5.5", api: "openai-responses" }, {}, {})) as {
+			[Symbol.asyncIterator](): AsyncIterator<unknown>;
+		};
+		const iterator = stream[Symbol.asyncIterator]();
+		assert.deepEqual(await iterator.next(), { value: "partial", done: false });
+		await assert.rejects(() => iterator.next() as Promise<unknown>, /421/);
+		assert.equal(calls, 1, "partial output must never be re-issued");
+	});
+
+	it("passes non-Copilot models straight through", async () => {
+		let calls = 0;
+		const wrapped = wrapStreamFnWithCopilotEndpointHeal(() => {
+			calls++;
+			return eventStream([]);
+		});
+		await wrapped({ provider: "openai", id: "gpt-5.5", api: "openai-responses" }, {}, {});
+		assert.equal(calls, 1);
+	});
+});

--- a/src/agents/github-copilot-transport.ts
+++ b/src/agents/github-copilot-transport.ts
@@ -1,0 +1,312 @@
+/**
+ * GitHub Copilot transport resolution — WHICH endpoint and WHICH host a given
+ * Copilot model must be called on, for THIS account.
+ *
+ * Both are account-specific and neither is knowable from a static catalog:
+ *
+ *   • HOST. Individual, business and enterprise seats each get their own API
+ *     host, encoded in the bearer token (`…;proxy-ep=proxy.business.github
+ *     copilot.com;…`). Pi's bundled catalog hardcodes the INDIVIDUAL host, so an
+ *     enterprise seat pointed at it gets `421 Misdirected Request` on every call.
+ *
+ *   • ENDPOINT. Copilot serves GPT-5+ / o-series / codex models ONLY on
+ *     `/responses`; everything else (Claude, Gemini, gpt-4.x) on
+ *     `/chat/completions`. Asking on the wrong one is the OTHER `421
+ *     Misdirected Request` (or a 400 "not accessible via the /chat/completions
+ *     endpoint"). GitHub's `/models` listing carries no endpoint metadata today
+ *     (github/copilot-cli#4337), and new families keep appearing on enterprise
+ *     tenants ahead of any bundled catalog — `gpt-5.6-*` is the current one.
+ *
+ * So endpoint selection is resolved DYNAMICALLY, newest evidence first:
+ *
+ *   1. LEARNED — what the live API actually accepted for this id. Set by the
+ *      self-healing stream wrapper below the first time a request is rejected
+ *      for endpoint reasons, so the mistake happens at most once per process
+ *      and never reaches the user.
+ *   2. ADVERTISED — an endpoint list on the account's own `/models` entry, if
+ *      GitHub ever ships one (parsed defensively; absent today).
+ *   3. FAMILY — the id-family rule, which is what Pi's bundled catalog encodes
+ *      and what GitHub's own clients assume.
+ *
+ * The host is always re-derived from the LIVE token, so a seat that moves
+ * between tiers (or a fresh login) routes correctly with no code change.
+ */
+
+import { getCopilotModelHint } from "../integrations/provider-discovery.js";
+
+/** Pi's provider id for the Copilot subscription backend. */
+export const GITHUB_COPILOT_PROVIDER = "github-copilot";
+
+/** The two API surfaces Copilot exposes, in Pi's `api` vocabulary. */
+export type CopilotApi = "openai-responses" | "openai-completions";
+
+/**
+ * The editor headers Copilot's API REQUIRES. Business/enterprise tenants reject
+ * a request without them with `421 Misdirected Request`. Pi's bundled catalog
+ * carries these per model; we re-apply them so a synthesized id can't lose them.
+ */
+export const COPILOT_EDITOR_HEADERS: Readonly<Record<string, string>> = {
+	"User-Agent": "GitHubCopilotChat/0.35.0",
+	"Editor-Version": "vscode/1.107.0",
+	"Editor-Plugin-Version": "copilot-chat/0.35.0",
+	"Copilot-Integration-Id": "vscode-chat",
+};
+
+/** Loose Pi Model shape — we only ever read/replace transport fields. */
+type LooseModel = Record<string, unknown> & {
+	provider?: string;
+	id?: string;
+	api?: string;
+	baseUrl?: string;
+	headers?: unknown;
+};
+
+/* ───────────────────────────── endpoint selection ───────────────────────────── */
+
+/**
+ * Layer 3 — the id-family rule. Mirrors exactly what Pi's bundled Copilot
+ * catalog encodes (every `gpt-5*` entry is `openai-responses`, `gpt-4.1` is
+ * `openai-completions`) and extends it to families the catalog doesn't ship yet.
+ */
+export function githubCopilotApiForModelId(modelId: string): CopilotApi {
+	const id = modelId.trim().toLowerCase().replace(/^github-copilot\//, "");
+	if (/codex/.test(id)) return "openai-responses";
+	if (/^o[1-9](?:$|[-.])/.test(id)) return "openai-responses";
+	const gpt = /^gpt-(\d+)/.exec(id);
+	if (gpt?.[1] && Number(gpt[1]) >= 5) return "openai-responses";
+	return "openai-completions";
+}
+
+/**
+ * Learned endpoints — id → the api surface the live account actually accepted.
+ *
+ * Process-scoped by design. The gateway is long-lived, so one correction covers
+ * every later turn; a restart re-derives from the advertised/family layers,
+ * which are right for every model family known so far. Deliberately NOT written
+ * to disk: it would need a mode-aware write path (convex mode keeps `~/.brigade`
+ * file-free) to cache something we can re-learn in a single request.
+ */
+const learnedCopilotApi = new Map<string, CopilotApi>();
+
+/** Record what the live API accepted for `modelId` (self-heal, see below). */
+export function rememberGitHubCopilotApi(modelId: string, api: CopilotApi): void {
+	learnedCopilotApi.set(modelId.trim().toLowerCase(), api);
+}
+
+/** Test seam — drop everything learned this process. */
+export function resetLearnedGitHubCopilotApis(): void {
+	learnedCopilotApi.clear();
+}
+
+/** The other API surface. A rejected endpoint leaves exactly one alternative. */
+export function flipCopilotApi(api: string | undefined): CopilotApi {
+	return api === "openai-responses" ? "openai-completions" : "openai-responses";
+}
+
+/**
+ * The endpoint this model must use, resolved dynamically: learned → advertised
+ * by the account's own catalog → family rule.
+ */
+export function resolveGitHubCopilotApi(modelId: string): CopilotApi {
+	const key = modelId.trim().toLowerCase();
+	const learned = learnedCopilotApi.get(key);
+	if (learned) return learned;
+	const advertised = getCopilotModelHint(modelId)?.api;
+	if (advertised) return advertised;
+	return githubCopilotApiForModelId(modelId);
+}
+
+/* ─────────────────────────────── host selection ─────────────────────────────── */
+
+/**
+ * The API host THIS account must talk to, parsed out of the live Copilot bearer
+ * token. Handles both the dotcom shape (`proxy.<tier>.githubcopilot.com` →
+ * `api.<tier>.…`) and the GitHub Enterprise shape (`copilot-proxy.<host>` →
+ * `copilot-api.<host>`).
+ */
+export function githubCopilotBaseUrlFromToken(token: string | undefined): string | undefined {
+	if (!token) return undefined;
+	const proxyHost = /proxy-ep=([^;,\s]+)/.exec(token)?.[1];
+	if (!proxyHost) return undefined;
+	const apiHost = proxyHost.startsWith("copilot-proxy.")
+		? proxyHost.replace(/^copilot-proxy\./, "copilot-api.")
+		: proxyHost.replace(/^proxy\./, "api.");
+	// Hostname (optional :port) only — never splice an arbitrary token field into a URL.
+	if (!/^[A-Za-z0-9.-]+(?::\d{1,5})?$/.test(apiHost)) return undefined;
+	return `https://${apiHost}`;
+}
+
+/** True when the baseUrl is one of Pi's bundled Copilot hosts (safe to re-point). */
+function isBundledCopilotHost(baseUrl: unknown): boolean {
+	return typeof baseUrl === "string" && /\/\/[A-Za-z0-9.-]*githubcopilot\.com(?::\d+)?(?:\/|$)/.test(baseUrl);
+}
+
+/* ─────────────────────────────── model correction ────────────────────────────── */
+
+/**
+ * Correct a resolved Copilot model's transport before it reaches Pi. Applied at
+ * ONE choke point in the agent loop, so the catalogued path and the synthesized
+ * path are both covered:
+ *
+ *   • `api` — the endpoint this id is actually served on (see resolution order).
+ *   • `baseUrl` — this seat's host, from the live token. A deliberately
+ *     configured non-Copilot baseUrl (a corporate gateway in models.json) is
+ *     left alone.
+ *   • `headers` — Copilot's required editor headers, always present.
+ *
+ * Pure: returns the input untouched for any other provider.
+ */
+export function applyGitHubCopilotRouting(model: unknown, modelId: string, copilotToken?: string): unknown {
+	if (!model || typeof model !== "object") return model;
+	const m = model as LooseModel;
+	if (m.provider !== GITHUB_COPILOT_PROVIDER) return model;
+
+	const next: LooseModel = { ...m };
+	const wantedApi = resolveGitHubCopilotApi(modelId);
+	if (next.api !== wantedApi) {
+		// `compat` / `thinkingLevelMap` describe the endpoint the model came from
+		// (e.g. a Claude chat-completions catalog entry). Carrying them onto the
+		// other API sends flags it doesn't understand — drop them and let Pi's
+		// per-api defaults apply.
+		delete next.compat;
+		delete next.thinkingLevelMap;
+		next.api = wantedApi;
+	}
+
+	const tokenBaseUrl = githubCopilotBaseUrlFromToken(copilotToken);
+	if (tokenBaseUrl && (next.baseUrl === undefined || isBundledCopilotHost(next.baseUrl))) {
+		next.baseUrl = tokenBaseUrl;
+	}
+
+	next.headers =
+		next.headers && typeof next.headers === "object"
+			? { ...COPILOT_EDITOR_HEADERS, ...(next.headers as Record<string, string>) }
+			: { ...COPILOT_EDITOR_HEADERS };
+
+	return next;
+}
+
+/* ──────────────────────────── self-healing stream ───────────────────────────── */
+
+/**
+ * Does this failure mean "right credential, wrong endpoint"? Copilot says so two
+ * ways: a bare `421 Misdirected Request` from the edge, or a 400 naming the
+ * endpoint the model isn't served on.
+ */
+export function isCopilotEndpointMismatch(err: unknown): boolean {
+	const text = endpointErrorText(err);
+	if (!text) return false;
+	return (
+		/misdirected request/i.test(text) ||
+		/\b421\b/.test(text) ||
+		/not accessible via the \/\S+ endpoint/i.test(text) ||
+		/not supported (?:on|by) (?:the )?\/\S+ endpoint/i.test(text)
+	);
+}
+
+function endpointErrorText(err: unknown): string {
+	if (!err) return "";
+	if (typeof err === "string") return err;
+	if (typeof err !== "object") return String(err);
+	const e = err as { message?: unknown; status?: unknown; statusCode?: unknown; cause?: unknown };
+	const status = typeof e.status === "number" ? e.status : typeof e.statusCode === "number" ? e.statusCode : undefined;
+	const message = typeof e.message === "string" ? e.message : "";
+	const causeText = e.cause && e.cause !== err ? endpointErrorText(e.cause) : "";
+	return `${status ?? ""} ${message} ${causeText}`.trim();
+}
+
+type StreamFn = (...args: unknown[]) => unknown;
+
+interface EventStreamLike {
+	[Symbol.asyncIterator](): AsyncIterator<unknown>;
+	result(): Promise<unknown>;
+}
+
+function isEventStreamLike(value: unknown): value is EventStreamLike {
+	if (!value || (typeof value !== "object" && typeof value !== "function")) return false;
+	const v = value as { [Symbol.asyncIterator]?: unknown; result?: unknown };
+	return typeof v[Symbol.asyncIterator] === "function" && typeof v.result === "function";
+}
+
+/**
+ * Compose over Pi's streamFn so a Copilot endpoint rejection heals itself.
+ *
+ * When a Copilot request comes back "wrong endpoint" BEFORE any event has been
+ * emitted, re-issue it once against the other API surface and remember the
+ * answer for every later turn. That makes the model catalog fully
+ * self-describing in practice: a family GitHub ships tomorrow routes itself,
+ * with no catalog update and nothing for the operator to do.
+ *
+ * Strictly bounded — Copilot models only, one re-issue per stream, and only
+ * while zero events have been consumed (so no partial output is ever replayed).
+ * Anything else rethrows untouched. Preserves Pi's EventStream shape (iterator
+ * + `result()`); returning a bare async generator would silently break the turn.
+ */
+export function wrapStreamFnWithCopilotEndpointHeal(
+	streamFn: StreamFn,
+	onHeal?: (info: { modelId: string; from: string; to: CopilotApi }) => void,
+): StreamFn {
+	return async (...args: unknown[]): Promise<unknown> => {
+		const model = args[0] as LooseModel | undefined;
+		if (!model || typeof model !== "object" || model.provider !== GITHUB_COPILOT_PROVIDER) {
+			return streamFn(...args);
+		}
+		const modelId = typeof model.id === "string" ? model.id : "";
+		let healed = false;
+		let eventsSeen = 0;
+
+		/** Re-issue the call on the other endpoint, or rethrow the original error. */
+		const reissue = async (err: unknown): Promise<EventStreamLike> => {
+			if (healed || eventsSeen > 0 || !modelId || !isCopilotEndpointMismatch(err)) throw err;
+			healed = true;
+			const to = flipCopilotApi(typeof model.api === "string" ? model.api : undefined);
+			const flipped: LooseModel = { ...model, api: to };
+			delete flipped.compat;
+			delete flipped.thinkingLevelMap;
+			const next = await streamFn(flipped, ...args.slice(1));
+			if (!isEventStreamLike(next)) throw err;
+			// Only learn once the retry actually produced a stream — a flip that
+			// fails too must not poison later turns.
+			rememberGitHubCopilotApi(modelId, to);
+			onHeal?.({ modelId, from: String(model.api ?? "?"), to });
+			return next;
+		};
+
+		let active: EventStreamLike;
+		try {
+			const initial = await streamFn(...args);
+			if (!isEventStreamLike(initial)) return initial;
+			active = initial;
+		} catch (err) {
+			active = await reissue(err);
+		}
+
+		return {
+			[Symbol.asyncIterator]: () => {
+				let iterator = active[Symbol.asyncIterator]();
+				return {
+					async next(): Promise<IteratorResult<unknown>> {
+						for (;;) {
+							try {
+								const step = await iterator.next();
+								if (!step.done) eventsSeen++;
+								return step;
+							} catch (err) {
+								active = await reissue(err); // rethrows when not healable
+								iterator = active[Symbol.asyncIterator]();
+							}
+						}
+					},
+				};
+			},
+			result: async () => {
+				try {
+					return await active.result();
+				} catch (err) {
+					active = await reissue(err);
+					return await active.result();
+				}
+			},
+		} satisfies EventStreamLike;
+	};
+}

--- a/src/agents/model-resolution.ts
+++ b/src/agents/model-resolution.ts
@@ -25,9 +25,15 @@
 import * as fs from "node:fs";
 
 import { isClaudeCliProvider, synthClaudeCliModel } from "./claude-cli/register.js";
+import { applyGitHubCopilotRouting, GITHUB_COPILOT_PROVIDER, githubCopilotApiForModelId } from "./github-copilot-transport.js";
 import { isLikelyReasoningModelId } from "../core/model-caps.js";
 import { rediscoverOllamaModel } from "../integrations/ollama.js";
-import { discoverCloudModelMeta, type DiscoveredModelMeta } from "../integrations/provider-discovery.js";
+import {
+	discoverCloudModelMeta,
+	fetchGitHubCopilotModels,
+	getCopilotModelHint,
+	type DiscoveredModelMeta,
+} from "../integrations/provider-discovery.js";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 8192;
@@ -165,7 +171,9 @@ export async function resolveModelNeverMiss(args: ResolveModelArgs): Promise<unk
 
 	// Find a catalogued template for this provider — it carries the correct
 	// transport (api/baseUrl) + auth routing, which we inherit for the synth.
-	const template = findProviderTemplate(registry, provider);
+	// Family-matched: a `gpt-5.6-sol` must clone a `gpt-5.x` entry, never the
+	// provider's first-listed model, or it inherits the wrong endpoint.
+	const template = findProviderTemplate(registry, provider, modelId);
 
 	// 3. Live cloud discovery for accurate metadata (best-effort).
 	const apiKey = await readApiKey(args.authStorage, provider);
@@ -173,6 +181,12 @@ export async function resolveModelNeverMiss(args: ResolveModelArgs): Promise<unk
 		baseUrl: typeof template?.baseUrl === "string" ? template.baseUrl : undefined,
 		apiKey,
 	});
+	// 3b. GitHub Copilot has a per-ACCOUNT live catalog, and reaching this line
+	// means the id is one Pi's bundled snapshot doesn't carry — exactly the case
+	// where the account's own list is the only accurate source (context window,
+	// vision, and any endpoint it advertises). Cached for 5 min and never throws,
+	// so at most one extra request per model generation.
+	const copilotMeta = provider === GITHUB_COPILOT_PROVIDER ? await readCopilotLiveMeta(modelId, apiKey) : undefined;
 
 	// 4. Synthesize from the provider template (clone routing, override the
 	// per-model fields). We synthesize even when discovery couldn't confirm
@@ -180,7 +194,10 @@ export async function resolveModelNeverMiss(args: ResolveModelArgs): Promise<unk
 	// validates the id and surfaces a precise provider error for a genuine
 	// typo, which is strictly better than an opaque "not registered".
 	if (template) {
-		return synthFromTemplate(template, modelId, discovery.meta);
+		const synth = synthFromTemplate(template, modelId, { ...discovery.meta, ...copilotMeta });
+		// Copilot: route to the endpoint/host THIS account needs. The template
+		// only gets us close (see applyGitHubCopilotRouting).
+		return provider === GITHUB_COPILOT_PROVIDER ? applyGitHubCopilotRouting(synth, modelId, apiKey) : synth;
 	}
 
 	// 5. Synthesize from a configured `custom`/OpenAI-compatible provider in
@@ -194,7 +211,11 @@ export async function resolveModelNeverMiss(args: ResolveModelArgs): Promise<unk
 	return undefined;
 }
 
-function findProviderTemplate(registry: LooseRegistry, provider: string): LooseModel | undefined {
+function findProviderTemplate(
+	registry: LooseRegistry,
+	provider: string,
+	modelId?: string,
+): LooseModel | undefined {
 	if (typeof registry.getAvailable !== "function") return undefined;
 	let list: unknown[];
 	try {
@@ -202,9 +223,67 @@ function findProviderTemplate(registry: LooseRegistry, provider: string): LooseM
 	} catch {
 		return undefined;
 	}
-	return list.find((m): m is LooseModel => {
+	const candidates = list.filter((m): m is LooseModel => {
 		return !!m && typeof m === "object" && (m as LooseModel).provider === provider;
 	});
+	if (candidates.length === 0) return undefined;
+	// GitHub Copilot templates are endpoint-split (gpt-5* → /responses, the rest
+	// → /chat/completions). Prefer a template already on the endpoint this id
+	// needs so `compat` / `thinkingLevelMap` come from a compatible entry.
+	const preferredApi = provider === GITHUB_COPILOT_PROVIDER && modelId ? githubCopilotApiForModelId(modelId) : undefined;
+	const pool = preferredApi ? candidates.filter((m) => m.api === preferredApi) : [];
+	return pickTemplateForModelId(pool.length > 0 ? pool : candidates, modelId);
+}
+
+/** Shared leading characters of two lowercased ids. */
+function commonPrefixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[i] === b[i]) i++;
+	return i;
+}
+
+/**
+ * Pick the catalogued model whose id is in the SAME FAMILY as `modelId`, so the
+ * synth inherits a transport that actually fits it.
+ *
+ * The old behaviour — "first model of this provider" — is what made an
+ * enterprise Copilot seat unusable: `gpt-5.6-sol` cloned `claude-fable-5` (the
+ * first Copilot entry alphabetically), inherited `api: "openai-completions"`,
+ * and every turn came back `421 Misdirected Request` because Copilot only
+ * serves GPT-5 on `/responses`.
+ *
+ * Scoring: longest shared id prefix (≥3 chars to count as a family), then the
+ * newest id within that family (lexicographically greatest — `gpt-5.5` over
+ * `gpt-5.2`), then the shortest id (the plain family member over a variant).
+ * Falls back to the first candidate when nothing shares a family, which is the
+ * previous behaviour.
+ */
+export function pickTemplateForModelId<T extends { id?: string }>(
+	candidates: readonly T[],
+	modelId?: string,
+): T | undefined {
+	const first = candidates[0];
+	if (!modelId || candidates.length <= 1) return first;
+	const wanted = modelId.trim().toLowerCase();
+	let best: T | undefined;
+	let bestScore = 0;
+	for (const candidate of candidates) {
+		const id = typeof candidate.id === "string" ? candidate.id.toLowerCase() : "";
+		if (!id) continue;
+		const score = commonPrefixLength(wanted, id);
+		if (score < 3) continue;
+		if (score > bestScore) {
+			best = candidate;
+			bestScore = score;
+			continue;
+		}
+		if (score === bestScore && best) {
+			const bestId = String(best.id ?? "").toLowerCase();
+			if (id.length === bestId.length ? id > bestId : id.length < bestId.length) best = candidate;
+		}
+	}
+	return best ?? first;
 }
 
 function synthFromTemplate(template: LooseModel, modelId: string, meta: DiscoveredModelMeta): LooseModel {
@@ -264,6 +343,29 @@ function readProviderConfigFromModelsJson(modelsFile: string, provider: string):
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * Capabilities for a Copilot id straight from the ACCOUNT's live catalog, so a
+ * model Pi has never heard of still gets its real context window and vision flag
+ * instead of the template's. Warming this cache also feeds endpoint selection
+ * (`resolveGitHubCopilotApi` reads the same hints). Best-effort by construction:
+ * `fetchGitHubCopilotModels` swallows its own failures and returns the last good
+ * cache, so a slow or unreachable catalog just leaves us on template defaults.
+ */
+async function readCopilotLiveMeta(modelId: string, token: string | undefined): Promise<DiscoveredModelMeta | undefined> {
+	if (!token) return undefined;
+	try {
+		await fetchGitHubCopilotModels(token);
+	} catch {
+		return undefined;
+	}
+	const hint = getCopilotModelHint(modelId);
+	if (!hint) return undefined;
+	return {
+		...(hint.contextWindow !== undefined ? { contextWindow: hint.contextWindow } : {}),
+		...(hint.vision !== undefined ? { vision: hint.vision } : {}),
+	};
 }
 
 async function readApiKey(authStorage: unknown, provider: string): Promise<string | undefined> {

--- a/src/integrations/provider-discovery.ts
+++ b/src/integrations/provider-discovery.ts
@@ -342,6 +342,57 @@ export function getCachedSubscriptionModels(providerId: string): LiveCloudModel[
 }
 
 /**
+ * Per-model transport facts read straight off the ACCOUNT's own Copilot catalog
+ * — the authoritative source for what this seat can do, as opposed to Pi's
+ * bundled snapshot. Consumed by `agents/github-copilot-transport.ts` (endpoint
+ * selection) and the never-miss resolver (capabilities for a synthesized id).
+ */
+export interface CopilotModelHint {
+	id: string;
+	/** Endpoint the catalog says this model is served on, when it says at all. */
+	api?: "openai-responses" | "openai-completions";
+	contextWindow?: number;
+	maxTokens?: number;
+	vision?: boolean;
+	family?: string;
+}
+
+const copilotModelHints = new Map<string, CopilotModelHint>();
+
+/** Live transport facts for a Copilot model id (case-insensitive), if fetched. */
+export function getCopilotModelHint(modelId: string): CopilotModelHint | undefined {
+	return copilotModelHints.get(modelId.trim().toLowerCase());
+}
+
+/** Test seam — drop the live-hint cache. */
+export function resetCopilotModelHints(): void {
+	copilotModelHints.clear();
+}
+
+/**
+ * Read the endpoint a Copilot catalog entry advertises.
+ *
+ * GitHub ships NO endpoint metadata today (github/copilot-cli#4337 asks for
+ * exactly this), so today this returns `undefined` and the family rule decides.
+ * It is parsed defensively across the field names the API might grow into, so
+ * the moment GitHub does advertise it, Brigade routes by the account's own truth
+ * instead of a heuristic — with no code change. A model that advertises BOTH
+ * surfaces is left undecided on purpose: either works, so the family rule (which
+ * matches what GitHub's own clients pick) stays in charge.
+ */
+function copilotApiFromCatalogEntry(item: Record<string, unknown>, capabilities: Record<string, unknown> | undefined): CopilotModelHint["api"] {
+	const raw =
+		item.supported_endpoints ?? item.supported_apis ?? item.api_modes ?? capabilities?.supported_endpoints ?? capabilities?.api_modes;
+	const list = Array.isArray(raw) ? raw.map((v) => String(v)) : typeof raw === "string" ? [raw] : [];
+	if (list.length === 0) return undefined;
+	const responses = list.some((e) => /responses/i.test(e));
+	const chat = list.some((e) => /chat[/_]completions/i.test(e));
+	if (responses && !chat) return "openai-responses";
+	if (chat && !responses) return "openai-completions";
+	return undefined;
+}
+
+/**
  * GitHub Copilot's per-account model catalog. The token embeds the proxy host
  * (`proxy-ep=…`) which `getGitHubCopilotBaseUrl` rewrites to the api host; we GET
  * `${baseUrl}/models` with Copilot's required editor headers (a plain
@@ -387,7 +438,11 @@ export async function fetchGitHubCopilotModels(copilotToken: string): Promise<Li
 			// the response is untyped.
 			const policy = item.policy as { state?: unknown } | undefined;
 			const capabilities = item.capabilities as
-				| { supports?: { tool_calls?: unknown; vision?: unknown }; limits?: { max_context_window_tokens?: unknown } }
+				| {
+						family?: unknown;
+						supports?: { tool_calls?: unknown; vision?: unknown };
+						limits?: { max_context_window_tokens?: unknown; max_output_tokens?: unknown };
+				  }
 				| undefined;
 			const supports = capabilities?.supports;
 			if (item.model_picker_enabled !== true) continue;
@@ -395,8 +450,18 @@ export async function fetchGitHubCopilotModels(copilotToken: string): Promise<Li
 			if (supports?.tool_calls === false) continue;
 			const maxCtx = capabilities?.limits?.max_context_window_tokens;
 			const contextWindow = typeof maxCtx === "number" && maxCtx > 0 ? maxCtx : undefined;
+			const maxOut = capabilities?.limits?.max_output_tokens;
 			const name = typeof item.name === "string" && item.name.length > 0 ? item.name : id;
 			const input = supports?.vision ? ["text", "image"] : ["text"];
+			// Transport + capability facts for THIS seat, keyed for the resolver.
+			copilotModelHints.set(id.toLowerCase(), {
+				id,
+				api: copilotApiFromCatalogEntry(item, capabilities as Record<string, unknown> | undefined),
+				...(contextWindow !== undefined ? { contextWindow } : {}),
+				...(typeof maxOut === "number" && maxOut > 0 ? { maxTokens: maxOut } : {}),
+				vision: supports?.vision === true,
+				...(typeof capabilities?.family === "string" ? { family: capabilities.family } : {}),
+			});
 			out.push({
 				provider: "github-copilot",
 				id,


### PR DESCRIPTION
## The bug

A GitHub Copilot **Business/Enterprise** login failed every turn with `421 Misdirected Request`, whatever the prompt was.

An enterprise seat's `/models` list carries ids Pi's bundled catalog doesn't have yet (the `gpt-5.6-*` family). The never-miss resolver synthesizes an unknown id by cloning a catalogued model of the same provider — but it cloned the **first** one, `claude-fable-5`, an `openai-completions` entry. Copilot serves GPT-5+/codex only on `/responses`, so every request went to `/chat/completions` and the edge answered 421.

Two aggravating factors on the same path:
- the bundled catalog hardcodes `api.individual.githubcopilot.com`, but a business/enterprise token must use its own host (encoded in the token's `proxy-ep`);
- 421 classified as `unknown` — transient — so the loop burned three identical retries and surfaced `last reason=unknown`.

## The approach

GitHub advertises no endpoint metadata in `/models` (github/copilot-cli#4337), so endpoint selection resolves **newest evidence first**:

1. **learned** — what the live API actually accepted for this id
2. **advertised** — an endpoint list on the account's own `/models` entry, parsed defensively so it activates itself if GitHub ever ships the field
3. **family** — the id-family rule, which is what Pi's catalog encodes and what GitHub's own clients assume

## Changes

- new `github-copilot-transport.ts` — endpoint + host + editor-header correction, applied at **one** choke point in the agent loop so the catalogued and synthesized paths are both covered
- **self-healing stream wrapper** — an endpoint rejection before any event is emitted re-issues once on the other surface and is remembered, so a model family shipped after this release routes itself. Bounded to Copilot, once per stream, never after partial output
- host derived from the live token's `proxy-ep`, covering individual/business/enterprise and the GHE `copilot-proxy.` → `copilot-api.` shape; a deliberately configured gateway baseUrl is left alone
- synthesized Copilot ids take context window + vision from the **account's own** catalog instead of a template's
- template selection is family-matched for every provider: `gpt-5.6-sol` clones `gpt-5.5`, not the provider's first-listed model
- `421` and "not accessible via the /… endpoint" classify as `model_not_found`: one fast failure with an actionable message, and the fallback chain gets its turn

## Verification

- `npm run build` clean; `tsc --noEmit` clean on both configs
- 708 agents + integrations tests pass, 21 of them new (`github-copilot-routing.test.ts`, plus 6 classifier cases)
- covered: endpoint rule per family, host derivation incl. GHE, family-matched templates, the heal wrapper (re-issue + learn, rethrow on unrelated errors, never replay after partial output, pass-through for other providers)

## References

- github/copilot-cli#4337 — `gpt-5.6-luna` listed in `/models`, rejected on `/chat/completions`
- openclaw/openclaw#8366 — GPT-5 models need the Responses API
- openclaw/openclaw#1797 — Enterprise 421 on missing editor headers
- anomalyco/opencode#20759 — business/enterprise host routing