### PR TITLE
feat(skills): add Atlas Cloud media generation

### DIFF
--- a/skills/atlas-cloud-media/SKILL.md
+++ b/skills/atlas-cloud-media/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: atlas-cloud-media
+description: Generate images and videos with Atlas Cloud, poll asynchronous predictions, and download the resulting media.
+metadata:
+  {
+    "brigade":
+      {
+        "emoji": "🦁",
+        "requires": { "bins": ["python3"], "env": ["ATLASCLOUD_API_KEY"] },
+        "primaryEnv": "ATLASCLOUD_API_KEY",
+      },
+  }
+---
+
+# Atlas Cloud Media
+
+Use this skill when the user asks to generate an image or video with Atlas Cloud.
+
+## Generate an image
+
+```bash
+{baseDir}/scripts/generate.py image \
+  --prompt "A clean product photograph on a white background" \
+  --out /tmp/atlas-image.png
+```
+
+Default image model: `qwen-image-3.0/text-to-image`.
+
+## Generate a video
+
+```bash
+{baseDir}/scripts/generate.py video \
+  --prompt "A paper airplane gliding through a sunlit studio" \
+  --out /tmp/atlas-video.mp4
+```
+
+Default video model: `bytedance/seedance-2.0-fast/text-to-video`.
+
+Use `--model` to select another compatible Atlas model. Use `--params-json`
+for model-specific fields after checking that model's schema. The JSON must be
+an object; `model` and `prompt` remain controlled by the corresponding flags.
+
+```bash
+{baseDir}/scripts/generate.py image \
+  --model qwen-image-3.0/text-to-image \
+  --prompt "Editorial portrait, soft daylight" \
+  --params-json '{"size":"1024*1024"}' \
+  --out /tmp/portrait.png
+```
+
+The command prints the saved path. Image generation can take tens of seconds;
+video generation can take several minutes. Do not expose prediction URLs or the
+API key in chat output. Confirm the destination before overwriting valuable
+files.

--- a/skills/atlas-cloud-media/scripts/generate.py
+++ b/skills/atlas-cloud-media/scripts/generate.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Generate Atlas Cloud image or video media with bounded polling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_BASE = "https://api.atlascloud.ai/api/v1"
+MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024
+USER_AGENT = "Brigade-AtlasCloudMedia/1.0"
+DEFAULT_MODELS = {
+    "image": "qwen-image-3.0/text-to-image",
+    "video": "bytedance/seedance-2.0-fast/text-to-video",
+}
+DEFAULT_PARAMS = {
+    "image": {"size": "1024*1024"},
+    "video": {"duration": 4, "resolution": "720p"},
+}
+
+
+def _request_json(
+    url: str,
+    *,
+    api_key: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=body, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            result = json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read(2048).decode(errors="replace")
+        raise RuntimeError(f"Atlas Cloud HTTP {error.code}: {detail}") from error
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise RuntimeError(f"Atlas Cloud request failed: {error}") from error
+    if not isinstance(result, dict):
+        raise RuntimeError("Atlas Cloud returned an invalid JSON response")
+    return result
+
+
+def _prediction_data(response: dict[str, Any]) -> dict[str, Any]:
+    data = response.get("data", response)
+    if not isinstance(data, dict):
+        raise RuntimeError("Atlas Cloud returned invalid prediction data")
+    return data
+
+
+def _output_url(prediction: dict[str, Any]) -> str:
+    outputs = prediction.get("outputs")
+    value = outputs[0] if isinstance(outputs, list) and outputs else None
+    if not isinstance(value, str):
+        raise RuntimeError("Atlas Cloud prediction completed without an output URL")
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise RuntimeError("Atlas Cloud returned an unsafe output URL")
+    return value
+
+
+def _payload(kind: str, model: str, prompt: str, params_json: str | None) -> dict[str, Any]:
+    params: dict[str, Any] = dict(DEFAULT_PARAMS[kind])
+    if params_json:
+        value = json.loads(params_json)
+        if not isinstance(value, dict):
+            raise ValueError("--params-json must contain a JSON object")
+        params.update(value)
+    params.pop("model", None)
+    params.pop("prompt", None)
+    return {"model": model, "prompt": prompt, **params}
+
+
+def _download(url: str, destination: Path) -> None:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "image/*,video/*,application/octet-stream",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    temporary = destination.with_name(f".{destination.name}.part")
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            final_url = urllib.parse.urlparse(response.geturl())
+            if final_url.scheme != "https" or not final_url.hostname:
+                raise RuntimeError("Media download redirected to an unsafe URL")
+            declared = response.headers.get("Content-Length")
+            if declared and declared.isdigit() and int(declared) > MAX_DOWNLOAD_BYTES:
+                raise RuntimeError("Generated media exceeds the 64 MiB download limit")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            total = 0
+            with temporary.open("wb") as output:
+                while chunk := response.read(1024 * 1024):
+                    total += len(chunk)
+                    if total > MAX_DOWNLOAD_BYTES:
+                        raise RuntimeError("Generated media exceeds the 64 MiB download limit")
+                    output.write(chunk)
+            os.replace(temporary, destination)
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise RuntimeError(f"Media download failed: {error}") from error
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _default_output(kind: str, output_url: str) -> Path:
+    suffix = Path(urllib.parse.urlparse(output_url).path).suffix
+    if not suffix:
+        suffix = mimetypes.guess_extension("image/png" if kind == "image" else "video/mp4") or ""
+    return Path.cwd() / f"atlas-{kind}{suffix}"
+
+
+def generate(args: argparse.Namespace) -> Path:
+    api_key = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError("ATLASCLOUD_API_KEY is not set")
+    endpoint = "generateImage" if args.kind == "image" else "generateVideo"
+    submitted = _prediction_data(
+        _request_json(
+            f"{API_BASE}/model/{endpoint}",
+            api_key=api_key,
+            payload=_payload(args.kind, args.model, args.prompt, args.params_json),
+        )
+    )
+    prediction_id = submitted.get("id")
+    if not isinstance(prediction_id, str) or not prediction_id:
+        raise RuntimeError("Atlas Cloud did not return a prediction id")
+
+    prediction = submitted
+    for attempt in range(args.max_polls + 1):
+        status = str(prediction.get("status") or "").lower()
+        if status == "completed":
+            break
+        if status in {"failed", "timeout", "cancelled", "canceled"}:
+            raise RuntimeError(f"Atlas Cloud generation failed: {prediction.get('error') or status}")
+        if attempt == args.max_polls:
+            raise RuntimeError("Atlas Cloud generation exceeded the polling limit")
+        time.sleep(args.poll_seconds)
+        prediction = _prediction_data(
+            _request_json(
+                f"{API_BASE}/model/prediction/{urllib.parse.quote(prediction_id, safe='')}",
+                api_key=api_key,
+            )
+        )
+
+    output_url = _output_url(prediction)
+    destination = Path(args.out).expanduser() if args.out else _default_output(args.kind, output_url)
+    _download(output_url, destination)
+    return destination.resolve()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=("image", "video"))
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--model")
+    parser.add_argument("--out")
+    parser.add_argument("--params-json")
+    parser.add_argument("--poll-seconds", type=float, default=2.0)
+    parser.add_argument("--max-polls", type=int, default=150)
+    return parser
+
+
+def main() -> int:
+    parser = _parser()
+    args = parser.parse_args()
+    args.model = args.model or DEFAULT_MODELS[args.kind]
+    if args.poll_seconds < 0 or args.max_polls < 1:
+        parser.error("polling values must be positive")
+    try:
+        print(generate(args))
+    except (RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/atlas-cloud-media/scripts/test_generate.py
+++ b/skills/atlas-cloud-media/scripts/test_generate.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import argparse
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("generate.py")
+SPEC = importlib.util.spec_from_file_location("atlas_generate", MODULE_PATH)
+assert SPEC and SPEC.loader
+generate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate)
+
+
+class AtlasMediaTests(unittest.TestCase):
+    def test_payload_uses_defaults_and_protects_core_fields(self) -> None:
+        payload = generate._payload(
+            "image",
+            "qwen-image-3.0/text-to-image",
+            "studio portrait",
+            '{"size":"1536*1024","model":"bad","prompt":"bad"}',
+        )
+        self.assertEqual(payload["model"], "qwen-image-3.0/text-to-image")
+        self.assertEqual(payload["prompt"], "studio portrait")
+        self.assertEqual(payload["size"], "1536*1024")
+
+    def test_output_url_rejects_non_https_and_credentials(self) -> None:
+        for value in ("http://cdn.example/output.png", "https://user@cdn.example/output.png"):
+            with self.subTest(value=value), self.assertRaisesRegex(RuntimeError, "unsafe"):
+                generate._output_url({"outputs": [value]})
+
+    def test_output_url_accepts_https(self) -> None:
+        value = "https://cdn.example/output.mp4"
+        self.assertEqual(generate._output_url({"outputs": [value]}), value)
+
+    def test_parser_requires_prompt(self) -> None:
+        parser = generate._parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["image"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a bundled Atlas Cloud media skill for executable image and video generation.
- Submit asynchronous predictions, use bounded polling, validate HTTPS output URLs, and download media without forwarding API credentials.
- Provide model overrides, model-specific parameters, safe 64 MiB downloads, documentation, and offline contract tests.

## Related issues

None.

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `test` / `chore` / `ci`

## Checklist

- [x] `npm run typecheck` passes
- [ ] `npm test` passes
- [x] `npm run build` compiles
- [x] Added/updated tests for the change
- [x] No secrets, real personal data, or local absolute paths in the diff
- [x] PR title follows Conventional Commits

## Notes for reviewers

- The focused skill validation and 4 Python contract tests pass.
- Real Atlas Cloud calls generated a 1024x1024 PNG with `qwen-image-3.0/text-to-image` and a valid MP4 with `bytedance/seedance-2.0-fast/text-to-video`; generated media is not committed.
- The full test command emitted 998 passing assertions and no `not ok` result, but did not exit after more than seven minutes because the suite retained a Node handle, so the full-suite checkbox remains unchecked.
- The implementation uses only the Python standard library and does not add runtime dependencies.