### PR TITLE
fix(copilot): route by what the API says, and refuse un-renewable logins

### DIFF
--- a/src/agents/agent-loop.ts
+++ b/src/agents/agent-loop.ts
@@ -73,16 +73,32 @@ import {
 } from "../sessions/bootstrap-marker.js";
 import { createSubsystemLogger } from "../logging/subsystem-logger.js";
 import { runWithRetry } from "./retry-policy.js";
-import { scrubAnthropicRefusalSentinel } from "./error-classifier.js";
+import { BrigadeRetryError, scrubAnthropicRefusalSentinel } from "./error-classifier.js";
 import { cleanProviderError } from "../core/model-caps.js";
 import { adoptNewerClaudeCliLogin, healDeadSubscriptionLogin } from "../auth/auth-health.js";
 import { persistentAuthBackend } from "../core/auth-bridge.js";
 import { billingSafeContextWindow, resolveModelNeverMiss } from "./model-resolution.js";
 import {
   applyGitHubCopilotRouting,
+  describeCopilotCredentialProblem,
   GITHUB_COPILOT_PROVIDER,
+  inspectCopilotCredential,
+  warmGitHubCopilotHints,
   wrapStreamFnWithCopilotEndpointHeal,
 } from "./github-copilot-transport.js";
+
+/** Agents already told their Copilot login can't renew — warn once, not every turn. */
+const copilotCredentialWarned = new Set<string>();
+
+function warnCopilotCredentialOnce(
+  agentId: string,
+  problem: string,
+  logger: { warn: (msg: string, fields?: Record<string, unknown>) => void },
+): void {
+  if (copilotCredentialWarned.has(agentId)) return;
+  copilotCredentialWarned.add(agentId);
+  logger.warn(problem, { agentId });
+}
 import { buildAutoRecallBlock, resolveAutoRecallOrigin } from "./memory/auto-recall.js";
 import { runPreCompactionExtraction } from "./memory/extract.js";
 import type { MemoryRecordOrigin } from "./memory/records.js";
@@ -506,6 +522,30 @@ export async function runSingleTurn(args: RunSingleTurnArgs): Promise<RunSingleT
     const copilotToken = await (authStorage as { getApiKey?: (p: string) => Promise<string | undefined> })
       .getApiKey?.(args.provider)
       .catch(() => undefined);
+    // A Copilot bearer held as a plain api_key cannot renew itself (see
+    // `inspectCopilotCredential`). Say so BEFORE the request: once expired it
+    // only ever produces 401s, and the honest fix is one `brigade login copilot`
+    // — not something the operator can guess from a bare auth error.
+    const copilotCredType = (authStorage as { get?: (p: string) => { type?: string } | undefined }).get?.(
+      args.provider,
+    )?.type;
+    const copilotHealth = inspectCopilotCredential(copilotToken, copilotCredType);
+    const copilotProblem = describeCopilotCredentialProblem(copilotHealth);
+    if (copilotProblem) {
+      if (copilotHealth.expired) {
+        throw new BrigadeRetryError({
+          message: copilotProblem,
+          reason: "auth_permanent", // no refresh path — a retry or profile rotation cannot fix it
+          provider: args.provider,
+          model: args.modelId,
+        });
+      }
+      warnCopilotCredentialOnce(agentId, copilotProblem, log);
+    }
+    // Load the account's own catalog first — its `supported_endpoints` outranks
+    // our id heuristic and is the only thing that routes a family the heuristic
+    // has never seen (e.g. `mai-code-1-flash`, which is /responses-only).
+    await warmGitHubCopilotHints(args.modelId, copilotToken);
     const routed = applyGitHubCopilotRouting(model, args.modelId, copilotToken);
     if (routed !== model) {
       const before = model as { api?: string; baseUrl?: string };

--- a/src/agents/error-classifier.test.ts
+++ b/src/agents/error-classifier.test.ts
@@ -254,3 +254,27 @@ test("classifyError: a bare 421 inside an unrelated token count is not misread",
   // as a routing failure.
   assert.equal(classifyErrorReason(new Error("prompt is too long: 421 tokens over the limit")), "context_overflow");
 });
+
+// ── Copilot plan entitlement vs endpoint routing (both are HTTP 400) ─────────
+// Verified live on a free_limited_copilot seat: two different 400s that need
+// two different responses. Neither should retry three times as `unknown`.
+
+test("classifyError: Copilot plan rejection → model_not_found, not unknown", () => {
+  const err = new Error("OpenAI API error (400): 400 The requested model is not supported.");
+  assert.equal(classifyErrorReason(err), "model_not_found");
+});
+
+test("classifyErrorDetailed: plan rejection explains it's the subscription, not the endpoint", () => {
+  const r = classifyErrorDetailed(new Error("400 The requested model is not supported."));
+  assert.equal(r.class, "model_not_found");
+  assert.equal(r.retryableOnSameModel, false);
+  assert.match(r.message, /subscription doesn't include this model/i);
+  assert.doesNotMatch(r.message, /\/responses/, "must not send them chasing an endpoint problem");
+});
+
+test("classifyError: the real 'via Responses API' wording is an endpoint mismatch", () => {
+  const err = new Error("model gpt-4.1 is not supported via Responses API.");
+  assert.equal(classifyErrorReason(err), "model_not_found");
+  const r = classifyErrorDetailed(err);
+  assert.match(r.message, /endpoint\/host/i);
+});

--- a/src/agents/error-classifier.ts
+++ b/src/agents/error-classifier.ts
@@ -221,10 +221,26 @@ const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
 // `model_not_found` policy: fail fast, advance to the fallback chain.
 // (The bare status code is deliberately NOT matched here — `421` can appear in
 // an unrelated message as a token count. The status path below catches it.)
+//
+// The "via <surface>" wordings are the ones GitHub actually returns — verified
+// against the live API: `model gpt-4.1 is not supported via Responses API.`
+// The `/chat/completions endpoint` phrasing (from github/copilot-cli#4337) is
+// real too, so both stay.
 export const ENDPOINT_MISMATCH_PATTERNS: RegExp[] = [
   /misdirected request/i,
+  /not (?:accessible|supported) via (?:the )?\/?\S+(?: api| endpoint)?\./i,
   /not accessible via the \/\S+ endpoint/i,
   /not supported (?:on|by) (?:the )?\/\S+ endpoint/i,
+];
+
+// Plan entitlement — the seat cannot run this model on ANY surface. Verified on
+// a `free_limited_copilot` Copilot seat, where `gpt-5-mini` and
+// `claude-haiku-4.5` both fail this way despite `/models` advertising them for
+// every plan. Retrying is useless and switching endpoints is useless; the only
+// move is a different model, so say that.
+const PLAN_ENTITLEMENT_PATTERNS: RegExp[] = [
+  /the requested model is not supported/i,
+  /model is not (?:supported|available) (?:for|on) (?:your|this) (?:plan|subscription|account)/i,
 ];
 
 const MODEL_NOT_FOUND_PATTERNS: RegExp[] = [
@@ -233,6 +249,7 @@ const MODEL_NOT_FOUND_PATTERNS: RegExp[] = [
   /model .*?(?:does not exist|is not available)/i,
   /no such model/i,
   ...ENDPOINT_MISMATCH_PATTERNS,
+  ...PLAN_ENTITLEMENT_PATTERNS,
 ];
 
 const SESSION_EXPIRED_PATTERNS: RegExp[] = [
@@ -678,6 +695,15 @@ export function classifyErrorDetailed(err: unknown): ClassifiedError {
   if (CONTENT_FILTER_PATTERNS_DETAILED.some((p) => p.test(message))) {
     return { class: "content_filter", message, retryableOnSameModel: false };
   }
+  // Entitlement BEFORE endpoint: a plan rejection names no surface, so it must
+  // not be mistaken for a routing problem the loop could retry around.
+  if (PLAN_ENTITLEMENT_PATTERNS.some((p) => p.test(message))) {
+    return {
+      class: "model_not_found",
+      message: planEntitlementMessage(message),
+      retryableOnSameModel: false,
+    };
+  }
   if (ENDPOINT_MISMATCH_PATTERNS.some((p) => p.test(message))) {
     return {
       class: "model_not_found",
@@ -697,6 +723,20 @@ export function classifyErrorDetailed(err: unknown): ClassifiedError {
  * Request" tells the user nothing and reads like a network blip they should
  * retry; this names the actual cause and the two things that fix it.
  */
+/**
+ * Operator-facing text for a plan-entitlement rejection. The raw provider line
+ * ("The requested model is not supported.") reads like a bug in the client, so
+ * it sends people looking in the wrong place — name the real cause and the one
+ * action that resolves it.
+ */
+function planEntitlementMessage(message: string): string {
+  return (
+    `${message} — your subscription doesn't include this model, so no retry or endpoint change ` +
+    `will help. Pick a different one with /model. (On GitHub Copilot, the plan's model list is ` +
+    `narrower than what \`/models\` advertises — a Free seat typically has gpt-4.1 and gpt-4o only.)`
+  );
+}
+
 function endpointMismatchMessage(message: string): string {
   return (
     `${message} — the provider won't serve this model on the endpoint/host the request used. ` +

--- a/src/agents/github-copilot-routing.test.ts
+++ b/src/agents/github-copilot-routing.test.ts
@@ -23,7 +23,14 @@ import {
 	flipCopilotApi,
 	githubCopilotApiForModelId,
 	githubCopilotBaseUrlFromToken,
+	copilotRejectedApi,
+	describeCopilotCredentialProblem,
+	inspectCopilotCredential,
 	isCopilotEndpointMismatch,
+	isCopilotModelKnownUnsupported,
+	isCopilotPlanRejection,
+	listCopilotUnsupportedModels,
+	resetCopilotEntitlementMemory,
 	resetLearnedGitHubCopilotApis,
 	wrapStreamFnWithCopilotEndpointHeal,
 } from "./github-copilot-transport.js";
@@ -295,5 +302,143 @@ describe("wrapStreamFnWithCopilotEndpointHeal", () => {
 		});
 		await wrapped({ provider: "openai", id: "gpt-5.5", api: "openai-responses" }, {}, {});
 		assert.equal(calls, 1);
+	});
+});
+
+// ── Wordings captured from the LIVE Copilot API (free_limited_copilot seat) ──
+// The first fix shipped with patterns taken from a GitHub issue; probing the
+// real API showed the common rejection is phrased differently, and that a
+// second, unrelated 400 (plan entitlement) must NOT be treated as routing.
+
+describe("copilotRejectedApi — read the surface out of the error", () => {
+	it("names /responses as the wrong surface", () => {
+		assert.equal(copilotRejectedApi(new Error("model gpt-4.1 is not supported via Responses API.")), "openai-responses");
+	});
+
+	it("names /chat/completions as the wrong surface", () => {
+		assert.equal(
+			copilotRejectedApi(new Error('model "gpt-5.6-luna" is not accessible via the /chat/completions endpoint')),
+			"openai-completions",
+		);
+	});
+
+	it("returns undefined when no surface is named (bare 421)", () => {
+		assert.equal(copilotRejectedApi(new Error("421 Misdirected Request")), undefined);
+	});
+});
+
+describe("plan entitlement vs endpoint mismatch", () => {
+	it("treats the bare 'not supported' 400 as entitlement, never as routing", () => {
+		const err = new Error("OpenAI API error (400): 400 The requested model is not supported.");
+		assert.equal(isCopilotPlanRejection(err), true);
+		assert.equal(isCopilotEndpointMismatch(err), false, "must not trigger an endpoint flip");
+	});
+
+	it("treats the 'via Responses API' 400 as routing, never as entitlement", () => {
+		const err = new Error("model gpt-4.1 is not supported via Responses API.");
+		assert.equal(isCopilotEndpointMismatch(err), true);
+		assert.equal(isCopilotPlanRejection(err), false);
+	});
+});
+
+describe("self-heal targeting", () => {
+	function eventStream(events: unknown[], result: unknown = "ok") {
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				for (const e of events) yield e;
+			},
+			result: async () => result,
+		};
+	}
+	function failingStream(err: Error) {
+		return {
+			[Symbol.asyncIterator]: async function* () {
+				throw err;
+			},
+			result: async () => {
+				throw err;
+			},
+		};
+	}
+
+	it("retries on the surface the server did NOT name", async () => {
+		resetLearnedGitHubCopilotApis();
+		resetCopilotEntitlementMemory();
+		const calls: string[] = [];
+		const wrapped = wrapStreamFnWithCopilotEndpointHeal((model: unknown) => {
+			const api = String((model as { api?: string }).api);
+			calls.push(api);
+			// Server rejects /responses by name — the retry must go to completions.
+			return api === "openai-responses"
+				? failingStream(new Error("model gpt-4.1 is not supported via Responses API."))
+				: eventStream(["ok"]);
+		});
+		const stream = (await wrapped({ provider: "github-copilot", id: "gpt-4.1", api: "openai-responses" }, {}, {})) as {
+			result(): Promise<unknown>;
+		};
+		assert.equal(await stream.result(), "ok");
+		assert.deepEqual(calls, ["openai-responses", "openai-completions"]);
+		resetLearnedGitHubCopilotApis();
+	});
+
+	it("does not re-issue a plan rejection, and remembers the model is unusable", async () => {
+		resetLearnedGitHubCopilotApis();
+		resetCopilotEntitlementMemory();
+		let calls = 0;
+		const wrapped = wrapStreamFnWithCopilotEndpointHeal(() => {
+			calls++;
+			return failingStream(new Error("400 The requested model is not supported."));
+		});
+		const stream = (await wrapped({ provider: "github-copilot", id: "gpt-5-mini", api: "openai-responses" }, {}, {})) as {
+			result(): Promise<unknown>;
+		};
+		await assert.rejects(() => stream.result(), /not supported/);
+		assert.equal(calls, 1, "the other surface refuses it identically — don't spend a request finding out");
+		assert.equal(isCopilotModelKnownUnsupported("gpt-5-mini"), true);
+		assert.deepEqual(listCopilotUnsupportedModels(), ["gpt-5-mini"]);
+		resetCopilotEntitlementMemory();
+	});
+});
+
+// ── Credential health: a Copilot bearer stored as a plain API key ────────────
+// GitHub Copilot has no durable API key. A `tid=…;exp=…` bearer held under any
+// credential type other than `oauth` has no refresh path, so it dies within the
+// half hour. Verified against a real profile that had exactly this shape.
+
+describe("inspectCopilotCredential", () => {
+	const NOW = 1_786_230_000_000;
+	const bearer = (expSeconds: number) => `tid=abc;exp=${expSeconds};proxy-ep=proxy.individual.githubcopilot.com;st=dotcom`;
+
+	it("flags a bearer held as an api_key as degraded (no refresh path)", () => {
+		const h = inspectCopilotCredential(bearer(Math.floor(NOW / 1000) + 1800), "api_key", NOW);
+		assert.equal(h.isBearer, true);
+		assert.equal(h.degraded, true);
+		assert.equal(h.expired, false);
+		assert.equal(Math.round((h.msRemaining ?? 0) / 60000), 30);
+	});
+
+	it("does not flag the same bearer under an oauth credential", () => {
+		const h = inspectCopilotCredential(bearer(Math.floor(NOW / 1000) + 1800), "oauth", NOW);
+		assert.equal(h.isBearer, true);
+		assert.equal(h.degraded, false, "oauth carries the GitHub grant and renews itself");
+	});
+
+	it("treats an about-to-expire token as expired (clock-skew allowance)", () => {
+		const h = inspectCopilotCredential(bearer(Math.floor(NOW / 1000) + 30), "api_key", NOW);
+		assert.equal(h.expired, true, "a request in flight at exp still fails");
+	});
+
+	it("ignores a real API key from any other provider", () => {
+		const h = inspectCopilotCredential("sk-ant-api03-abcdef", "api_key", NOW);
+		assert.equal(h.isBearer, false);
+		assert.equal(h.degraded, false);
+		assert.equal(describeCopilotCredentialProblem(h), undefined);
+	});
+
+	it("explains the fix in the operator message", () => {
+		const h = inspectCopilotCredential(bearer(Math.floor(NOW / 1000) - 60), "api_key", NOW);
+		const msg = describeCopilotCredentialProblem(h);
+		assert.match(String(msg), /brigade login copilot/);
+		assert.match(String(msg), /already/);
 	});
 });

--- a/src/agents/github-copilot-transport.ts
+++ b/src/agents/github-copilot-transport.ts
@@ -32,7 +32,7 @@
  * between tiers (or a fresh login) routes correctly with no code change.
  */
 
-import { getCopilotModelHint } from "../integrations/provider-discovery.js";
+import { fetchGitHubCopilotModels, getCopilotModelHint } from "../integrations/provider-discovery.js";
 
 /** Pi's provider id for the Copilot subscription backend. */
 export const GITHUB_COPILOT_PROVIDER = "github-copilot";
@@ -116,6 +116,30 @@ export function resolveGitHubCopilotApi(modelId: string): CopilotApi {
 	return githubCopilotApiForModelId(modelId);
 }
 
+/**
+ * Make sure the account's live catalog is loaded before routing decisions.
+ *
+ * The advertised layer is only useful if the hints are actually in memory, and
+ * `/models` DOES carry `supported_endpoints` today (verified live: 35 of 53
+ * entries, and it is the only thing that gets a family like `mai-code-1-flash`
+ * — `/responses`-only, matching no id heuristic — right). So warm it on the turn
+ * path too, not just when synthesizing an unknown id.
+ *
+ * Cost-shaped: awaited only when we have nothing for this model (first turn on a
+ * cold cache); otherwise the cached hint is used immediately and the refresh
+ * runs detached. `fetchGitHubCopilotModels` is 5-minute cached, timeout-bounded
+ * and swallows its own errors, so the worst case is that we fall through to the
+ * family rule exactly as before.
+ */
+export async function warmGitHubCopilotHints(modelId: string, token: string | undefined): Promise<void> {
+	if (!token) return;
+	if (getCopilotModelHint(modelId)) {
+		void fetchGitHubCopilotModels(token).catch(() => {}); // keep it fresh for the next turn
+		return;
+	}
+	await fetchGitHubCopilotModels(token).catch(() => {});
+}
+
 /* ─────────────────────────────── host selection ─────────────────────────────── */
 
 /**
@@ -186,22 +210,162 @@ export function applyGitHubCopilotRouting(model: unknown, modelId: string, copil
 	return next;
 }
 
+/* ─────────────────────────── credential health ─────────────────────────── */
+
+/**
+ * GitHub Copilot has NO durable API key. The only bearer the API accepts is the
+ * short-lived token exchanged from a GitHub OAuth grant — `tid=…;exp=…;proxy-ep=…`,
+ * good for ~30 minutes. Renewing it requires the GitHub grant, which lives in the
+ * `refresh` field of an OAuth credential.
+ *
+ * So a Copilot bearer stored as `type: "api_key"` is a login with a countdown on
+ * it: Pi's refresh path only runs for `type: "oauth"`, so when `exp` passes there
+ * is nothing to renew from and every turn 401s. Observed in the wild — the
+ * gateway's `add-provider` RPC accepts a key for any provider id, and a Copilot
+ * bearer pasted there looks durable but dies within the half hour.
+ *
+ * This inspection lets the loop say so precisely, instead of surfacing a bare 401
+ * half an hour after a login that appeared to work.
+ */
+export interface CopilotCredentialHealth {
+	/** The value is an exchanged Copilot bearer, not a durable key. */
+	isBearer: boolean;
+	/** Epoch ms from the token's own `exp`, when present. */
+	expiresAt?: number;
+	/** Already past `exp` (with a small clock-skew allowance). */
+	expired: boolean;
+	/** Milliseconds left; negative once expired. */
+	msRemaining?: number;
+	/** Cannot renew itself: a bearer held under a non-OAuth credential type. */
+	degraded: boolean;
+}
+
+/** Treat a token as spent slightly early — a request in flight at `exp` still fails. */
+const COPILOT_EXPIRY_SKEW_MS = 60_000;
+
+export function inspectCopilotCredential(
+	token: string | undefined,
+	credentialType?: string,
+	now: number = Date.now(),
+): CopilotCredentialHealth {
+	if (!token || !/(?:^|;)\s*tid=/.test(token)) {
+		return { isBearer: false, expired: false, degraded: false };
+	}
+	const exp = /(?:^|;)\s*exp=(\d{1,12})/.exec(token)?.[1];
+	const expiresAt = exp ? Number(exp) * 1000 : undefined;
+	const msRemaining = expiresAt === undefined ? undefined : expiresAt - now;
+	const expired = msRemaining !== undefined && msRemaining <= COPILOT_EXPIRY_SKEW_MS;
+	// `oauth` credentials carry the GitHub grant and renew themselves; anything
+	// else holding a bearer has no way back once it lapses.
+	const degraded = credentialType !== undefined && credentialType !== "oauth";
+	return { isBearer: true, expiresAt, expired, msRemaining, degraded };
+}
+
+/** Operator-facing explanation for a Copilot login that cannot renew itself. */
+export function describeCopilotCredentialProblem(health: CopilotCredentialHealth): string | undefined {
+	if (!health.isBearer || !health.degraded) return undefined;
+	const when =
+		health.expiresAt === undefined
+			? "shortly"
+			: health.expired
+				? "already"
+				: `in ~${Math.max(1, Math.round((health.msRemaining ?? 0) / 60_000))} min`;
+	return (
+		`Your GitHub Copilot credential is a short-lived access token stored as a plain API key, ` +
+		`so it cannot refresh itself — it expires ${when}. GitHub Copilot has no durable API key; ` +
+		`run \`brigade login copilot\` and complete the device-code sign-in to store a credential ` +
+		`that renews automatically.`
+	);
+}
+
 /* ──────────────────────────── self-healing stream ───────────────────────────── */
+
+/**
+ * Which API surface did Copilot say was the WRONG one? Verified against the live
+ * API, it names the surface in the rejection rather than the model's real home:
+ *
+ *   "model gpt-4.1 is not supported via Responses API."                 → /responses was wrong
+ *   "model gpt-5.6-luna is not accessible via the /chat/completions endpoint"
+ *                                                                       → /chat/completions was wrong
+ *
+ * Reading the surface out of the message is strictly better than flipping
+ * blindly: the retry targets what the server implied instead of guessing, and a
+ * future third surface can't send us to the wrong place. Returns `undefined`
+ * when the error names no surface (e.g. a bare 421 from the edge), which leaves
+ * the caller to flip.
+ */
+export function copilotRejectedApi(err: unknown): CopilotApi | undefined {
+	const text = endpointErrorText(err);
+	if (!text) return undefined;
+	if (/(?:via|on|by)\s+(?:the\s+)?(?:\/)?responses(?:\s+api|\s+endpoint)?\b/i.test(text)) return "openai-responses";
+	if (/(?:via|on|by)\s+(?:the\s+)?(?:\/)?chat[\s/_-]?completions(?:\s+api|\s+endpoint)?\b/i.test(text)) {
+		return "openai-completions";
+	}
+	return undefined;
+}
 
 /**
  * Does this failure mean "right credential, wrong endpoint"? Copilot says so two
  * ways: a bare `421 Misdirected Request` from the edge, or a 400 naming the
- * endpoint the model isn't served on.
+ * surface the model isn't served on (see `copilotRejectedApi` for the wordings
+ * observed live — the earlier pattern set only covered the `/chat/completions
+ * endpoint` phrasing and missed the far more common "via Responses API" one).
  */
 export function isCopilotEndpointMismatch(err: unknown): boolean {
 	const text = endpointErrorText(err);
 	if (!text) return false;
-	return (
-		/misdirected request/i.test(text) ||
-		/\b421\b/.test(text) ||
-		/not accessible via the \/\S+ endpoint/i.test(text) ||
-		/not supported (?:on|by) (?:the )?\/\S+ endpoint/i.test(text)
-	);
+	if (isCopilotPlanRejection(err)) return false; // entitlement, not routing
+	return /misdirected request/i.test(text) || /\b421\b/.test(text) || copilotRejectedApi(err) !== undefined;
+}
+
+/**
+ * The OTHER 400 — the seat isn't entitled to this model at all:
+ *
+ *   "The requested model is not supported."
+ *
+ * Verified on a `free_limited_copilot` seat, where `gpt-5-mini` and
+ * `claude-haiku-4.5` both fail this way even though `/models` advertises them as
+ * available on every plan. It is NOT an endpoint problem, so re-issuing on the
+ * other surface is guaranteed to fail the same way — the heal must sit this one
+ * out and let the error surface with a "pick another model" message.
+ *
+ * Distinguished from the endpoint case by the absence of a named surface: the
+ * entitlement rejection never says "via …".
+ */
+export function isCopilotPlanRejection(err: unknown): boolean {
+	const text = endpointErrorText(err);
+	if (!text) return false;
+	if (copilotRejectedApi(err) !== undefined) return false;
+	return /requested model is not supported/i.test(text) || /model is not supported\b/i.test(text);
+}
+
+/**
+ * Models this seat has been told it cannot use, learned from live rejections.
+ * `/models` cannot be trusted for entitlement (a free seat's listing claims
+ * `restricted_to: all` for models the API then refuses), so the only reliable
+ * source is what the API actually answered. Process-scoped, same rationale as
+ * the learned-endpoint map above.
+ */
+const unsupportedCopilotModels = new Set<string>();
+
+/** Record that this seat cannot run `modelId` (learned from a live rejection). */
+export function rememberCopilotModelUnsupported(modelId: string): void {
+	if (modelId) unsupportedCopilotModels.add(modelId.trim().toLowerCase());
+}
+
+/** Has this seat already been refused `modelId`? */
+export function isCopilotModelKnownUnsupported(modelId: string): boolean {
+	return unsupportedCopilotModels.has(modelId.trim().toLowerCase());
+}
+
+/** Every model this seat has been refused so far — for an actionable error. */
+export function listCopilotUnsupportedModels(): string[] {
+	return [...unsupportedCopilotModels].sort();
+}
+
+/** Test seam — drop everything learned about entitlement this process. */
+export function resetCopilotEntitlementMemory(): void {
+	unsupportedCopilotModels.clear();
 }
 
 function endpointErrorText(err: unknown): string {
@@ -257,9 +421,20 @@ export function wrapStreamFnWithCopilotEndpointHeal(
 
 		/** Re-issue the call on the other endpoint, or rethrow the original error. */
 		const reissue = async (err: unknown): Promise<EventStreamLike> => {
+			// Entitlement rejections are terminal for this model — the other surface
+			// refuses it identically. Learn it so the next turn fails instantly with
+			// an actionable message instead of probing again.
+			if (modelId && isCopilotPlanRejection(err)) {
+				rememberCopilotModelUnsupported(modelId);
+				throw err;
+			}
 			if (healed || eventsSeen > 0 || !modelId || !isCopilotEndpointMismatch(err)) throw err;
 			healed = true;
-			const to = flipCopilotApi(typeof model.api === "string" ? model.api : undefined);
+			// Prefer the surface the server NAMED as wrong (retry the other one); fall
+			// back to flipping whatever we sent when the error names none (bare 421).
+			const rejected = copilotRejectedApi(err);
+			const to = rejected ? flipCopilotApi(rejected) : flipCopilotApi(typeof model.api === "string" ? model.api : undefined);
+			if (to === model.api) throw err; // nothing left to try — don't repeat the same call
 			const flipped: LooseModel = { ...model, api: to };
 			delete flipped.compat;
 			delete flipped.thinkingLevelMap;

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -133,6 +133,7 @@ import { clearChannelMetaRegistry, registerChannelMeta } from "../agents/channel
 import type { GroupToolPolicyConfig } from "../agents/channels/access-control/index.js";
 import { makeOpQueue, withTimeout } from "./extension-lifecycle.js";
 import { resolveModelNeverMiss } from "../agents/model-resolution.js";
+import { inspectCopilotCredential } from "../agents/github-copilot-transport.js";
 import { isClaudeCliAvailable } from "../agents/claude-cli/availability.js";
 import { listClaudeCliModels, listClaudeCliModelsLive } from "../agents/claude-cli/register.js";
 import {
@@ -3582,6 +3583,20 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				const apiKey = p.apiKey?.trim();
 				if (!providerId) throw new Error("providerId is required");
 				if (!apiKey) throw new Error("apiKey is required");
+				// GitHub Copilot has no durable API key — the only accepted bearer is
+				// the ~30-minute token exchanged from a GitHub OAuth grant. Storing one
+				// here produces a login that looks fine and then 401s within the half
+				// hour with nothing to refresh from, because Pi only renews
+				// `type: "oauth"` credentials. Refuse it and point at the flow that
+				// stores a renewable credential.
+				const copilotHealth = inspectCopilotCredential(apiKey, "api_key");
+				if (copilotHealth.isBearer) {
+					throw new Error(
+						"That's a short-lived GitHub Copilot access token, not a durable API key — it " +
+							"expires within the hour and can't refresh itself. Run `brigade login copilot` " +
+							"and complete the device-code sign-in instead.",
+					);
+				}
 				// Live validation against the provider's models endpoint (8s timeout):
 				// 401/403 hard-reject; rate-limit / outage soft-accept with a warning.
 				let warning: string | undefined;


### PR DESCRIPTION
Follow-up to #93, driven by probing a real Copilot seat rather than issue reports. Three defects, all confirmed against the live API, plus a credential-durability hole.

## 1. The endpoint detector missed the wording GitHub actually uses

#93's patterns came from github/copilot-cli#4337 (`"not accessible via the /chat/completions endpoint"`). The common rejection is:

```
model gpt-4.1 is not supported via Responses API.
```

The self-heal never fired for it, so those turns burned three retries and surfaced `last reason=unknown`. Worse, the heal **flipped blindly**. It now reads the rejected surface out of the message and re-issues on the *other* one — a future third surface can't send the retry somewhere wrong. A bare 421 (which names nothing) still flips.

## 2. A second, unrelated 400 was being treated as routing

`The requested model is not supported.` is **plan entitlement** — the seat can't run the model on any surface. Verified on a `free_limited_copilot` seat where `gpt-5-mini` and `claude-haiku-4.5` both fail this way *even though `/models` advertises them for every plan*, so `billing.restricted_to` cannot be trusted for entitlement.

It now fails fast with "your subscription doesn't include this model", is remembered so the next turn is instant, and never spends a request discovering the other endpoint refuses it too.

## 3. `supported_endpoints` is real, and wasn't being consulted

#93 assumed GitHub ships no endpoint metadata. It does — **35 of 53** entries carry it, and it confirms `gpt-5.6-sol` is `/responses`-only. The advertised layer was only warmed when synthesizing an unknown id, leaving catalogued models on the id heuristic — which gets `mai-code-1-flash` wrong (`/responses`-only, matching no `gpt-5`/`codex` rule). The account's catalog now loads on the turn path too, awaited only on a cold cache.

## 4. Copilot logins that cannot renew themselves

A `tid=…;exp=…` bearer stored as a plain `api_key` has no refresh path: the only accepted bearer is the ~30-minute token exchanged from a GitHub OAuth grant, and Pi refreshes `type: "oauth"` credentials only. Such a login looks healthy and then 401s within the half hour with nothing to refresh from. Found on a live profile.

- the loop detects it, warns once while valid, and fails with a "run `brigade login copilot`" message once it lapses instead of a bare 401
- the gateway's `add-provider` RPC — which accepts a key for any provider id, and is how the credential got there — now refuses a Copilot bearer outright

## Verification

- 33 routing tests + 41 classifier tests, covering every wording captured from the live API
- `tsc --noEmit` clean on both configs; `npm run build` clean
- broader `agents` + `integrations` + `core` sweep: 0 failures

## Known, deliberately not changed

The model picker still lists models a seat can't run. `/models` reports `model_picker_enabled: false` for **all 53** entries on a free seat and misreports `restricted_to`, so filtering on it would hide working models and show broken ones. Failing fast with an accurate message (#2) is the honest behaviour until GitHub's metadata is trustworthy.