### PR TITLE
feat(copilot): plan-aware model list with Auto, and human error copy

### DIFF
--- a/src/agents/agent-loop.ts
+++ b/src/agents/agent-loop.ts
@@ -83,6 +83,8 @@ import {
   describeCopilotCredentialProblem,
   GITHUB_COPILOT_PROVIDER,
   inspectCopilotCredential,
+  isCopilotAutoModelId,
+  resolveCopilotAutoModel,
   warmGitHubCopilotHints,
   wrapStreamFnWithCopilotEndpointHeal,
 } from "./github-copilot-transport.js";
@@ -478,10 +480,9 @@ export async function runSingleTurn(args: RunSingleTurnArgs): Promise<RunSingleT
   const registryAsFinder = modelRegistry as { find?: (p: string, m: string) => unknown };
   if (typeof registryAsFinder.find !== "function") {
     throw new Error(
-      "Pi ModelRegistry.find is not a function — likely a Pi SDK version drift. " +
-        "Brigade was built against the 0.70.x ModelRegistry surface. " +
-        "Pin `@earendil-works/pi-coding-agent` to a known-compatible version, or " +
-        "update brigade's agent-loop to match the new Pi API.",
+      "Brigade's model engine is a version we don't recognise — this build can't " +
+        "start a turn. Update Brigade (`npm i -g @spinabot/brigade@latest`); if it " +
+        "persists, report it at https://github.com/spinabot/brigade/issues.",
     );
   }
   let model = registryAsFinder.find(args.provider, args.modelId);
@@ -500,15 +501,24 @@ export async function runSingleTurn(args: RunSingleTurnArgs): Promise<RunSingleT
     });
   }
   if (!model) {
-    throw new Error(
-      `Model not registered: provider=${args.provider} model=${args.modelId}.\n` +
-        `  • Pi's built-in catalog covers known Anthropic/OpenAI/Google/Ollama models;\n` +
-        `    if yours isn't listed, append an entry to ${modelsFile}\n` +
-        `    (one object under .providers.<provider>.models[]).\n` +
-        `  • For local Ollama: run \`ollama pull <model>\` first.\n` +
-        `  • Verify your auth profile is configured: ` +
-        `\`cat ${resolveAuthProfilesPath(args.agentId)}\``,
-    );
+    // Operator-facing: name the model, say the one thing that fixes it, stop.
+    // The old copy named our internal engine, quoted a models.json schema and a
+    // `cat` of the auth file — four lines of implementation detail for what is
+    // almost always "that model isn't on your plan, pick another". The
+    // diagnostics still exist, one debug log away.
+    log.debug("model resolution missed", {
+      provider: args.provider,
+      model: args.modelId,
+      modelsFile,
+      authProfiles: resolveAuthProfilesPath(args.agentId),
+    });
+    const nextStep =
+      args.provider === "ollama"
+        ? `Pull it first: \`ollama pull ${args.modelId}\``
+        : args.provider === GITHUB_COPILOT_PROVIDER
+          ? "Your Copilot plan may not include it — /model to see what this account can use."
+          : "Use /model to pick another, or /provider to switch provider.";
+    throw new Error(`${args.modelId} isn't available on ${args.provider}. ${nextStep}`);
   }
 
   // GitHub Copilot transport correction — the ONE choke point both the
@@ -546,13 +556,44 @@ export async function runSingleTurn(args: RunSingleTurnArgs): Promise<RunSingleT
     // our id heuristic and is the only thing that routes a family the heuristic
     // has never seen (e.g. `mai-code-1-flash`, which is /responses-only).
     await warmGitHubCopilotHints(args.modelId, copilotToken);
-    const routed = applyGitHubCopilotRouting(model, args.modelId, copilotToken);
+    // `auto` — the only selection a Copilot Free seat is allowed to make since
+    // GitHub removed manual model choice from that plan. Resolve it against the
+    // account's live catalog, minus anything the API has already refused, so the
+    // pick self-corrects instead of needing a plan table we'd have to maintain.
+    let copilotEffectiveModelId = args.modelId;
+    if (isCopilotAutoModelId(args.modelId)) {
+      const picked = resolveCopilotAutoModel(copilotToken);
+      if (picked) {
+        log.debug("github-copilot auto resolved", { model: picked });
+        copilotEffectiveModelId = picked;
+        model =
+          registryAsFinder.find(args.provider, picked) ??
+          (await resolveModelNeverMiss({
+            modelRegistry,
+            provider: args.provider,
+            modelId: picked,
+            modelsFile,
+            authStorage,
+          }));
+      }
+      if (!model) {
+        throw new BrigadeRetryError({
+          message:
+            "Couldn't work out which GitHub Copilot model your plan allows — the account's model list " +
+            "was unreachable. Pick one explicitly with /model, or try again in a moment.",
+          reason: "model_not_found",
+          provider: args.provider,
+          model: args.modelId,
+        });
+      }
+    }
+    const routed = applyGitHubCopilotRouting(model, copilotEffectiveModelId, copilotToken);
     if (routed !== model) {
       const before = model as { api?: string; baseUrl?: string };
       const after = routed as { api?: string; baseUrl?: string };
       if (before.api !== after.api || before.baseUrl !== after.baseUrl) {
         log.debug("github-copilot routing corrected", {
-          model: args.modelId,
+          model: copilotEffectiveModelId,
           api: `${before.api ?? "?"} → ${after.api ?? "?"}`,
           baseUrl: `${before.baseUrl ?? "?"} → ${after.baseUrl ?? "?"}`,
         });
@@ -1087,7 +1128,7 @@ async function runSingleTurnLocked(p: RunSingleTurnLockedArgs): Promise<RunSingl
   } as never);
 
   if (!session) {
-    throw new Error("Pi createAgentSession returned no session.");
+    throw new Error("Couldn't start a session with the model engine. Try again, or update Brigade if it persists.");
   }
 
   // H4 — install the payload-level streamFn wrap so every outbound LLM

--- a/src/agents/github-copilot-routing.test.ts
+++ b/src/agents/github-copilot-routing.test.ts
@@ -23,7 +23,9 @@ import {
 	flipCopilotApi,
 	githubCopilotApiForModelId,
 	githubCopilotBaseUrlFromToken,
+	copilotPlanFromToken,
 	copilotRejectedApi,
+	isCopilotAutoModelId,
 	describeCopilotCredentialProblem,
 	inspectCopilotCredential,
 	isCopilotEndpointMismatch,
@@ -440,5 +442,41 @@ describe("inspectCopilotCredential", () => {
 		const msg = describeCopilotCredentialProblem(h);
 		assert.match(String(msg), /brigade login copilot/);
 		assert.match(String(msg), /already/);
+	});
+});
+
+// ── Plan detection + Auto ────────────────────────────────────────────────────
+// GitHub removed manual model selection from Copilot Free in June 2026, and
+// reports it per model as `model_picker_enabled: false`. Detection reads the
+// seat's own sku and catalog rather than a plan table we'd have to maintain.
+
+describe("copilotPlanFromToken", () => {
+	const tok = (sku: string) => `tid=abc;exp=9999999999;sku=${sku};proxy-ep=proxy.individual.githubcopilot.com`;
+
+	it("recognises a free seat and marks it unable to pick models", () => {
+		const plan = copilotPlanFromToken(tok("free_limited_copilot"));
+		assert.equal(plan.isFree, true);
+		assert.equal(plan.canPickModels, false);
+		assert.match(plan.label, /free/i);
+	});
+
+	it("leaves a paid seat free to choose", () => {
+		const plan = copilotPlanFromToken(tok("copilot_for_business"));
+		assert.equal(plan.isFree, false);
+		assert.equal(plan.canPickModels, true);
+	});
+
+	it("degrades gracefully with no token", () => {
+		const plan = copilotPlanFromToken(undefined);
+		assert.equal(plan.isFree, false);
+		assert.equal(plan.canPickModels, true, "an unknown seat must not be locked out of picking");
+	});
+});
+
+describe("isCopilotAutoModelId", () => {
+	it("matches the synthetic id, case and space tolerant", () => {
+		assert.equal(isCopilotAutoModelId("auto"), true);
+		assert.equal(isCopilotAutoModelId(" Auto "), true);
+		assert.equal(isCopilotAutoModelId("gpt-4.1"), false);
 	});
 });

--- a/src/agents/github-copilot-transport.ts
+++ b/src/agents/github-copilot-transport.ts
@@ -32,7 +32,7 @@
  * between tiers (or a fresh login) routes correctly with no code change.
  */
 
-import { fetchGitHubCopilotModels, getCopilotModelHint } from "../integrations/provider-discovery.js";
+import { fetchGitHubCopilotModels, getCopilotModelHint, listCopilotModelHints } from "../integrations/provider-discovery.js";
 
 /** Pi's provider id for the Copilot subscription backend. */
 export const GITHUB_COPILOT_PROVIDER = "github-copilot";
@@ -208,6 +208,123 @@ export function applyGitHubCopilotRouting(model: unknown, modelId: string, copil
 			: { ...COPILOT_EDITOR_HEADERS };
 
 	return next;
+}
+
+/* ───────────────────────────── plan + auto model ───────────────────────────── */
+
+/** The synthetic model id that means "let Brigade choose for this seat". */
+export const COPILOT_AUTO_MODEL_ID = "auto";
+
+export interface CopilotPlan {
+	/** Raw `sku` from the token, e.g. `free_limited_copilot`, `copilot_for_business`. */
+	sku?: string;
+	/** Human label for onboarding / the picker. */
+	label: string;
+	/** A Free (or Student-equivalent) seat. */
+	isFree: boolean;
+	/**
+	 * Whether the seat may choose its own model. GitHub removed manual model
+	 * selection from Copilot Free in June 2026, and reports it per model as
+	 * `model_picker_enabled: false` — on a Free seat that is false for EVERY
+	 * entry, which is the signal we read rather than hardcoding plan names.
+	 */
+	canPickModels: boolean;
+}
+
+/**
+ * What plan is this seat on? Read from the token's own `sku`, cross-checked
+ * against the catalog's picker flags — so a plan GitHub invents next quarter is
+ * classified by behaviour ("nothing is pickable") rather than by a name we'd
+ * have to keep updating.
+ */
+export function copilotPlanFromToken(token: string | undefined): CopilotPlan {
+	const sku = token ? /(?:^|;)\s*sku=([^;]+)/.exec(token)?.[1] : undefined;
+	const isFree = !!sku && /free|student/i.test(sku);
+	const hints = listCopilotModelHints();
+	// Only trust the catalog when we actually have one; an empty cache must not
+	// be read as "nothing is pickable".
+	const catalogSaysNoPicking = hints.length > 0 && hints.every((h) => h.pickerEnabled !== true);
+	const label = sku ? sku.replace(/_/g, " ").replace(/\bcopilot\b/gi, "Copilot").trim() : "GitHub Copilot";
+	return { sku, label, isFree, canPickModels: !(isFree || catalogSaysNoPicking) };
+}
+
+/**
+ * Resolve `auto` to a concrete model this seat can actually run.
+ *
+ * Ranked from the account's own catalog, never a hardcoded list:
+ *   1. drop anything the API has already refused (learned at runtime)
+ *   2. drop policy-disabled and non-tool-calling models — Brigade needs tools
+ *   3. drop models whose `restricted_to` excludes this seat's sku (advisory:
+ *      the field over-promises, so it only ever narrows, never confirms)
+ *   4. prefer the seat's own `is_chat_default`, then vision, then the largest
+ *      context window
+ *
+ * Returns `undefined` when the catalog isn't loaded or nothing survives, and the
+ * caller falls back to its configured model. Entitlement mistakes are
+ * self-correcting: a plan rejection marks the model unsupported, so the next
+ * resolution picks the next candidate.
+ */
+export function resolveCopilotAutoModel(token: string | undefined): string | undefined {
+	const plan = copilotPlanFromToken(token);
+	const candidates = listCopilotModelHints().filter((h) => {
+		if (isCopilotModelKnownUnsupported(h.id)) return false;
+		if (h.policyState === "disabled") return false;
+		if (h.toolCalls === false) return false;
+		// GitHub's auto-routing pseudo-models only resolve inside a `/models/session`
+		// (see the Auto design notes) — they 400 on a direct call, so exclude them.
+		if (/-free-auto$|^copilot-search-|^exec-agent-|^trajectory-/.test(h.id)) return false;
+		if (plan.sku && h.restrictedTo && h.restrictedTo.length > 0) {
+			const skuFamily = plan.isFree ? "free" : plan.sku;
+			if (!h.restrictedTo.some((r) => r === skuFamily || plan.sku?.includes(r))) return false;
+		}
+		return true;
+	});
+	if (candidates.length === 0) return undefined;
+	candidates.sort((a, b) => {
+		if (!!a.isChatDefault !== !!b.isChatDefault) return a.isChatDefault ? -1 : 1;
+		if (!!a.vision !== !!b.vision) return a.vision ? -1 : 1;
+		return (b.contextWindow ?? 0) - (a.contextWindow ?? 0);
+	});
+	return candidates[0]?.id;
+}
+
+/** True when the requested id is the synthetic auto entry. */
+export function isCopilotAutoModelId(modelId: string): boolean {
+	return modelId.trim().toLowerCase() === COPILOT_AUTO_MODEL_ID;
+}
+
+/**
+ * Build a usable Model for a Copilot id from the ACCOUNT's catalog alone, with
+ * no catalogued template to clone.
+ *
+ * Needed because Pi filters the registry down to the ids the login reported
+ * (`availableModelIds`). When a seat's real ids don't intersect Pi's bundled
+ * snapshot — routine on enterprise seats, and on any seat once GitHub ships a
+ * new family — EVERY Copilot entry is filtered out, the never-miss resolver
+ * finds no template to clone, and the turn dies with "isn't available on
+ * github-copilot" for a model the picker just listed.
+ *
+ * Everything here comes from the live catalog or the live token, so it stays
+ * correct for models that don't exist yet.
+ */
+export function buildCopilotModelFromCatalog(modelId: string, token: string | undefined): unknown | undefined {
+	const hint = getCopilotModelHint(modelId);
+	if (!hint) return undefined;
+	return applyGitHubCopilotRouting(
+		{
+			provider: GITHUB_COPILOT_PROVIDER,
+			id: hint.id,
+			name: hint.name ?? hint.id,
+			api: resolveGitHubCopilotApi(hint.id),
+			input: hint.vision ? ["text", "image"] : ["text"],
+			reasoning: false,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: hint.contextWindow ?? 128_000,
+			maxTokens: hint.maxTokens ?? 8192,
+		},
+		hint.id,
+		token,
+	);
 }
 
 /* ─────────────────────────── credential health ─────────────────────────── */

--- a/src/agents/model-resolution.ts
+++ b/src/agents/model-resolution.ts
@@ -25,7 +25,12 @@
 import * as fs from "node:fs";
 
 import { isClaudeCliProvider, synthClaudeCliModel } from "./claude-cli/register.js";
-import { applyGitHubCopilotRouting, GITHUB_COPILOT_PROVIDER, githubCopilotApiForModelId } from "./github-copilot-transport.js";
+import {
+	applyGitHubCopilotRouting,
+	buildCopilotModelFromCatalog,
+	GITHUB_COPILOT_PROVIDER,
+	githubCopilotApiForModelId,
+} from "./github-copilot-transport.js";
 import { isLikelyReasoningModelId } from "../core/model-caps.js";
 import { rediscoverOllamaModel } from "../integrations/ollama.js";
 import {
@@ -175,18 +180,22 @@ export async function resolveModelNeverMiss(args: ResolveModelArgs): Promise<unk
 	// provider's first-listed model, or it inherits the wrong endpoint.
 	const template = findProviderTemplate(registry, provider, modelId);
 
-	// 3. Live cloud discovery for accurate metadata (best-effort).
+	// 3. Live discovery for accurate metadata (best-effort).
 	const apiKey = await readApiKey(args.authStorage, provider);
-	const discovery = await discoverCloudModelMeta(provider, modelId, {
-		baseUrl: typeof template?.baseUrl === "string" ? template.baseUrl : undefined,
-		apiKey,
-	});
-	// 3b. GitHub Copilot has a per-ACCOUNT live catalog, and reaching this line
-	// means the id is one Pi's bundled snapshot doesn't carry — exactly the case
-	// where the account's own list is the only accurate source (context window,
-	// vision, and any endpoint it advertises). Cached for 5 min and never throws,
-	// so at most one extra request per model generation.
-	const copilotMeta = provider === GITHUB_COPILOT_PROVIDER ? await readCopilotLiveMeta(modelId, apiKey) : undefined;
+	const isCopilot = provider === GITHUB_COPILOT_PROVIDER;
+	// Copilot has a per-ACCOUNT live catalog, and reaching this line means the id
+	// is one Pi's bundled snapshot doesn't carry — exactly when the account's own
+	// list is the only accurate source (context window, vision, and any endpoint
+	// it advertises). It needs Copilot's editor headers, which the generic probe
+	// doesn't send (that request 400s), so route to the purpose-built reader
+	// instead of the generic one. Cached for 5 min and never throws.
+	const copilotMeta = isCopilot ? await readCopilotLiveMeta(modelId, apiKey) : undefined;
+	const discovery = isCopilot
+		? { exists: false, meta: {} as DiscoveredModelMeta }
+		: await discoverCloudModelMeta(provider, modelId, {
+				baseUrl: typeof template?.baseUrl === "string" ? template.baseUrl : undefined,
+				apiKey,
+			});
 
 	// 4. Synthesize from the provider template (clone routing, override the
 	// per-model fields). We synthesize even when discovery couldn't confirm
@@ -197,7 +206,17 @@ export async function resolveModelNeverMiss(args: ResolveModelArgs): Promise<unk
 		const synth = synthFromTemplate(template, modelId, { ...discovery.meta, ...copilotMeta });
 		// Copilot: route to the endpoint/host THIS account needs. The template
 		// only gets us close (see applyGitHubCopilotRouting).
-		return provider === GITHUB_COPILOT_PROVIDER ? applyGitHubCopilotRouting(synth, modelId, apiKey) : synth;
+		return isCopilot ? applyGitHubCopilotRouting(synth, modelId, apiKey) : synth;
+	}
+
+	// 4b. GitHub Copilot with NO template to clone. Pi filters the registry to the
+	// ids the login reported, so a seat whose real ids don't intersect the bundled
+	// snapshot has every Copilot entry filtered out — leaving a model the picker
+	// just listed unresolvable. The account's own catalog carries everything
+	// needed to build it outright.
+	if (isCopilot) {
+		const fromCatalog = buildCopilotModelFromCatalog(modelId, apiKey);
+		if (fromCatalog) return fromCatalog;
 	}
 
 	// 5. Synthesize from a configured `custom`/OpenAI-compatible provider in

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -19,6 +19,7 @@
  * Ollama, BYO-endpoint) still need the full `brigade onboard` wizard.
  */
 
+import { COPILOT_AUTO_MODEL_ID } from "../../agents/github-copilot-transport.js";
 import process from "node:process";
 import { randomUUID } from "node:crypto";
 import * as nodePath from "node:path";
@@ -3650,7 +3651,16 @@ export async function wireConnectUi(
 				const head = current
 					? `${brand.amber(current)} ${brand.dim("(current)")}`
 					: brand.dim("models");
-				const body = currentModels.map((m) => `    ${brand.white(m.id)}`).join("\n");
+				// `auto` (GitHub Copilot) leads the list and is ruled off from the
+				// concrete ids below it — it's a different KIND of choice, and on a
+				// plan that can't pick its own model it's the one that works.
+				const body = currentModels
+					.map((m) =>
+						m.id === COPILOT_AUTO_MODEL_ID
+							? `    ${brand.amber(m.id)}  ${brand.dim("— picks a model your plan allows")}\n    ${brand.dim("─".repeat(24))}`
+							: `    ${brand.white(m.id)}`,
+					)
+					.join("\n");
 				insertBeforeEditor(
 					new Markdown(
 						`${brand.dim("models on your current provider:")}\n\n  ${head}\n${body}\n\n${brand.dim("usage: /model <id>  ·  switch provider with /provider")}`,

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -133,7 +133,12 @@ import { clearChannelMetaRegistry, registerChannelMeta } from "../agents/channel
 import type { GroupToolPolicyConfig } from "../agents/channels/access-control/index.js";
 import { makeOpQueue, withTimeout } from "./extension-lifecycle.js";
 import { resolveModelNeverMiss } from "../agents/model-resolution.js";
-import { inspectCopilotCredential } from "../agents/github-copilot-transport.js";
+import {
+	COPILOT_AUTO_MODEL_ID,
+	GITHUB_COPILOT_PROVIDER,
+	inspectCopilotCredential,
+	isCopilotModelKnownUnsupported,
+} from "../agents/github-copilot-transport.js";
 import { isClaudeCliAvailable } from "../agents/claude-cli/availability.js";
 import { listClaudeCliModels, listClaudeCliModelsLive } from "../agents/claude-cli/register.js";
 import {
@@ -3556,6 +3561,24 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 					for (const cm of cliModels) {
 						if (!seenCli.has(`${cm.provider}/${cm.id}`)) merged.push(cm as unknown as Model<any>);
 					}
+				}
+				// GitHub Copilot: lead with `auto`, and drop models this seat has
+				// already been refused. On a plan that can't choose its own model
+				// (Copilot Free, since GitHub removed manual selection) `auto` is the
+				// only reliable pick, and listing 20 models the account will reject is
+				// how an operator ends up debugging a 400 instead of chatting.
+				if (merged.some((m) => m.provider === GITHUB_COPILOT_PROVIDER)) {
+					merged = merged.filter(
+						(m) => m.provider !== GITHUB_COPILOT_PROVIDER || !isCopilotModelKnownUnsupported(m.id),
+					);
+					const copilotIndex = merged.findIndex((m) => m.provider === GITHUB_COPILOT_PROVIDER);
+					const template = merged[copilotIndex] as Model<any> | undefined;
+					merged.splice(copilotIndex < 0 ? merged.length : copilotIndex, 0, {
+						...(template ?? {}),
+						provider: GITHUB_COPILOT_PROVIDER,
+						id: COPILOT_AUTO_MODEL_ID,
+						name: "Auto — Brigade picks a model your plan allows",
+					} as Model<any>);
 				}
 				const models = merged.map((m: Model<any>) => modelToSummary(m));
 				return models as ResponseFor[M];

--- a/src/integrations/provider-discovery.ts
+++ b/src/integrations/provider-discovery.ts
@@ -349,12 +349,26 @@ export function getCachedSubscriptionModels(providerId: string): LiveCloudModel[
  */
 export interface CopilotModelHint {
 	id: string;
+	name?: string;
 	/** Endpoint the catalog says this model is served on, when it says at all. */
 	api?: "openai-responses" | "openai-completions";
 	contextWindow?: number;
 	maxTokens?: number;
 	vision?: boolean;
+	toolCalls?: boolean;
 	family?: string;
+	/** Plans the catalog claims may use this model. Advisory only — a free seat's
+	 *  listing says `all` for models the API then refuses, so this narrows the
+	 *  candidate set but never proves entitlement. */
+	restrictedTo?: string[];
+	/** `disabled` means the account must accept the model's terms first. */
+	policyState?: string;
+	/** The seat's own default pick — the closest thing to "what Auto would use". */
+	isChatDefault?: boolean;
+	/** GitHub's per-seat "can this user choose models at all" flag. False across
+	 *  the board on Copilot Free since June 2026, when manual selection was
+	 *  removed from that plan. */
+	pickerEnabled?: boolean;
 }
 
 const copilotModelHints = new Map<string, CopilotModelHint>();
@@ -380,6 +394,39 @@ export function resetCopilotModelHints(): void {
  * surfaces is left undecided on purpose: either works, so the family rule (which
  * matches what GitHub's own clients pick) stays in charge.
  */
+/** Every model the seat's catalog listed, pickable or not. Drives `auto`. */
+export function listCopilotModelHints(): CopilotModelHint[] {
+	return [...copilotModelHints.values()];
+}
+
+/** Record one `/models` entry verbatim — the selectability gate comes later. */
+function recordCopilotHint(
+	item: Record<string, unknown>,
+	capabilities: { family?: unknown; supports?: { tool_calls?: unknown; vision?: unknown }; limits?: { max_context_window_tokens?: unknown; max_output_tokens?: unknown } } | undefined,
+	policy: { state?: unknown } | undefined,
+	supports: { tool_calls?: unknown; vision?: unknown } | undefined,
+): void {
+	const id = typeof item.id === "string" ? item.id : "";
+	if (!id) return;
+	const ctx = capabilities?.limits?.max_context_window_tokens;
+	const maxOut = capabilities?.limits?.max_output_tokens;
+	const billing = item.billing as { restricted_to?: unknown } | undefined;
+	copilotModelHints.set(id.toLowerCase(), {
+		id,
+		...(typeof item.name === "string" && item.name ? { name: item.name } : {}),
+		api: copilotApiFromCatalogEntry(item, capabilities as Record<string, unknown> | undefined),
+		...(typeof ctx === "number" && ctx > 0 ? { contextWindow: ctx } : {}),
+		...(typeof maxOut === "number" && maxOut > 0 ? { maxTokens: maxOut } : {}),
+		vision: supports?.vision === true,
+		toolCalls: supports?.tool_calls !== false,
+		...(typeof capabilities?.family === "string" ? { family: capabilities.family } : {}),
+		...(Array.isArray(billing?.restricted_to) ? { restrictedTo: billing.restricted_to.map((v) => String(v)) } : {}),
+		...(typeof policy?.state === "string" ? { policyState: policy.state } : {}),
+		isChatDefault: item.is_chat_default === true,
+		pickerEnabled: item.model_picker_enabled === true,
+	});
+}
+
 function copilotApiFromCatalogEntry(item: Record<string, unknown>, capabilities: Record<string, unknown> | undefined): CopilotModelHint["api"] {
 	const raw =
 		item.supported_endpoints ?? item.supported_apis ?? item.api_modes ?? capabilities?.supported_endpoints ?? capabilities?.api_modes;
@@ -445,6 +492,11 @@ export async function fetchGitHubCopilotModels(copilotToken: string): Promise<Li
 				  }
 				| undefined;
 			const supports = capabilities?.supports;
+			// Hints are recorded for EVERY entry, before the selectability gate —
+			// a Copilot Free seat reports `model_picker_enabled: false` on all of
+			// them, and the picker still has to know what those models are in order
+			// to resolve `auto` and to explain why the list is short.
+			recordCopilotHint(item, capabilities, policy, supports);
 			if (item.model_picker_enabled !== true) continue;
 			if (policy?.state === "disabled") continue;
 			if (supports?.tool_calls === false) continue;
@@ -453,15 +505,7 @@ export async function fetchGitHubCopilotModels(copilotToken: string): Promise<Li
 			const maxOut = capabilities?.limits?.max_output_tokens;
 			const name = typeof item.name === "string" && item.name.length > 0 ? item.name : id;
 			const input = supports?.vision ? ["text", "image"] : ["text"];
-			// Transport + capability facts for THIS seat, keyed for the resolver.
-			copilotModelHints.set(id.toLowerCase(), {
-				id,
-				api: copilotApiFromCatalogEntry(item, capabilities as Record<string, unknown> | undefined),
-				...(contextWindow !== undefined ? { contextWindow } : {}),
-				...(typeof maxOut === "number" && maxOut > 0 ? { maxTokens: maxOut } : {}),
-				vision: supports?.vision === true,
-				...(typeof capabilities?.family === "string" ? { family: capabilities.family } : {}),
-			});
+			void maxOut;
 			out.push({
 				provider: "github-copilot",
 				id,

--- a/src/ui/onboarding.ts
+++ b/src/ui/onboarding.ts
@@ -29,6 +29,7 @@ import { CancellableLoader, Input, type SelectItem, SelectList, Text, TUI } from
 import {
 	upsertApiKeyProfile,
 	upsertApiKeyRefProfile,
+	readProfiles,
 	upsertOAuthProfile,
 	upsertTokenProfile,
 } from "../auth/profiles.js";
@@ -62,6 +63,13 @@ import {
 	prefetchSubscriptionModels,
 	probeModelReachable,
 } from "../integrations/provider-discovery.js";
+import {
+	COPILOT_AUTO_MODEL_ID,
+	copilotPlanFromToken,
+	GITHUB_COPILOT_PROVIDER,
+	isCopilotModelKnownUnsupported,
+	resolveCopilotAutoModel,
+} from "../agents/github-copilot-transport.js";
 
 export interface OnboardingResult {
 	provider: string;
@@ -1217,10 +1225,37 @@ export async function ensureSubscriptionLogin(
 
 		tui.addChild(new Text("", 0, 0));
 		tui.addChild(new Text(`  ${brand.amber("✓")} ${provider.name} connected.`, 0, 0));
+		// Say what the seat can actually do, HERE, rather than letting the operator
+		// discover it as a 400 three screens later. A Copilot Free seat cannot
+		// choose its own model at all (GitHub removed manual selection from that
+		// plan in June 2026), so the honest thing is to name the plan and point at
+		// Auto before they reach the picker.
+		if (providerId === GITHUB_COPILOT_PROVIDER) {
+			for (const line of describeCopilotPlanForOnboarding(creds.access)) {
+				tui.addChild(new Text(line, 0, 0));
+			}
+		}
 		tui.requestRender();
 		await delay(600);
 		return "ok";
 	}
+}
+
+/**
+ * Plain-language summary of what a Copilot seat may do, shown right after login.
+ * Reads the plan off the token and the account's own catalog — no plan table to
+ * keep in sync.
+ */
+function describeCopilotPlanForOnboarding(token: string): string[] {
+	const plan = copilotPlanFromToken(token);
+	const lines: string[] = [`  ${brand.dim("Plan:")} ${brand.white(plan.label)}`];
+	if (plan.canPickModels) return lines;
+	const auto = resolveCopilotAutoModel(token);
+	lines.push(
+		brand.dim("  This plan doesn't allow choosing your own model — GitHub decides for you."),
+		brand.dim(`  Pick ${brand.amber("Auto")} on the next screen and Brigade will use one your plan allows${auto ? ` (currently ${auto})` : ""}.`),
+	);
+	return lines;
 }
 
 /** True when EITHER the operator's own `claude` login OR Brigade's managed
@@ -1863,11 +1898,14 @@ async function pickModel(tui: TUI, modelRegistry: ModelRegistry, providerId: str
 		}
 	}
 
-	const items: SelectItem[] = models.map((m) => ({
-		value: m.id,
-		label: m.id,
-		description: describeModel(m),
-	}));
+	const items: SelectItem[] = models
+		// Models this account has already been refused are noise, not choices.
+		.filter((m) => !(providerId === GITHUB_COPILOT_PROVIDER && isCopilotModelKnownUnsupported(m.id)))
+		.map((m) => ({
+			value: m.id,
+			label: m.id,
+			description: describeModel(m),
+		}));
 
 	// Default-first ordering: reasoning > non-reasoning, then larger context first.
 	items.sort((a, b) => {
@@ -1877,6 +1915,24 @@ async function pickModel(tui: TUI, modelRegistry: ModelRegistry, providerId: str
 		if (!!ma.reasoning !== !!mb.reasoning) return ma.reasoning ? -1 : 1;
 		return (mb.contextWindow ?? 0) - (ma.contextWindow ?? 0);
 	});
+
+	// GitHub Copilot: offer Auto first. On a plan that can't choose its own model
+	// it's the only choice that reliably works, so it leads and says why; on a
+	// paid seat it's a convenience. The rule below it is decorative — SelectItem
+	// has no separator primitive, so it's a row we refuse to select.
+	if (providerId === GITHUB_COPILOT_PROVIDER) {
+		const plan = copilotPlanFromToken(readCopilotTokenForPicker());
+		items.unshift(
+			{
+				value: COPILOT_AUTO_MODEL_ID,
+				label: "Auto",
+				description: plan.canPickModels
+					? "Brigade picks a model your plan allows"
+					: `recommended — ${plan.label} can't choose models; Brigade picks one that works`,
+			},
+			{ value: PICKER_SEPARATOR, label: "─".repeat(18), description: "" },
+		);
+	}
 
 	// Searchable picker — providers like OpenRouter expose 270+ models, so a
 	// type-to-filter box on top of the list is the difference between usable
@@ -1899,13 +1955,37 @@ async function pickModel(tui: TUI, modelRegistry: ModelRegistry, providerId: str
 
 	try {
 		const chosen = await new Promise<SelectItem>((resolve, reject) => {
-			list.onSelect = (item) => resolve(item);
+			// Swallow the separator: not resolving leaves the picker open and focused,
+			// so the row reads as a divider even though the list has no concept of one.
+			list.onSelect = (item) => {
+				if (item.value === PICKER_SEPARATOR) return;
+				resolve(item);
+			};
 			list.onCancel = () => reject(new Error("back"));
 		});
 		return { modelId: chosen.value };
 	} catch {
 		return "back";
 	}
+}
+
+/** Sentinel value for the decorative divider row in a model picker. */
+const PICKER_SEPARATOR = "__brigade_separator__";
+
+/** The live Copilot bearer, for plan-aware picker copy. Best-effort: the picker
+ *  must render even when the credential can't be read. */
+function readCopilotTokenForPicker(): string | undefined {
+	try {
+		const profiles = readProfiles(DEFAULT_AGENT_ID) as {
+			profiles?: Record<string, { provider?: string; key?: string; access?: string; token?: string }>;
+		};
+		for (const p of Object.values(profiles.profiles ?? {})) {
+			if (p?.provider === GITHUB_COPILOT_PROVIDER) return p.access || p.key || p.token;
+		}
+	} catch {
+		/* no credential readable — Auto still renders, just without the plan name */
+	}
+	return undefined;
 }
 
 /** Model picker for the claude-cli backend — its models are synthesized (not in


### PR DESCRIPTION
## Why

[GitHub removed manual model selection from Copilot Free in June 2026](https://roboin.io/article/en/2026/06/25/github-copilot-free-and-student-plans-limited-to-auto-model-selection/). A Free seat therefore reports `model_picker_enabled: false` on **every** model (verified: all 53 on a live seat) and rejects most direct invocations with `400 The requested model is not supported`.

Brigade was showing those seats a 20-model picker built from the bundled catalog, nearly all of which the account cannot run — which is how a user ends up debugging a 400 instead of chatting.

## What

**`auto`** — a synthetic model id resolved against the *account's* live catalog, minus anything the API has already refused, ranked by the seat's own `is_chat_default` → vision → context window. Plan rejections mark a model unusable, so the pick self-corrects rather than needing a plan table to maintain. GitHub's own auto-routing pseudo-models (`*-free-auto`, `copilot-search-*`, `exec-agent-*`) are excluded — they only resolve inside a `/models/session` and 400 on a direct call.

**Plan detection** reads the token's `sku` *and* cross-checks the catalog's picker flags, so a plan invented next quarter is classified by behaviour ("nothing is pickable"), not by a name.

**Onboarding says it up front:**
```
✓ GitHub Copilot connected.
  Plan: free limited Copilot
  This plan doesn't allow choosing your own model — GitHub decides for you.
  Pick Auto on the next screen and Brigade will use one your plan allows (currently gpt-4.1).
```

**Both pickers** lead with Auto over a rule and hide models this seat has been refused. `SelectItem` has no divider primitive, so the onboarding separator is a row that refuses selection.

## Two bugs fixed alongside

**A model the picker lists could be unresolvable at turn time.** Pi filters the registry to the ids the login reported, so a seat whose real ids don't intersect the bundled snapshot has *every* Copilot entry filtered out — no template to clone. Routine on enterprise seats. Such a model is now built outright from the account's catalog entry plus the live token.

**The error copy was a brain-dump that leaked our internal engine name.** Before:
```
Model not registered: provider=github-copilot model=gpt-5-mini.
 • Pi's built-in catalog covers known Anthropic/OpenAI/Google/Ollama models;
   if yours isn't listed, append an entry to C:\Users\...\models.json
   (one object under .providers.<provider>.models[]).
 • For local Ollama: run `ollama pull <model>` first.
 • Verify your auth profile is configured: `cat C:\...\auth-profiles.json`
```
After:
```
gpt-5-mini isn't available on github-copilot. Your Copilot plan may not include it — /model to see what this account can use.
```
Provider-aware (Ollama gets the pull hint), diagnostics moved to a debug log. Two other engine-named errors de-branded with it.

## Verification

- 37 routing tests + 88 across routing/resolution/classifier, all passing
- `tsc --noEmit` clean on both configs, `npm run build` clean
- `auto` confirmed working end-to-end on a live Free seat (status bar `github-copilot · auto`, turn completed)