### PR TITLE
fix(security): patch dependency advisories and close CodeQL findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,14 @@ updates:
           - minor
           - patch
     # Pi SDK is pinned exact on purpose — bump it deliberately, not via Dependabot.
+    # These moved from @mariozechner/* to @earendil-works/*; the old names matched
+    # nothing, so the pin was unprotected. Three of the four are also held by
+    # `overrides` in package.json — a Dependabot bump here would fight that.
     ignore:
-      - dependency-name: "@mariozechner/pi-coding-agent"
-      - dependency-name: "@mariozechner/pi-tui"
+      - dependency-name: "@earendil-works/pi-ai"
+      - dependency-name: "@earendil-works/pi-agent-core"
+      - dependency-name: "@earendil-works/pi-coding-agent"
+      - dependency-name: "@earendil-works/pi-tui"
 
   # GitHub Actions used by our workflows
   - package-ecosystem: github-actions

--- a/convex/config.d.ts
+++ b/convex/config.d.ts
@@ -9,9 +9,9 @@ export declare const read: import("convex/server").RegisteredQuery<"public", {
     session?: any;
     agents?: any;
     gateway?: any;
+    tools?: any;
     skills?: any;
     org?: any;
-    tools?: any;
     plugins?: any;
     bindings?: any;
     wizard?: any;
@@ -33,9 +33,9 @@ export declare const write: import("convex/server").RegisteredMutation<"public",
     session?: any;
     agents?: any;
     gateway?: any;
+    tools?: any;
     skills?: any;
     org?: any;
-    tools?: any;
     plugins?: any;
     bindings?: any;
     wizard?: any;

--- a/convex/logs.d.ts
+++ b/convex/logs.d.ts
@@ -1,11 +1,11 @@
 export declare const appendSessionEvent: import("convex/server").RegisteredMutation<"public", {
     toolName?: string | undefined;
+    aborted?: boolean | undefined;
     role?: string | undefined;
     content?: ArrayBuffer | undefined;
     toolCallId?: string | undefined;
     isError?: boolean | undefined;
     args?: ArrayBuffer | undefined;
-    aborted?: boolean | undefined;
     inner?: string | undefined;
     delta?: string | undefined;
     stopReason?: string | undefined;
@@ -33,12 +33,12 @@ export declare const readSessionEventTail: import("convex/server").RegisteredQue
     _id: import("convex/values").GenericId<"sessionEvents">;
     _creationTime: number;
     toolName?: string | undefined;
+    aborted?: boolean | undefined;
     role?: string | undefined;
     content?: ArrayBuffer | undefined;
     toolCallId?: string | undefined;
     isError?: boolean | undefined;
     args?: ArrayBuffer | undefined;
-    aborted?: boolean | undefined;
     inner?: string | undefined;
     delta?: string | undefined;
     stopReason?: string | undefined;
@@ -65,12 +65,12 @@ export declare const findLastError: import("convex/server").RegisteredQuery<"pub
     _id: import("convex/values").GenericId<"sessionEvents">;
     _creationTime: number;
     toolName?: string | undefined;
+    aborted?: boolean | undefined;
     role?: string | undefined;
     content?: ArrayBuffer | undefined;
     toolCallId?: string | undefined;
     isError?: boolean | undefined;
     args?: ArrayBuffer | undefined;
-    aborted?: boolean | undefined;
     inner?: string | undefined;
     delta?: string | undefined;
     stopReason?: string | undefined;

--- a/convex/org.d.ts
+++ b/convex/org.d.ts
@@ -33,11 +33,11 @@ export declare const getChart: import("convex/server").RegisteredQuery<"public",
     _creationTime: number;
     transient: boolean;
     mtimeMs: number;
+    mimeType: "image/png";
     width: number;
     height: number;
     themeId: string;
     themeName: string;
-    mimeType: "image/png";
     hash: string;
     ownerId: string;
     pngBytes: ArrayBuffer;
@@ -63,11 +63,11 @@ export declare const listCharts: import("convex/server").RegisteredQuery<"public
     _creationTime: number;
     transient: boolean;
     mtimeMs: number;
+    mimeType: "image/png";
     width: number;
     height: number;
     themeId: string;
     themeName: string;
-    mimeType: "image/png";
     hash: string;
     ownerId: string;
     pngBytes: ArrayBuffer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,8 @@
         "proper-lockfile": "^4.1.2",
         "qrcode-terminal": "^0.12.0",
         "socks-proxy-agent": "^10.1.0",
-        "tar": "^7.5.15",
-        "undici": "^7.25.0",
+        "tar": "^7.5.22",
+        "undici": "^7.29.0",
         "unpdf": "^1.6.2",
         "ws": "^8.21.0",
         "yaml": "^2.9.0",
@@ -750,7 +750,9 @@
       }
     },
     "node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -1042,23 +1044,6 @@
       "version": "0.3.4",
       "license": "Apache-2.0"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
       "version": "5.6.2",
       "license": "MIT",
@@ -1242,7 +1227,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -2877,13 +2864,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -3764,7 +3753,9 @@
       }
     },
     "node_modules/discord.js/node_modules/undici": {
-      "version": "6.27.0",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -4269,7 +4260,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4559,7 +4552,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5400,7 +5395,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5489,7 +5486,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5707,7 +5706,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -5857,7 +5858,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -221,8 +221,8 @@
     "proper-lockfile": "^4.1.2",
     "qrcode-terminal": "^0.12.0",
     "socks-proxy-agent": "^10.1.0",
-    "tar": "^7.5.15",
-    "undici": "^7.25.0",
+    "tar": "^7.5.22",
+    "undici": "^7.29.0",
     "unpdf": "^1.6.2",
     "ws": "^8.21.0",
     "@anthropic-ai/claude-code": "^2.1.0",
@@ -242,17 +242,25 @@
   "overrides": {
     "ws": "$ws",
     "discord.js": {
-      "undici": "^6.27.0"
+      "undici": "^6.28.0"
     },
     "@discordjs/rest": {
-      "undici": "^6.27.0"
+      "undici": "^6.28.0"
+    },
+    "@earendil-works/pi-coding-agent": {
+      "undici": "^8.9.0"
     },
     "exceljs": {
       "uuid": "^11.1.1"
     },
     "@earendil-works/pi-ai": "0.79.9",
     "@earendil-works/pi-agent-core": "0.79.9",
-    "@earendil-works/pi-tui": "0.79.9"
+    "@earendil-works/pi-tui": "0.79.9",
+    "brace-expansion@1": "^1.1.18",
+    "brace-expansion@2": "^2.1.4",
+    "brace-expansion@5": "^5.0.9",
+    "ip-address": "^10.5.0",
+    "protobufjs": "^7.6.5"
   },
   "keywords": [
     "ai",

--- a/scripts/convex-dev.mjs
+++ b/scripts/convex-dev.mjs
@@ -18,8 +18,8 @@ import { spawn } from "node:child_process";
 import { mkdirSync, existsSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { createServer } from "node:http";
-import { readFile, stat } from "node:fs/promises";
-import { extname, join, dirname, resolve, sep } from "node:path";
+import { readFile } from "node:fs/promises";
+import { extname, join, dirname, resolve, relative, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -237,44 +237,58 @@ const MIME = {
 
 // Confine a request-derived file path under DASHBOARD_DIR. `req.url` is
 // attacker-controllable (any local process can hit 127.0.0.1:6791), so a
-// decoded `..` segment must never let `join` escape the served root. Resolve
-// to an absolute path and reject anything outside DASHBOARD_DIR.
+// decoded `..` segment — or an absolute path — must never let `join` escape
+// the served root. Resolve the candidate, then ask `relative()` whether the
+// result is still *inside* the root: a bare `resolved.startsWith(root)` is
+// not a containment test (a sibling `<root>-evil` passes it). Returns the
+// safe absolute path, or null for anything that walks out.
 const DASHBOARD_ROOT = resolve(DASHBOARD_DIR);
 function confineToDashboard(candidate) {
-  const resolved = resolve(candidate);
-  if (resolved === DASHBOARD_ROOT || resolved.startsWith(DASHBOARD_ROOT + sep)) {
-    return resolved;
-  }
-  return null;
+  const rel = relative(DASHBOARD_ROOT, resolve(DASHBOARD_ROOT, candidate));
+  if (rel === "") return DASHBOARD_ROOT;
+  if (rel.startsWith("..") || isAbsolute(rel)) return null;
+  return join(DASHBOARD_ROOT, rel);
 }
 
 const dashboardServer = createServer(async (req, res) => {
   try {
     let urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
     if (urlPath === "/") urlPath = "/index.html";
+    // No decoded segment may be a parent-directory hop. The containment check
+    // below is the real defence; this just rejects the obvious probe early,
+    // before any of it reaches the filesystem.
+    if (urlPath.split(/[/\\]/).includes("..")) { res.writeHead(404); res.end("Not Found"); return; }
 
-    let filePath = confineToDashboard(join(DASHBOARD_DIR, urlPath));
-    if (!filePath) { res.writeHead(404); res.end("Not Found"); return; }
+    const requested = confineToDashboard(join(DASHBOARD_ROOT, urlPath));
+    if (!requested) { res.writeHead(404); res.end("Not Found"); return; }
 
-    // SPA fallback — if the requested path has no extension and doesn't exist,
-    // try $path.html, then fall back to index.html.
-    let st;
-    try { st = await stat(filePath); } catch {}
-    if (!st || st.isDirectory()) {
-      const candidates = [
-        confineToDashboard(filePath + ".html"),
-        confineToDashboard(join(filePath, "index.html")),
-        join(DASHBOARD_ROOT, "index.html"),
-      ];
-      for (const c of candidates) {
-        if (!c) continue;
-        try {
-          const s = await stat(c);
-          if (s.isFile()) { filePath = c; st = s; break; }
-        } catch {}
+    // SPA fallback — the requested path, then $path.html, then $path/index.html,
+    // then the app shell. Read each candidate outright rather than stat-ing it
+    // first: a stat/read pair can straddle a rename and end up describing one
+    // file while serving another, and the read has to handle "not there" anyway.
+    // EISDIR/EACCES/EPERM are how the platforms variously report "that's a
+    // directory" — all of them just mean "try the next candidate".
+    const candidates = [
+      requested,
+      confineToDashboard(requested + ".html"),
+      confineToDashboard(join(requested, "index.html")),
+      join(DASHBOARD_ROOT, "index.html"),
+    ];
+    let filePath = null;
+    let body = null;
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      try {
+        body = await readFile(candidate);
+        filePath = candidate;
+        break;
+      } catch (err) {
+        const code = err?.code;
+        if (code === "ENOENT" || code === "ENOTDIR" || code === "EISDIR" || code === "EACCES" || code === "EPERM") continue;
+        throw err;
       }
     }
-    if (!st || !st.isFile()) { res.writeHead(404); res.end("Not Found"); return; }
+    if (!filePath) { res.writeHead(404); res.end("Not Found"); return; }
 
     const ext = extname(filePath).toLowerCase();
     const mime = MIME[ext] ?? "application/octet-stream";
@@ -296,7 +310,7 @@ const dashboardServer = createServer(async (req, res) => {
         `{type:"dashboard-credentials",adminKey:${JSON.stringify(adminKey)},` +
         `deploymentUrl:${JSON.stringify(`http://${BACKEND_HOST}:${BACKEND_PORT}`)},` +
         `deploymentName:${JSON.stringify(identity.instanceName)}}`;
-      const html = (await readFile(filePath, "utf8")).replace(
+      const html = body.toString("utf8").replace(
         /<head>/i,
         `<head><script>(function(){try{` +
           `window.addEventListener("message",function(ev){` +
@@ -307,7 +321,7 @@ const dashboardServer = createServer(async (req, res) => {
       res.end(html);
       return;
     }
-    res.end(await readFile(filePath));
+    res.end(body);
   } catch (err) {
     // Log the detail locally; never echo the raw error (path/stack) to the
     // HTTP response.

--- a/scripts/update-brigadiers.mjs
+++ b/scripts/update-brigadiers.mjs
@@ -16,7 +16,15 @@ import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-const REPO = process.env.BRIGADIERS_REPO || "spinabot/brigade";
+// `owner/repo`, nothing else. BRIGADIERS_REPO is spliced straight into the API
+// path, so an unvalidated value (`../../gists/…`, a query string, an encoded
+// slash) would aim this script at a different endpoint than the contributor
+// graph it is written to read.
+const REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+const REPO = process.env.BRIGADIERS_REPO?.trim() || "spinabot/brigade";
+if (!REPO_PATTERN.test(REPO)) {
+	throw new Error(`BRIGADIERS_REPO must be "owner/repo" — got: ${REPO}`);
+}
 // Linked HTML avatars with EXPLICIT width/height so every avatar renders at a
 // uniform 48px. Markdown `![](…&s=48)` can't enforce a display size — GitHub only
 // honors the `s=` param for users with a real photo; for identicon (no-photo)
@@ -25,6 +33,7 @@ const REPO = process.env.BRIGADIERS_REPO || "spinabot/brigade";
 // rows separated by a blank line.
 const AVATAR_SIZE = 48;
 const PER_LINE = 10;
+const LOGIN_PATTERN = /^[A-Za-z0-9-]{1,39}$/;
 const START = "<!-- brigadiers:start -->";
 const END = "<!-- brigadiers:end -->";
 const README = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "README.md");
@@ -46,6 +55,10 @@ async function fetchContributors() {
 		if (!res.ok) {
 			throw new Error(`GitHub contributors API ${res.status}: ${await res.text().catch(() => "")}`);
 		}
+		const contentType = res.headers.get("content-type") ?? "";
+		if (!contentType.toLowerCase().startsWith("application/json")) {
+			throw new Error(`GitHub contributors API returned ${contentType || "no content-type"}, expected JSON.`);
+		}
 		const batch = await res.json();
 		if (!Array.isArray(batch) || batch.length === 0) break;
 		all.push(...batch);
@@ -53,7 +66,18 @@ async function fetchContributors() {
 	}
 	// Drop bots (github-actions, dependabot, …). The API already sorts humans by
 	// contribution count, so the wall leads with the most active.
-	return all.filter((c) => c && c.type !== "Bot" && !String(c.login).endsWith("[bot]"));
+	const humans = all.filter((c) => c && c.type !== "Bot" && !String(c.login).endsWith("[bot]"));
+	// Every remaining login and id goes into HTML attributes in a committed
+	// file, so take only the two fields the wall needs and only in the shape
+	// GitHub guarantees — a login is 1–39 of [A-Za-z0-9-], an id a positive
+	// integer. Anything else means the response isn't the contributor graph;
+	// stop rather than splice unknown markup into README.md.
+	return humans.map((c) => {
+		if (typeof c.login !== "string" || !LOGIN_PATTERN.test(c.login) || !Number.isInteger(c.id) || c.id <= 0) {
+			throw new Error(`Unexpected contributor entry from GitHub: ${JSON.stringify(c).slice(0, 200)}`);
+		}
+		return { login: c.login, id: c.id };
+	});
 }
 
 function renderWall(contributors) {

--- a/src/agents/approval-bridge.test.ts
+++ b/src/agents/approval-bridge.test.ts
@@ -15,6 +15,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import { _resetApprovalsCacheForTests, listApprovals } from "../core/exec-approvals.js";
+import { ambiguousAlternation, nestedQuantifier } from "../core/exec-pattern-fixtures.js";
 import {
 	applyApprovalDecision,
 	type ApprovalDecisionKind,
@@ -247,7 +248,7 @@ describe("applyApprovalDecision — allow-pattern", () => {
 		const refusals: string[] = [];
 		const outcome = applyApprovalDecision({
 			command: "git aaaa",
-			decision: { kind: "allow-pattern", pattern: "^git (a+)+$" },
+			decision: { kind: "allow-pattern", pattern: nestedQuantifier("a", { head: "git " }) },
 			onRefused: (message) => refusals.push(message),
 		});
 		// The operator picked an "allow" disposition — blocking the call they
@@ -272,7 +273,7 @@ describe("applyApprovalDecision — allow-pattern", () => {
 	it("a listener that throws doesn't break the call", () => {
 		const outcome = applyApprovalDecision({
 			command: "echo hi",
-			decision: { kind: "allow-pattern", pattern: "^(a|a)*$" },
+			decision: { kind: "allow-pattern", pattern: ambiguousAlternation("a") },
 			onRefused: () => {
 				throw new Error("transport is gone");
 			},

--- a/src/agents/approval-bridge.test.ts
+++ b/src/agents/approval-bridge.test.ts
@@ -2,15 +2,21 @@
  * Tests for the approval bridge — pure unit-level coverage of the
  * in-memory request/resolve/timeout behaviour.
  *
- * Persistence behaviour (`applyApprovalDecision` calling `recordApproval`)
- * is tested in exec-approvals.test.ts; here we mock the broadcaster and
- * verify the bridge's own state machine.
+ * The allowlist-file mechanics behind `recordApproval` are tested in
+ * exec-approvals.test.ts; here we mock the broadcaster, verify the bridge's
+ * own state machine, and cover how `applyApprovalDecision` reports a pattern
+ * the allowlist refuses to store.
  */
 
 import { strict as assert } from "node:assert";
-import { afterEach, describe, it } from "node:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
 
+import { _resetApprovalsCacheForTests, listApprovals } from "../core/exec-approvals.js";
 import {
+	applyApprovalDecision,
 	type ApprovalDecisionKind,
 	type ApprovalRequest,
 	getActiveApprovalBridge,
@@ -209,5 +215,68 @@ describe("requestApproval — abort cancels the prompt", () => {
 		assert.equal(bridge.listPending().length, 0, "all drained");
 		// every settle detached its listener; aborting now must not throw or resolve anything
 		assert.doesNotThrow(() => ac.abort());
+	});
+});
+
+/* ─────────────── applyApprovalDecision — pattern persistence ─────────────── */
+
+describe("applyApprovalDecision — allow-pattern", () => {
+	let prevStateDir: string | undefined;
+
+	beforeEach(() => {
+		prevStateDir = process.env.BRIGADE_STATE_DIR;
+		process.env.BRIGADE_STATE_DIR = mkdtempSync(join(tmpdir(), "brigade-approval-bridge-"));
+		_resetApprovalsCacheForTests();
+	});
+	afterEach(() => {
+		if (prevStateDir === undefined) delete process.env.BRIGADE_STATE_DIR;
+		else process.env.BRIGADE_STATE_DIR = prevStateDir;
+		_resetApprovalsCacheForTests();
+	});
+
+	it("persists a healthy pattern and allows the call", () => {
+		const outcome = applyApprovalDecision({
+			command: "git status",
+			decision: { kind: "allow-pattern", pattern: "^git (status|diff)( |$)" },
+		});
+		assert.equal(outcome, "allow");
+		assert.deepEqual(listApprovals().patterns, ["^git (status|diff)( |$)"]);
+	});
+
+	it("a refused pattern still allows THIS call, reports why, and stores nothing", () => {
+		const refusals: string[] = [];
+		const outcome = applyApprovalDecision({
+			command: "git aaaa",
+			decision: { kind: "allow-pattern", pattern: "^git (a+)+$" },
+			onRefused: (message) => refusals.push(message),
+		});
+		// The operator picked an "allow" disposition — blocking the call they
+		// just approved would be the wrong failure mode.
+		assert.equal(outcome, "allow");
+		assert.deepEqual(listApprovals().patterns, []);
+		assert.equal(refusals.length, 1);
+		assert.match(refusals[0] ?? "", /didn't save the pattern/);
+		assert.match(refusals[0] ?? "", /backtracks catastrophically/);
+	});
+
+	it("a refused pattern never throws, even with no listener attached", () => {
+		assert.doesNotThrow(() => {
+			applyApprovalDecision({
+				command: "echo hi",
+				decision: { kind: "allow-pattern", pattern: "[unclosed" },
+			});
+		});
+		assert.deepEqual(listApprovals().patterns, []);
+	});
+
+	it("a listener that throws doesn't break the call", () => {
+		const outcome = applyApprovalDecision({
+			command: "echo hi",
+			decision: { kind: "allow-pattern", pattern: "^(a|a)*$" },
+			onRefused: () => {
+				throw new Error("transport is gone");
+			},
+		});
+		assert.equal(outcome, "allow");
 	});
 });

--- a/src/agents/approval-bridge.ts
+++ b/src/agents/approval-bridge.ts
@@ -23,7 +23,7 @@
 
 import * as crypto from "node:crypto";
 
-import { recordApproval } from "../core/exec-approvals.js";
+import { BrigadeApprovalRefusedError, recordApproval } from "../core/exec-approvals.js";
 import { createSubsystemLogger } from "../logging/subsystem-logger.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
@@ -285,17 +285,31 @@ export function getActiveApprovalBridge(): ApprovalBridge | null {
  *                          falls back to "allow-once" semantics otherwise
  *   - `"deny"`           → no write
  *
- * Persistence errors (hard-deny conflict, symlink at the file path) bubble
+ * Persistence errors (symlink at the file path, unwritable state dir) bubble
  * up — the caller decides whether to refuse the tool call or treat the
  * decision as allow-once.
+ *
+ * A REFUSED pattern is not one of those. The operator typed a regex the gate
+ * won't store (hard-deny shaped, malformed, or catastrophically slow); they
+ * still picked an "allow" disposition for the command in front of them, so
+ * this call proceeds as allow-once and the refusal is reported through
+ * `onRefused` — the caller's own transport, which for a channel-routed turn is
+ * a message back in the conversation. Throwing here would block a call the
+ * operator explicitly approved.
  */
 export function applyApprovalDecision(args: {
 	command: string;
 	decision: ApprovalDecision;
 	/** Per-agent allowlist scope — defaults to the canonical agent. */
 	agentId?: string;
+	/**
+	 * Called with an operator-readable sentence when a pattern was refused and
+	 * therefore NOT persisted. Optional: without it the refusal is still logged,
+	 * it just isn't echoed to whoever answered the prompt.
+	 */
+	onRefused?: (message: string) => void;
 }): "allow" | "deny" {
-	const { command, decision, agentId } = args;
+	const { command, decision, agentId, onRefused } = args;
 	switch (decision.kind) {
 		case "deny":
 			return "deny";
@@ -311,7 +325,23 @@ export function applyApprovalDecision(args: {
 		case "allow-pattern": {
 			const pattern = decision.pattern?.trim();
 			if (pattern) {
-				recordApproval(pattern, "pattern", agentId);
+				try {
+					recordApproval(pattern, "pattern", agentId);
+				} catch (err) {
+					if (!(err instanceof BrigadeApprovalRefusedError)) throw err;
+					const message =
+						`Ran the command, but didn't save the pattern /${pattern}/: ${err.message.replace(/^refused to record approval: /, "")}`;
+					log.warn("approval pattern refused — not persisted", {
+						agentId: agentId ?? "",
+						pattern,
+						reason: err.message,
+					});
+					try {
+						onRefused?.(message);
+					} catch {
+						// A transport that can't deliver the note must not fail the call.
+					}
+				}
 			}
 			// Even if no pattern was provided, this call IS allowed — the
 			// operator picked an "allow" disposition. Future calls miss the

--- a/src/agents/channels/bluebubbles/media.test.ts
+++ b/src/agents/channels/bluebubbles/media.test.ts
@@ -119,6 +119,21 @@ describe("downloadInboundAttachments", () => {
 		assert.equal(out.length, 0);
 	});
 
+	it("keeps a traversal-shaped guid/transferName inside cacheDir", async () => {
+		const cacheDir = mkdtempSync(path.join(os.tmpdir(), "bb-media-"));
+		const out = await downloadInboundAttachments(
+			[
+				{ guid: "../../etc", transferName: "../../../passwd.png" },
+				{ guid: "..\\..\\win", transferName: "..\\evil.png" },
+			],
+			{ serverUrl: SERVER, password: PASSWORD, cacheDir, maxBytes: 1024, fetchImpl: bytesFetch(new Uint8Array([1])) },
+		);
+		assert.equal(out.length, 2);
+		for (const att of out) {
+			assert.equal(path.dirname(path.resolve(att.path)), path.resolve(cacheDir));
+		}
+	});
+
 	it("returns [] when a download fails (non-2xx)", async () => {
 		const cacheDir = mkdtempSync(path.join(os.tmpdir(), "bb-media-"));
 		const out = await downloadInboundAttachments([{ guid: "ATT-2", transferName: "p.png" }], {

--- a/src/agents/channels/telegram/format.ts
+++ b/src/agents/channels/telegram/format.ts
@@ -270,12 +270,39 @@ export function markdownToTelegramHtml(markdown: string): string {
  */
 export function telegramHtmlIsEmpty(html: string): boolean {
 	if (!html) return true;
-	// Drop tags (allowing quoted attribute values that themselves contain `>`),
-	// then decode the handful of entities we emit, then trim.
-	const withoutTags = html.replace(/<(?:"[^"]*"|'[^']*'|[^'">])*>/g, "");
+	// Scan the tags out rather than `replace`-ing them: a single-pass strip lets
+	// the text on either side of a removed match close up into a tag the pass has
+	// already walked by (`<<b>b>` leaves `<b>`), so the "is anything visible"
+	// answer would depend on markup the scan never re-examined. Walking left to
+	// right never re-emits a `<` it consumed, so it settles in one pass.
+	let text = "";
+	let i = 0;
+	while (i < html.length) {
+		const lt = html.indexOf("<", i);
+		if (lt === -1) {
+			text += html.slice(i);
+			break;
+		}
+		text += html.slice(i, lt);
+		// Walk to the tag's `>`; quoted attribute values may hold a literal `>`.
+		let quote = "";
+		let j = lt + 1;
+		for (; j < html.length; j += 1) {
+			const ch = html[j] as string;
+			if (quote) {
+				if (ch === quote) quote = "";
+			} else if (ch === '"' || ch === "'") {
+				quote = ch;
+			} else if (ch === ">") {
+				break;
+			}
+		}
+		if (j >= html.length) break; // unterminated tag — nothing visible follows
+		i = j + 1;
+	}
 	// Decode `&amp;` LAST so an already-decoded entity sequence is never
 	// re-expanded into a second decode pass (e.g. `&amp;lt;` → `&lt;`, not `<`).
-	const decoded = withoutTags
+	const decoded = text
 		.replace(/&lt;/g, "<")
 		.replace(/&gt;/g, ">")
 		.replace(/&quot;/g, '"')

--- a/src/agents/claude-cli/spawn.ts
+++ b/src/agents/claude-cli/spawn.ts
@@ -130,13 +130,30 @@ export function spawnClaudeCli(args: SpawnClaudeCliArgs): ClaudeCliRunHandle {
 		(hasToolPlane ? CLAUDE_CLI_TOOL_PLANE_OVERALL_TIMEOUT_MS : CLAUDE_CLI_OVERALL_TIMEOUT_MS);
 	const doSpawn = args.spawnFn ?? spawn;
 
-	// Isolated, empty working dir — the tool-containment boundary.
+	// Isolated, empty working dir — the tool-containment boundary. `mkdtempSync`
+	// gives it a random suffix nobody can pre-claim, at mode 0700: what lands in
+	// here is the composed system prompt and the tool-plane config (which carries
+	// this turn's MCP token), and a fixed name under a world-writable /tmp (mode
+	// 1777) is a path any local user can create or symlink ahead of us.
+	//
+	// There is deliberately NO fallback to the bare temp dir. That would hand both
+	// files a predictable path AND drop the containment boundary itself, pointing a
+	// `bypassPermissions` binary at everyone's /tmp. A machine that cannot make a
+	// temp dir cannot run this turn safely, so say so.
 	let cwd: string;
 	try {
 		cwd = mkdtempSync(path.join(tmpdir(), "brigade-claude-cli-"));
-	} catch {
-		cwd = tmpdir();
+	} catch (err) {
+		throw new Error(`claude-cli: could not create an isolated working dir under ${tmpdir()}: ${String(err)}`);
 	}
+	// Every exit from here on — thrown or spawned — goes through this.
+	const removeCwd = () => {
+		try {
+			rmSync(cwd, { recursive: true, force: true });
+		} catch {
+			/* leave it for the OS temp reaper */
+		}
+	};
 
 	// Prefer Brigade's OWN Claude login (dedicated grant in its managed config
 	// dir) when present — the binary auths + refreshes there, isolated from the
@@ -152,7 +169,7 @@ export function spawnClaudeCli(args: SpawnClaudeCliArgs): ClaudeCliRunHandle {
 	if (sys && sys.length > 0) {
 		try {
 			const sysFile = path.join(cwd, "system-prompt.txt");
-			writeFileSync(sysFile, sys, "utf8");
+			writeFileSync(sysFile, sys, { encoding: "utf8", mode: 0o600 });
 			finalArgs.push(CLAUDE_CLI_SYSTEM_PROMPT_FILE_FLAG, sysFile);
 		} catch {
 			/* couldn't write the file — proceed without the appended prompt rather
@@ -167,7 +184,7 @@ export function spawnClaudeCli(args: SpawnClaudeCliArgs): ClaudeCliRunHandle {
 	if (mcpJson && mcpJson.length > 0) {
 		try {
 			const mcpFile = path.join(cwd, "mcp-config.json");
-			writeFileSync(mcpFile, mcpJson, "utf8");
+			writeFileSync(mcpFile, mcpJson, { encoding: "utf8", mode: 0o600 });
 			finalArgs.push(CLAUDE_CLI_MCP_CONFIG_FLAG, mcpFile, CLAUDE_CLI_STRICT_MCP_FLAG);
 		} catch (err) {
 			// Fail-open is only safe when the binary keeps its own tools. On a FULL-PLANE
@@ -176,6 +193,9 @@ export function spawnClaudeCli(args: SpawnClaudeCliArgs): ClaudeCliRunHandle {
 			// promises a filesystem — it would confidently report work it cannot do.
 			// Fail LOUD instead: the retry layer respawns, and the operator sees why.
 			if (args.requireMcpConfig === true) {
+				// Nothing will ever start here, so nothing will ever run `finish` — take the
+				// system prompt we just wrote with us.
+				removeCwd();
 				throw new Error(
 					`claude-cli: could not write the tool-plane config; refusing to spawn a tool-less agent: ${String(err)}`,
 				);
@@ -184,13 +204,21 @@ export function spawnClaudeCli(args: SpawnClaudeCliArgs): ClaudeCliRunHandle {
 		}
 	}
 
-	const child: ChildProcessWithoutNullStreams = doSpawn(command, finalArgs, {
-		cwd,
-		env: buildClaudeCliEnv(process.env, { configDir }),
-		stdio: ["pipe", "pipe", "pipe"],
-		// No shell — argv is passed verbatim so nothing is word-split or expanded.
-		shell: false,
-	}) as ChildProcessWithoutNullStreams;
+	let child: ChildProcessWithoutNullStreams;
+	try {
+		child = doSpawn(command, finalArgs, {
+			cwd,
+			env: buildClaudeCliEnv(process.env, { configDir }),
+			stdio: ["pipe", "pipe", "pipe"],
+			// No shell — argv is passed verbatim so nothing is word-split or expanded.
+			shell: false,
+		}) as ChildProcessWithoutNullStreams;
+	} catch (err) {
+		// A synchronous spawn failure (bad argv, EPERM) never reaches the 'error'
+		// handler below, so this is the only place the prompt file can be removed.
+		removeCwd();
+		throw err;
+	}
 
 	let killReason: SpawnKillReason | undefined;
 	let settled = false;
@@ -332,11 +360,7 @@ export function spawnClaudeCli(args: SpawnClaudeCliArgs): ClaudeCliRunHandle {
 				closed = true;
 				pump();
 				// Best-effort cleanup of the throwaway cwd.
-				try {
-					rmSync(cwd, { recursive: true, force: true });
-				} catch {
-					/* leave it for the OS temp reaper */
-				}
+				removeCwd();
 				resolve({ code, killReason, stderr });
 			};
 			child.on("close", (code) => finish(code));

--- a/src/agents/extensions/modules/duckduckgo.ts
+++ b/src/agents/extensions/modules/duckduckgo.ts
@@ -19,7 +19,7 @@ import type {
 	WebSearchProvider,
 } from "../types.js";
 import { guardedFetch } from "../../../infra/net/fetch-guard.js";
-import { decodeHtmlEntities } from "../../tools/web-fetch-utils.js";
+import { decodeHtmlEntities, stripHtmlTags } from "../../tools/web-fetch-utils.js";
 import { DEFAULT_TIMEOUT_SECONDS, readResponseText } from "../../tools/web-shared.js";
 import { resolveSiteName, wrapSearchHit } from "./web-provider-helpers.js";
 
@@ -51,21 +51,15 @@ function unwrapDdgUrl(rawHref: string): string {
 	}
 }
 
-/** Strip ALL HTML tags from a fragment + decode entities. */
+/**
+ * Strip ALL HTML tags from a fragment + decode entities. Tag removal runs
+ * through the shared scanner in `web-fetch-utils` — a one-shot `<[^>]*>`
+ * replace lets overlapping angle brackets (`<<a>script>`) close back up into a
+ * live tag after the pass has moved on, and DDG's title/snippet HTML comes
+ * straight off whatever page ranked.
+ */
 function stripHtmlToText(html: string): string {
-	// Strip tags repeatedly until the string stabilises. A single
-	// `<[^>]+>` pass is incomplete: overlapping/nested angle brackets
-	// (e.g. `<a<b>`) can leave a residual `<…>` that the one-shot replace
-	// never sees, which — after entity decoding — could smuggle markup
-	// back into the title/snippet text. Looping to a fixed point closes
-	// that gap and is a no-op for well-formed fragments.
-	let prev = html;
-	let stripped = html.replace(/<[^>]*>/g, "");
-	while (stripped !== prev) {
-		prev = stripped;
-		stripped = stripped.replace(/<[^>]*>/g, "");
-	}
-	return decodeHtmlEntities(stripped).replace(/\s+/g, " ").trim();
+	return decodeHtmlEntities(stripHtmlTags(html)).replace(/\s+/g, " ").trim();
 }
 
 /** Parse the DDG HTML response into normalized hit objects. */

--- a/src/agents/extensions/modules/wikipedia.ts
+++ b/src/agents/extensions/modules/wikipedia.ts
@@ -16,6 +16,7 @@ import type {
 	WebProviderToolDefinition,
 	WebSearchProvider,
 } from "../types.js";
+import { stripHtmlTags } from "../../tools/web-fetch-utils.js";
 import { DEFAULT_TIMEOUT_SECONDS, readResponseText } from "../../tools/web-shared.js";
 import {
 	readProviderConfigSlot,
@@ -41,7 +42,6 @@ interface MwSearchResponse {
 	query?: { search?: MwSearchHit[] };
 }
 
-const MW_TAG_RE = /<[^>]*>/g;
 const MW_ENTITY_RE = /&(?:quot|amp|lt|gt|nbsp);/g;
 const MW_ENTITY_MAP: Record<string, string> = {
 	"&quot;": '"',
@@ -53,13 +53,13 @@ const MW_ENTITY_MAP: Record<string, string> = {
 
 function stripMwMarkup(html: string): string {
 	// MediaWiki returns snippets with `<span class="searchmatch">…</span>`
-	// wrappers around hit terms. Strip every `<…>` span first (one pass over
-	// a regex that can't leave a reconstructable tag behind), THEN decode the
-	// entities in a single map-driven pass. Doing the decode last — and as one
-	// pass rather than chained replaces — avoids double-unescaping (`&amp;lt;`
-	// must stay `&lt;`, not become `<`).
-	return html
-		.replace(MW_TAG_RE, "")
+	// wrappers around hit terms. Strip the markup with the shared scanner in
+	// `web-fetch-utils` — a `/<[^>]*>/g` replace walks the string once, so
+	// overlapping angle brackets from a hostile article revision can close back
+	// up into a tag behind it. THEN decode the entities in a single map-driven
+	// pass. Doing the decode last — and as one pass rather than chained
+	// replaces — avoids double-unescaping (`&amp;lt;` must stay `&lt;`).
+	return stripHtmlTags(html)
 		.replace(MW_ENTITY_RE, (m) => MW_ENTITY_MAP[m] ?? m)
 		.trim();
 }

--- a/src/agents/skills/grant.ts
+++ b/src/agents/skills/grant.ts
@@ -26,6 +26,7 @@ import {
 	recordApproval,
 	removeApproval,
 } from "../../core/exec-approvals.js";
+import { validateApprovalPattern } from "../../core/exec-pattern-guard.js";
 import { discoverEligibleSkills } from "./index.js";
 import { readSkillCommandManifest, type SkillCommandManifest } from "./skill-manifest.js";
 
@@ -101,6 +102,13 @@ export function grantSkill(args: {
 	});
 	const grantablePatterns = manifest.patterns.filter((p) => {
 		if (patternMatchesHardDeny(p)) {
+			base.refused.push(p);
+			return false;
+		}
+		// A manifest is just a file — it can carry a regex the gate won't store.
+		// Report it as refused alongside the hard-deny hits instead of letting
+		// `recordApproval` throw halfway through a partially applied grant.
+		if (!validateApprovalPattern(p).ok) {
 			base.refused.push(p);
 			return false;
 		}

--- a/src/agents/skills/install.test.ts
+++ b/src/agents/skills/install.test.ts
@@ -126,6 +126,25 @@ describe("installSkill", () => {
 		assert.equal(fs.readFileSync(res.downloadedTo!, "utf8"), "hi");
 	});
 
+	it("kind=download confines the write to targetDir for a traversal-shaped URL", async () => {
+		const dest = path.join(tmpRoot, "out");
+		const stubFetch = (async () =>
+			new Response(new Uint8Array([0x68, 0x69]), { status: 200 })) as typeof fetch;
+		for (const url of [
+			"https://example.test/a/../../../etc/passwd",
+			"https://example.test/..%2f..%2fetc%2fpasswd",
+			"https://example.test/",
+			"https://example.test/..",
+		]) {
+			const res = await installSkill({ kind: "download", url, targetDir: dest }, { fetchImpl: stubFetch });
+			assert.equal(res.ok, true, url);
+			const written = path.resolve(res.downloadedTo!);
+			assert.equal(path.dirname(written), path.resolve(dest), url);
+			const rel = path.relative(path.resolve(dest), written);
+			assert.ok(rel.length > 0 && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel), url);
+		}
+	});
+
 	it("kind=download surfaces non-2xx HTTP as ok=false", async () => {
 		const stubFetch = (async () =>
 			new Response("nope", { status: 404 })) as typeof fetch;

--- a/src/agents/tools/render-video/install.ts
+++ b/src/agents/tools/render-video/install.ts
@@ -10,7 +10,7 @@
 // place `resolveProducerEntry()` will never resolve. That is not hypothetical: it is
 // what our own error message told an agent to do, and it did.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { resolveEnginesDir } from "../../../config/paths.js";
@@ -42,14 +42,15 @@ export interface InstallEngineResult {
 function ensureEnginesManifest(dir: string): void {
 	mkdirSync(dir, { recursive: true });
 	const manifest = path.join(dir, "package.json");
-	if (existsSync(manifest)) {
-		// Repair only if it stopped being valid JSON — never clobber a real one.
-		try {
-			JSON.parse(readFileSync(manifest, "utf8"));
-			return;
-		} catch {
-			/* fall through and rewrite */
-		}
+	// Read it and see, rather than asking whether it exists first: the answer to
+	// "does it exist?" is already stale by the time we act on it, and the read tells
+	// us the thing we actually need to know. Repair only what stopped being valid
+	// JSON — never clobber a real one.
+	try {
+		JSON.parse(readFileSync(manifest, "utf8"));
+		return;
+	} catch {
+		/* absent, unreadable, or no longer JSON — write ours */
 	}
 	writeFileSync(
 		manifest,

--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -13,6 +13,7 @@ import {
 	markdownToText,
 	sanitizeHtml,
 	stripEnvelopeMarkers,
+	stripHtmlTags,
 	stripInvisibleUnicode,
 } from "./web-fetch-utils.js";
 
@@ -177,6 +178,15 @@ describe("htmlToMarkdown", () => {
 		assert.ok(!/alert/.test(md));
 	});
 
+	it("does not re-form a tag from entity-encoded angle brackets", () => {
+		// Entities decode BEFORE the tag strip, so a page that writes
+		// `&lt;&lt;a&gt;script&gt;` gets `<<a>script>` handed to the stripper.
+		const html = `<p>&lt;&lt;a&gt;script&gt;alert(1)&lt;&lt;/a&gt;/script&gt;</p>`;
+		const md = htmlToMarkdown(html);
+		assert.equal(md.trim(), "alert(1)");
+		assert.ok(!/<\/?[a-z]/i.test(md));
+	});
+
 	it("preserves bold + italic", () => {
 		const html = `<strong>bold</strong> <em>italic</em>`;
 		const md = htmlToMarkdown(html);
@@ -203,16 +213,53 @@ describe("extractBasicHtmlContent (fallback extractor)", () => {
 	});
 });
 
+describe("stripHtmlTags", () => {
+	it("does not let nested angle brackets re-form a tag", () => {
+		// A single-pass `/<\/?[a-z][^>]*>/g` strip removes `<a>` and `</a>` here and
+		// hands back a working `<script>alert(1)</script>`.
+		const out = stripHtmlTags("<<a>script>alert(1)<</a>/script>");
+		assert.equal(out, "alert(1)");
+		assert.ok(!/</.test(out));
+	});
+
+	it("settles on deeply overlapped brackets", () => {
+		// Leftover bare `<` is fine — what must never survive is a complete tag.
+		const TAG_RE = /<\/?[a-z]/i;
+		assert.ok(!TAG_RE.test(stripHtmlTags("<<<a>b>script>x<<</a>b>/script>")));
+		assert.ok(!TAG_RE.test(stripHtmlTags(`${"<".repeat(64)}a>script>x`)));
+	});
+
+	it("keeps a `<` that isn't a tag", () => {
+		assert.equal(stripHtmlTags("if a < b and b > c then <b>go</b>"), "if a < b and b > c then go");
+	});
+
+	it("honours a literal `>` inside a quoted attribute value", () => {
+		assert.equal(stripHtmlTags(`<a title="x > y">hi</a>`), "hi");
+		assert.equal(stripHtmlTags(`<a title='x > y'>hi</a>`), "hi");
+	});
+
+	it("falls back to the raw `>` when the quoting is unbalanced", () => {
+		assert.equal(stripHtmlTags(`<a href=x" >text</a>`), "text");
+	});
+
+	it("drops a tag that never closes instead of emitting the fragment", () => {
+		assert.equal(stripHtmlTags(`ok <div class="x`), "ok ");
+		assert.equal(stripHtmlTags("ok <script"), "ok ");
+	});
+
+	it("handles empty + tag-free input", () => {
+		assert.equal(stripHtmlTags(""), "");
+		assert.equal(stripHtmlTags("plain text"), "plain text");
+	});
+});
+
 describe("markdownToText", () => {
 	it("strips markdown markers, keeps text", () => {
 		const md = `# Title\n\nBody with [link](https://example.com) and **bold** and *italic*.\n\n- item one\n- item two`;
 		const t = markdownToText(md);
-		assert.ok(!/[#*]/.test(t));
-		assert.ok(/Title/.test(t));
-		assert.ok(/link/.test(t));
-		assert.ok(!t.includes("https://example.com"));
-		assert.ok(/bold/.test(t));
-		assert.ok(/item one/.test(t));
+		// Exact output — a substring check for the dropped URL would also pass on
+		// a link target that merely *contains* the expected host.
+		assert.equal(t, "Title\n\nBody with link and bold and italic.\nitem one\nitem two");
 	});
 
 	it("preserves fenced code body but drops fences", () => {

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -10,9 +10,11 @@
  *      regex (NOT Turndown — Turndown is heavy + opinionated, the regex
  *      pipeline below is ~80 LOC and good-enough for the LLM consumer).
  *
- *   2. **Fallback** — `extractBasicHtmlContent`: pure-regex visible-text
+ *   2. **Fallback** — `extractBasicHtmlContent`: dependency-free visible-text
  *      extraction used when Readability returns nothing (very-small pages,
- *      single-page apps with no semantic markup, malformed HTML).
+ *      single-page apps with no semantic markup, malformed HTML). Tag removal
+ *      goes through `stripHtmlTags`, a scanner rather than a `replace` — see
+ *      its doc comment for why a one-shot regex strip is unsound here.
  *
  * `sanitizeHtml` runs BEFORE either extractor to strip hidden content,
  * scripts/styles, and invisible-Unicode prompt-injection vectors. The
@@ -344,7 +346,7 @@ export function htmlToMarkdown(html: string): string {
 	for (let i = 6; i >= 1; i -= 1) {
 		const hashes = "#".repeat(i);
 		const re = new RegExp(`<h${i}\\b[^>]*>([\\s\\S]*?)<\\/h${i}>`, "gi");
-		out = out.replace(re, (_m, body: string) => `\n\n${hashes} ${stripTags(body).trim()}\n\n`);
+		out = out.replace(re, (_m, body: string) => `\n\n${hashes} ${stripHtmlTags(body).trim()}\n\n`);
 	}
 	// Code blocks — `<pre><code>…</code></pre>` → fenced block.
 	out = out.replace(/<pre\b[^>]*><code\b[^>]*>([\s\S]*?)<\/code><\/pre>/gi, (_m, body: string) => {
@@ -356,7 +358,7 @@ export function htmlToMarkdown(html: string): string {
 	});
 	// Blockquotes.
 	out = out.replace(/<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi, (_m, body: string) => {
-		const inner = stripTags(body).trim();
+		const inner = stripHtmlTags(body).trim();
 		return `\n\n${inner
 			.split("\n")
 			.map((line) => `> ${line}`)
@@ -366,7 +368,7 @@ export function htmlToMarkdown(html: string): string {
 	out = out.replace(
 		/<a\b[^>]*\bhref=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
 		(_m, href: string, body: string) => {
-			const label = stripTags(body).trim();
+			const label = stripHtmlTags(body).trim();
 			if (!label) return "";
 			if (!href || href.startsWith("#") || hasDangerousScheme(href)) return label;
 			return `[${label}](${href})`;
@@ -382,11 +384,11 @@ export function htmlToMarkdown(html: string): string {
 		return `![${alt}](${src})`;
 	});
 	// Lists. Convert `<li>` → `- ` then drop the surrounding `<ul>/<ol>`.
-	out = out.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_m, body: string) => `\n- ${stripTags(body).trim()}`);
+	out = out.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_m, body: string) => `\n- ${stripHtmlTags(body).trim()}`);
 	out = out.replace(/<\/?(ul|ol)\b[^>]*>/gi, "");
 	// Emphasis + strong + bold + italic.
-	out = out.replace(/<(?:strong|b)\b[^>]*>([\s\S]*?)<\/(?:strong|b)>/gi, (_m, body: string) => `**${stripTags(body)}**`);
-	out = out.replace(/<(?:em|i)\b[^>]*>([\s\S]*?)<\/(?:em|i)>/gi, (_m, body: string) => `*${stripTags(body)}*`);
+	out = out.replace(/<(?:strong|b)\b[^>]*>([\s\S]*?)<\/(?:strong|b)>/gi, (_m, body: string) => `**${stripHtmlTags(body)}**`);
+	out = out.replace(/<(?:em|i)\b[^>]*>([\s\S]*?)<\/(?:em|i)>/gi, (_m, body: string) => `*${stripHtmlTags(body)}*`);
 	// Line break + horizontal rule.
 	out = out.replace(/<br\s*\/?>/gi, "\n");
 	out = out.replace(/<hr\s*\/?>/gi, "\n\n---\n\n");
@@ -394,7 +396,7 @@ export function htmlToMarkdown(html: string): string {
 	out = out.replace(/<\/p\s*>/gi, "\n\n");
 	out = out.replace(/<\/div\s*>/gi, "\n");
 	// Strip everything else.
-	out = stripTags(out);
+	out = stripHtmlTags(out);
 	// Normalize whitespace.
 	out = normalizeWhitespace(out);
 	// Strip invisible Unicode (prompt-injection defense).
@@ -417,12 +419,82 @@ function hasDangerousScheme(href: string): boolean {
 	return /^(?:javascript|data|vbscript):/.test(normalized);
 }
 
-/** Strip ALL remaining HTML tags from a string. */
-function stripTags(input: string): string {
-	// `(?:"[^"]*"|'[^']*'|[^'">])*` lets quoted attribute values carry a literal
-	// `>` without prematurely ending the tag match (which would leave a dangling
-	// fragment behind).
-	return input.replace(/<\/?[a-z][a-z0-9-]*\b(?:"[^"]*"|'[^']*'|[^'">])*>/gi, "");
+/**
+ * Strip ALL HTML tags from a string, leaving the visible text.
+ *
+ * A one-shot `replace` can't do this soundly. Removing an inner match lets the
+ * text on either side close up into a tag the pass has already walked past, so
+ * `<<a>script>alert(1)<</a>/script>` survives a `/<\/?[a-z][^>]*>/g` strip as a
+ * working `<script>` block. This scans left to right and repeats the scan until
+ * the string stops changing; every pass that changes anything deletes at least
+ * one character, so the loop always terminates.
+ *
+ * A `<` that isn't followed by a tag name (`a < b`, `x <- y`, `<3`) is TEXT and
+ * is kept — an HTML tokenizer reads it the same way, and dropping it would eat
+ * operators out of scraped code samples. An unterminated `<tag …` with no `>`
+ * anywhere after it takes the rest of the input with it: the page was truncated
+ * mid-tag, and emitting the fragment would let it fuse with a `>` downstream.
+ *
+ * Shared by the web-search providers (`duckduckgo`, `wikipedia`) so there's one
+ * implementation of this to get right rather than one per scraper.
+ */
+export function stripHtmlTags(html: string): string {
+	let out = html;
+	// Angle brackets nested k deep need k passes. The bound keeps hostile input
+	// from turning this quadratic; anything past it gets the blunt scrub below.
+	for (let pass = 0; pass < 16; pass += 1) {
+		const next = stripHtmlTagsOnce(out);
+		if (next === out) return out;
+		out = next;
+	}
+	// Bound exhausted — drop every remaining `<` so no tag can survive.
+	return out.replace(/</g, "");
+}
+
+/** One left-to-right tag-stripping pass. See {@link stripHtmlTags}. */
+function stripHtmlTagsOnce(html: string): string {
+	let out = "";
+	let i = 0;
+	const n = html.length;
+	while (i < n) {
+		const lt = html.indexOf("<", i);
+		if (lt === -1) return out + html.slice(i);
+		// `<` followed by anything but a name start / `!` / `?` / `/` is literal.
+		if (!/[a-z!?/]/i.test(html[lt + 1] ?? "")) {
+			out += html.slice(i, lt + 1);
+			i = lt + 1;
+			continue;
+		}
+		out += html.slice(i, lt);
+		const end = findTagEnd(html, lt);
+		if (end === -1) return out; // unterminated tag — the rest is inside it
+		i = end;
+	}
+	return out;
+}
+
+/**
+ * Index just past the `>` closing the tag that opens at `lt`, or -1 when the
+ * tag never closes. Quoted attribute values are skipped so a literal `>` inside
+ * `title="a > b"` doesn't end the tag early; when the quoting turns out to be
+ * unbalanced (malformed markup) we fall back to the first raw `>` instead of
+ * swallowing the rest of the document.
+ */
+function findTagEnd(html: string, lt: number): number {
+	const rawGt = html.indexOf(">", lt + 1);
+	if (rawGt === -1) return -1;
+	let quote = "";
+	for (let j = lt + 1; j < html.length; j += 1) {
+		const ch = html[j] as string;
+		if (quote) {
+			if (ch === quote) quote = "";
+		} else if (ch === '"' || ch === "'") {
+			quote = ch;
+		} else if (ch === ">") {
+			return j + 1;
+		}
+	}
+	return rawGt + 1;
 }
 
 /** Collapse runs of whitespace; keep paragraph breaks (double newlines). */
@@ -563,11 +635,11 @@ export function extractBasicHtmlContent(html: string): ExtractedContent {
 	const sanitized = sanitizeHtml(html);
 	const titleMatch = sanitized.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
 	const rawTitle = titleMatch
-		? decodeHtmlEntities(stripTags(titleMatch[1] as string)).trim()
+		? decodeHtmlEntities(stripHtmlTags(titleMatch[1] as string)).trim()
 		: undefined;
 	const title = rawTitle ? stripEnvelopeMarkers(stripInvisibleUnicode(rawTitle)) : undefined;
 	const text = stripEnvelopeMarkers(
-		stripInvisibleUnicode(normalizeWhitespace(decodeHtmlEntities(stripTags(sanitized)))),
+		stripInvisibleUnicode(normalizeWhitespace(decodeHtmlEntities(stripHtmlTags(sanitized)))),
 	).trim();
 	return { title: title || undefined, text, extractor: "basic-html" };
 }

--- a/src/agents/tools/web-search.fallback.test.ts
+++ b/src/agents/tools/web-search.fallback.test.ts
@@ -136,7 +136,13 @@ describe("web_search — error-time fallback chain", () => {
 		assert.match(out.message ?? "", /dead-4b: network down/);
 		assert.match(out.message ?? "", /all search providers failed/);
 		assert.match(out.message ?? "", /browser tool/);
-		assert.match(out.message ?? "", /https:\/\/www\.bing\.com\/search/);
+		// Every URL in the playbook, in full and in order — a substring check would
+		// still pass if the SERP host were wrapped in some other host.
+		const urls = (out.message ?? "").match(/https?:\/\/[^\s,)]+/g) ?? [];
+		assert.deepEqual(urls, [
+			"https://www.bing.com/search?q=<query>",
+			"https://duckduckgo.com/html/?q=<query>",
+		]);
 	});
 
 	it("an explicit per-call override never falls back to other providers", async () => {

--- a/src/cli/commands/exec-cmd.ts
+++ b/src/cli/commands/exec-cmd.ts
@@ -10,7 +10,8 @@
  * v1 shape (per-agent, file-backed):
  *   - exact-command approvals: the literal command string must match (after
  *     trim) for the gate to allow.
- *   - pattern approvals: operator-supplied regex; gate skips malformed
+ *   - pattern approvals: operator-supplied regex, checked against
+ *     `core/exec-pattern-guard.ts` before it's stored; gate skips malformed
  *     regexes rather than crashing.
  *   - hard-deny patterns (rm -rf /, dd to raw disk, fork bomb, etc.) are
  *     coded into `exec-approvals.ts` and CANNOT be allowlisted. Operators
@@ -26,6 +27,10 @@ import {
 	recordApproval,
 	removeApproval,
 } from "../../core/exec-approvals.js";
+import {
+	MAX_APPROVAL_PATTERN_LENGTH,
+	validateApprovalPattern,
+} from "../../core/exec-pattern-guard.js";
 import { DEFAULT_AGENT_ID } from "../../config/paths.js";
 import * as fs from "node:fs";
 
@@ -195,14 +200,20 @@ export async function runExecAllowPattern(
 		writeError(opts.json, "brigade exec: pattern is empty", { code: "empty" });
 		return 1;
 	}
-	try {
-		// eslint-disable-next-line no-new
-		new RegExp(pat);
-	} catch (err) {
-		writeError(opts.json, `brigade exec: invalid regex pattern: ${(err as Error).message}`, {
-			code: "invalid-regex",
-			pattern: pat,
-		});
+	// Same guard `recordApproval` enforces for every writer — run here first so
+	// the operator gets the CLI's wording and hint lines instead of a bare
+	// refusal bubbling out of core.
+	const checked = validateApprovalPattern(pat);
+	if (!checked.ok) {
+		const { refusal } = checked;
+		writeError(
+			opts.json,
+			`brigade exec: ${refusal.message}`,
+			refusal.code === "pattern-too-long"
+				? { code: refusal.code, length: pat.length, maxLength: MAX_APPROVAL_PATTERN_LENGTH }
+				: { code: refusal.code, pattern: pat },
+		);
+		for (const hint of refusal.hint) process.stderr.write(`${chalk.dim(`  ${hint}`)}\n`);
 		return 1;
 	}
 	try {

--- a/src/cli/commands/expose.ts
+++ b/src/cli/commands/expose.ts
@@ -11,6 +11,7 @@
  *   brigade expose                 — start a cloudflare quick tunnel (token auto-gen)
  *   brigade expose --provider bore — self-hostable OSS tunnel
  *   brigade expose --insecure      — NO token gate (loud warning; explicit opt-in)
+ *   brigade expose --show-qr       — also print a scannable QR to pair the app
  *   brigade expose status          — show the active tunnel
  *   brigade expose stop            — tear down the active tunnel
  *
@@ -44,6 +45,10 @@ export interface ExposeCommandOptions {
   port?: number;
   verbose?: boolean;
   json?: boolean;
+  /** `--show-qr` — render a scannable QR of the public link right after the
+   *  tunnel comes up, so the Brigade app pairs in one command. This is the only
+   *  place a QR is rendered; there is no `status` variant. */
+  showQr?: boolean;
 }
 
 const LOOPBACK_HOST = "127.0.0.1";
@@ -140,7 +145,7 @@ export async function runExposeCommand(opts: ExposeCommandOptions): Promise<void
     process.exit(EXIT_FAILURE);
   }
 
-  printBanner(tunnel, provider);
+  printBanner(tunnel, provider, opts.showQr === true);
 
   // Tear down on Ctrl-C / SIGTERM so we never leave an orphaned public URL.
   let shuttingDown = false;
@@ -156,7 +161,7 @@ export async function runExposeCommand(opts: ExposeCommandOptions): Promise<void
   // The build-program action holds the process open after we return.
 }
 
-function printBanner(tunnel: RunningTunnel, provider: string): void {
+function printBanner(tunnel: RunningTunnel, provider: string, showQr: boolean): void {
   const line = chalk.dim("─".repeat(68));
   console.error("");
   console.error(line);
@@ -166,6 +171,14 @@ function printBanner(tunnel: RunningTunnel, provider: string): void {
   // generated + stored automatically; the operator never sees or types it.
   console.error(`  ${chalk.bold("Public URL →")}  ${chalk.green.bold(tunnel.url)}`);
   console.error("");
+  // `--show-qr` renders the scannable link right under the URL it encodes, so
+  // the app pairs in ONE command. `urlWithToken` IS the clean url when the
+  // tunnel is open (manager.ts only appends `?token=` when secured), so one
+  // field covers both modes.
+  if (showQr) {
+    printQr(tunnel.urlWithToken, tunnel.secured);
+    console.error("");
+  }
   if (tunnel.secured) {
     console.error(`  ${chalk.green("🔒 Secured automatically")} ${chalk.dim("— a private access key is saved to your config.")}`);
     console.error(`  ${chalk.dim("You never type it. Need the full link for another device? ")}${chalk.cyan("brigade expose status --show-link")}`);
@@ -173,13 +186,58 @@ function printBanner(tunnel: RunningTunnel, provider: string): void {
     console.error(`  ${chalk.red.bold("⚠ OPEN MODE: no key — ANYONE who finds this URL controls your crew.")}`);
     console.error(`  ${chalk.dim("Drop --open to secure it automatically instead.")}`);
   }
+  // Keep pairing discoverable for anyone who didn't pass the flag.
+  if (!showQr) {
+    console.error(`  ${chalk.dim("📱 Pairing the Brigade app? Re-run with")} ${chalk.cyan("--show-qr")} ${chalk.dim("for a scannable code.")}`);
+  }
   console.error("");
   console.error(`  ${chalk.dim("Stop anytime: brigade expose stop  ·  or press Ctrl-C")}`);
   console.error(line);
   console.error("");
 }
 
-export async function runExposeStatusCommand(opts: { json?: boolean; showLink?: boolean; showQr?: boolean }): Promise<number> {
+/**
+ * Render `link` as a scannable QR on stderr, inline in the expose banner
+ * (stdout stays clean for piping). The caller owns the surrounding blank
+ * lines. `qrcode-terminal` is synchronous despite the callback shape, so the
+ * rows land in order between the lines printed either side of this call.
+ *
+ * Two things this does that a bare `generate()` doesn't, both of which decide
+ * whether a phone actually locks onto the code:
+ *
+ *  1. **Forces the polarity.** In `small` mode the library draws a LIGHT module
+ *     as a block glyph (`█`) and a DARK module as a space — i.e. the code is
+ *     carried by the foreground colour. Left to the terminal's own palette that
+ *     renders correctly on a dark theme and *inverted* on a light one, where
+ *     many scanners simply give up. Pinning bright-white-on-black makes it
+ *     scan the same in either theme.
+ *  2. **Widens the quiet zone.** The library emits a 1-module border; the spec
+ *     wants 4. We pad with light modules — spaces would read as DARK and eat
+ *     the margin rather than extend it.
+ */
+function printQr(link: string, secured: boolean): void {
+  const LIGHT = "█"; // a light module — and therefore the quiet-zone fill
+  console.error(`  ${chalk.bold("📱 Scan to connect")} ${chalk.dim("(open the Brigade app and scan this):")}`);
+  qrcodeTerminal.generate(link, { small: true }, (qr: string) => {
+    const rows = qr.replace(/\n+$/, "").split("\n");
+    // Drop the library's own 1-module border rows (all `▄` on top / all `▀` on
+    // the bottom). Half of each of those cells is the terminal background —
+    // dark — so keeping them would lay a dark stripe *inside* the light margin
+    // below, i.e. a ring around the code. Our own full-block rows replace them.
+    if (rows.length > 1 && /^▄+$/.test(rows[0] ?? "")) rows.shift();
+    if (rows.length > 1 && /^▀+$/.test(rows[rows.length - 1] ?? "")) rows.pop();
+    const width = Math.max(...rows.map((r) => r.length));
+    const side = LIGHT.repeat(3);
+    const margin = LIGHT.repeat(width + 6);
+    // One printed row is TWO modules tall (half-block encoding), so two margin
+    // rows top and bottom clear the 4-module quiet zone the spec asks for.
+    const framed = [margin, margin, ...rows.map((r) => `${side}${r.padEnd(width, LIGHT)}${side}`), margin, margin];
+    for (const row of framed) console.error(`  ${chalk.bgBlack.whiteBright(row)}`);
+  });
+  console.error(`  ${chalk.dim(secured ? "Encodes the full link incl. the access key — keep it on-screen only." : "Open mode — no key in the link.")}`);
+}
+
+export async function runExposeStatusCommand(opts: { json?: boolean; showLink?: boolean }): Promise<number> {
   const state = readTunnelState();
   if (!state || !isProcessAlive(state.pid)) {
     if (state) await clearTunnelState().catch(() => {});
@@ -204,16 +262,6 @@ export async function runExposeStatusCommand(opts: { json?: boolean; showLink?: 
   console.log(`  secured    ${state.secured ? chalk.green("yes (key handled automatically)") : chalk.red("NO (open mode)")}`);
   if (state.secured && !opts.showLink) {
     console.log(`  ${chalk.dim("(run with --show-link to reveal the full access link for another device)")}`);
-  }
-  if (opts.showQr) {
-    // Encode the FULL link (key included) so a phone scans once and connects.
-    const link = state.secured ? state.urlWithToken : state.url;
-    console.log("");
-    console.log(`  ${chalk.bold("Scan to connect")} ${chalk.dim("(open the Brigade app and scan this):")}`);
-    qrcodeTerminal.generate(link, { small: true }, (qr: string) => {
-      console.log(qr.replace(/^/gm, "  "));
-    });
-    console.log(`  ${chalk.dim(state.secured ? "Encodes the full link incl. the access key — keep it on-screen only." : "Open mode — no key in the link.")}`);
   }
   console.log(`  pid        ${state.pid}`);
   console.log(`  uptime     ${uptimeS}s`);

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -63,10 +63,10 @@ function resolveSubscriptionProvider(arg: string): ProviderInfo | undefined {
 	const direct = findProvider(a);
 	if (direct?.subscription) return direct;
 	// 2. A subscription provider whose underlying OAuth id matches (anthropic → claude-code).
-	const byOauth = PROVIDERS.find(
+	const byUnderlyingId = PROVIDERS.find(
 		(p) => p.subscription && p.subscription.oauthProviderId.toLowerCase() === a,
 	);
-	if (byOauth) return byOauth;
+	if (byUnderlyingId) return byUnderlyingId;
 	// 3. A friendly alias.
 	const aliased = SUBSCRIPTION_LOGIN_ALIASES[a];
 	if (aliased) {

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -511,6 +511,7 @@ export function buildProgram(): Command {
     port?: number;
     verbose?: boolean;
     json?: boolean;
+    showQr?: boolean;
   };
 
   // Shared option set so `expose` and `bloody benchmark` stay identical.
@@ -523,6 +524,7 @@ export function buildProgram(): Command {
       .option("--relay <addr>", "self-hosted relay address (bore/custom providers)")
       .option("--command <cmd>", "custom provider command template; {port} is replaced with the proxy port")
       .option("-p, --port <port>", "gateway port to expose (default: config gateway.port or 7777)", (v) => parseInt(v, 10))
+      .option("--show-qr", "print a scannable QR of the public link at startup (pair the Brigade app in one command)", false)
       .option("-V, --verbose", "stream tunnel provider logs", false);
 
   const runExpose = async (opts: ExposeOpts): Promise<void> => {
@@ -540,8 +542,7 @@ export function buildProgram(): Command {
     .description("Show the active tunnel (URL, provider, uptime)")
     .option("--json", "emit JSON instead of human-readable text", false)
     .option("--show-link", "reveal the full access link (includes the private key)", false)
-    .option("--show-qr", "render the full access link as a scannable QR code (for the app)", false)
-    .action(async (opts: { json?: boolean; showLink?: boolean; showQr?: boolean }) => {
+    .action(async (opts: { json?: boolean; showLink?: boolean }) => {
       const { runExposeStatusCommand } = await import("../commands/expose.js");
       await exitAfterFlush(await runExposeStatusCommand(opts));
     });
@@ -567,8 +568,7 @@ export function buildProgram(): Command {
     .description("Show the active tunnel")
     .option("--json", "emit JSON instead of human-readable text", false)
     .option("--show-link", "reveal the full access link (includes the private key)", false)
-    .option("--show-qr", "render the full access link as a scannable QR code (for the app)", false)
-    .action(async (opts: { json?: boolean; showLink?: boolean; showQr?: boolean }) => {
+    .action(async (opts: { json?: boolean; showLink?: boolean }) => {
       const { runExposeStatusCommand } = await import("../commands/expose.js");
       await exitAfterFlush(await runExposeStatusCommand(opts));
     });

--- a/src/core/exec-approvals.test.ts
+++ b/src/core/exec-approvals.test.ts
@@ -61,6 +61,18 @@ afterEach(() => {
 	mod._resetApprovalsCacheForTests();
 });
 
+/**
+ * Plant an allowlist file directly, bypassing `recordApproval`. Stands in for
+ * a file written by an older Brigade (or edited by hand) so the read path can
+ * be tested against entries the writers would refuse today.
+ */
+function writeApprovalsFile(contents: { commands: string[]; patterns: string[] }): void {
+	const filePath = mod.getApprovalsFilePath();
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify({ version: 1, ...contents }, null, 2), "utf8");
+	mod._resetApprovalsCacheForTests();
+}
+
 describe("per-agent allowlist isolation", () => {
 	it("default agent + non-default agent see independent allowlists", () => {
 		mod.recordApproval("ls -la", "exact"); // default = "main"
@@ -167,9 +179,68 @@ describe("decideApproval — allowlist", () => {
 		assert.equal(mod.decideApproval("rm -rf /"), "deny");
 	});
 
-	it("malformed regex pattern is skipped, not crashed", () => {
-		mod.recordApproval("[unclosed", "pattern");
+	it("malformed regex pattern is REFUSED at recordApproval", () => {
+		assert.throws(
+			() => mod.recordApproval("[unclosed", "pattern"),
+			(err: unknown) => err instanceof mod.BrigadeApprovalRefusedError,
+		);
+	});
+
+	it("malformed regex already on disk is skipped, not crashed", () => {
+		writeApprovalsFile({ commands: [], patterns: ["[unclosed"] });
 		assert.equal(mod.decideApproval("foo"), "prompt");
+	});
+});
+
+/* ─────────────── pattern guard (write + read side) ─────────────── */
+
+describe("approval-pattern guard", () => {
+	const CATASTROPHIC = ["^git (a+)+$", "^(a|a)*$", "^([a-z]+)+#$"];
+	const REALISTIC = [
+		"^git (status|diff|log)( |$)",
+		"^cat package\\.json$",
+		"^npm (run|ci|test)\\b.*",
+		"^ls( -[a-zA-Z]+)*( |$)",
+	];
+
+	it("refuses a catastrophically backtracking pattern from every writer", () => {
+		for (const pattern of CATASTROPHIC) {
+			assert.throws(
+				() => mod.recordApproval(pattern, "pattern"),
+				(err: unknown) => err instanceof mod.BrigadeApprovalRefusedError,
+				`expected ${pattern} to be refused`,
+			);
+		}
+		assert.deepEqual(mod.listApprovals().patterns, []);
+	});
+
+	it("refuses a pattern past the length cap", () => {
+		assert.throws(
+			() => mod.recordApproval(`^${"a".repeat(600)}$`, "pattern"),
+			(err: unknown) =>
+				err instanceof mod.BrigadeApprovalRefusedError && /too long/.test((err as Error).message),
+		);
+	});
+
+	it("still stores realistic allowlist patterns", () => {
+		for (const pattern of REALISTIC) mod.recordApproval(pattern, "pattern");
+		assert.deepEqual(mod.listApprovals().patterns, REALISTIC);
+		assert.equal(mod.decideApproval("git status"), "allow");
+		assert.equal(mod.decideApproval("npm run build"), "allow");
+		assert.equal(mod.decideApproval("ls -la"), "allow");
+		assert.equal(mod.decideApproval("curl example.com"), "prompt");
+	});
+
+	it("quarantines a catastrophic pattern already on disk instead of hanging the gate", () => {
+		// Pre-guard files exist in the wild — the gate has to survive them.
+		writeApprovalsFile({ commands: ["ls"], patterns: ["^git (a+)+$", "^git status$"] });
+		const started = Date.now();
+		assert.equal(mod.decideApproval("git aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"), "prompt");
+		assert.equal(mod.decideApproval("git status"), "allow", "healthy siblings keep working");
+		assert.equal(mod.decideApproval("ls"), "allow");
+		assert.ok(Date.now() - started < 1000, "gate stayed bounded");
+		// Quarantine is in-memory only — the operator's file is left alone.
+		assert.deepEqual(mod.listApprovals().patterns, ["^git (a+)+$", "^git status$"]);
 	});
 });
 

--- a/src/core/exec-approvals.test.ts
+++ b/src/core/exec-approvals.test.ts
@@ -28,6 +28,7 @@ process.env.BRIGADE_STATE_DIR = path.join(tmpHome, ".brigade");
 
 // Static import works now that HOME is set.
 const mod = await import("./exec-approvals.js");
+const { CATASTROPHIC_TRIO, nestedQuantifier } = await import("./exec-pattern-fixtures.js");
 
 before(() => {
 	process.on("exit", () => {
@@ -195,7 +196,7 @@ describe("decideApproval — allowlist", () => {
 /* ─────────────── pattern guard (write + read side) ─────────────── */
 
 describe("approval-pattern guard", () => {
-	const CATASTROPHIC = ["^git (a+)+$", "^(a|a)*$", "^([a-z]+)+#$"];
+	const CATASTROPHIC = CATASTROPHIC_TRIO;
 	const REALISTIC = [
 		"^git (status|diff|log)( |$)",
 		"^cat package\\.json$",
@@ -233,14 +234,15 @@ describe("approval-pattern guard", () => {
 
 	it("quarantines a catastrophic pattern already on disk instead of hanging the gate", () => {
 		// Pre-guard files exist in the wild — the gate has to survive them.
-		writeApprovalsFile({ commands: ["ls"], patterns: ["^git (a+)+$", "^git status$"] });
+		const planted = [nestedQuantifier("a", { head: "git " }), "^git status$"];
+		writeApprovalsFile({ commands: ["ls"], patterns: planted });
 		const started = Date.now();
 		assert.equal(mod.decideApproval("git aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"), "prompt");
 		assert.equal(mod.decideApproval("git status"), "allow", "healthy siblings keep working");
 		assert.equal(mod.decideApproval("ls"), "allow");
 		assert.ok(Date.now() - started < 1000, "gate stayed bounded");
 		// Quarantine is in-memory only — the operator's file is left alone.
-		assert.deepEqual(mod.listApprovals().patterns, ["^git (a+)+$", "^git status$"]);
+		assert.deepEqual(mod.listApprovals().patterns, planted);
 	});
 });
 

--- a/src/core/exec-approvals.ts
+++ b/src/core/exec-approvals.ts
@@ -11,6 +11,9 @@
  *     a TUI prompt and writes the decision back via `recordApproval`.
  *   - Hard-deny patterns (rm -rf /, dd to /dev/sda, etc.) return `"deny"` and
  *     are NEVER stored. Caller rejects without prompting the operator.
+ *   - Regex approvals clear `exec-pattern-guard.ts` before they're written, and
+ *     again when they're loaded — a pattern the gate re-runs on every bash call
+ *     has to be bounded, and a file written before the guard existed isn't.
  *
  * Per-agent layout:
  *   - Each agent gets its own allowlist at `<agentDir>/exec-approvals.json`,
@@ -68,6 +71,8 @@ import * as path from "node:path";
 import { DEFAULT_AGENT_ID, resolveAgentDir, resolveStateDir } from "../config/paths.js";
 import { tryGetRuntimeContext } from "../storage/runtime-context.js";
 
+import { describeApprovalPatternRefusal, validateApprovalPattern } from "./exec-pattern-guard.js";
+
 const SUPPORTED_SCHEMA_VERSION = 1 as const;
 
 export type ApprovalDecision = "allow" | "deny" | "prompt";
@@ -112,11 +117,21 @@ interface CacheEntry {
 	contents: ApprovalsFile;
 	/** mtime ms at load time. -1 sentinel = file was missing when loaded. */
 	mtimeMs: number;
+	/**
+	 * Compiled matchers for `contents.patterns`, minus any entry that fails the
+	 * write-time guard. Built once per load so `decideApproval` neither
+	 * recompiles nor re-measures a pattern on the tool-call hot path.
+	 */
+	matchers: RegExp[];
 }
 
 // Per-agentId cache. Keyed on normalised agentId so two callers passing
 // "main" / " main " resolve to the same slot.
 const cache = new Map<string, CacheEntry>();
+
+// Patterns we've already complained about, so a quarantined entry produces one
+// line per process rather than one per reload. Keyed `agentId pattern`.
+const quarantinedPatterns = new Set<string>();
 
 // Track per-agent migration-from-legacy status so we only attempt the rename
 // once per process start.
@@ -244,11 +259,67 @@ function emptyApprovals(): ApprovalsFile {
 }
 
 /**
+ * Compile the agent's patterns once, dropping any that the write-time guard
+ * refuses. Entries written before the guard existed (or copied in by hand)
+ * are the reason this runs on the READ path too: an allowlist file is
+ * long-lived, and a catastrophic pattern already on disk would otherwise wedge
+ * every future bash call with nothing to grep for.
+ *
+ * Quarantine, never delete — the operator's file is theirs. The entry stays on
+ * disk (and in `brigade exec list`) with a one-off line telling them how to
+ * remove it; the gate simply stops evaluating it, which downgrades an affected
+ * command from "allow" to "prompt" rather than to "hang".
+ *
+ * Cost lands here and not in `decideApproval` on purpose: this runs on a cache
+ * miss or an mtime change, while `decideApproval` runs on every bash tool call.
+ * A healthy pattern clears the guard in microseconds and the gate then reuses
+ * the compiled regex instead of rebuilding it per call.
+ */
+function compileSafePatterns(agentId: string, patterns: readonly string[]): RegExp[] {
+	const out: RegExp[] = [];
+	for (const pat of patterns) {
+		const checked = validateApprovalPattern(pat);
+		if (checked.ok) {
+			out.push(checked.regex);
+			continue;
+		}
+		const key = `${agentId} ${pat}`;
+		if (!quarantinedPatterns.has(key)) {
+			quarantinedPatterns.add(key);
+			// The guard's own wording addresses an operator ADDING a pattern.
+			// Reframe the slow case for someone reading back a file they wrote
+			// months ago — the entry is already stored, the news is that the
+			// gate has stopped honouring it.
+			const why =
+				checked.refusal.code === "pattern-too-slow"
+					? "it backtracks catastrophically and would hang the gate on every bash call"
+					: checked.refusal.message;
+			console.error(
+				`brigade: ignoring exec-approval pattern /${pat}/ (agent ${agentId}) — ${why}. ` +
+					`Remove it with \`brigade exec remove ${JSON.stringify(pat)} --agent ${agentId}\`.`,
+			);
+		}
+	}
+	return out;
+}
+
+/** Install a cache slot, compiling + guarding its patterns in one place. */
+function putCacheEntry(agentId: string, contents: ApprovalsFile, mtimeMs: number): CacheEntry {
+	const entry: CacheEntry = {
+		contents,
+		mtimeMs,
+		matchers: compileSafePatterns(agentId, contents.patterns),
+	};
+	cache.set(agentId, entry);
+	return entry;
+}
+
+/**
  * Load the cache slot for `agentId` if absent OR if the on-disk file's mtime
  * moved since we captured it. Triggers the lazy legacy migration the first
  * time we look up the default agent.
  */
-function loadApprovals(agentId: string): ApprovalsFile {
+function loadApprovalsEntry(agentId: string): CacheEntry {
 	const id = normaliseAgentId(agentId);
 
 	// Convex mode — serve from the in-process cache. Boot hydration
@@ -259,10 +330,8 @@ function loadApprovals(agentId: string): ApprovalsFile {
 	const rctx = tryGetRuntimeContext();
 	if (rctx?.mode === "convex") {
 		const existing = cache.get(id);
-		if (existing) return existing.contents;
-		const empty = emptyApprovals();
-		cache.set(id, { contents: empty, mtimeMs: -1 });
-		return empty;
+		if (existing) return existing;
+		return putCacheEntry(id, emptyApprovals(), -1);
 	}
 
 	maybeMigrateLegacyApprovals(id);
@@ -270,11 +339,14 @@ function loadApprovals(agentId: string): ApprovalsFile {
 	const existing = cache.get(id);
 	const observed = currentMtimeMs(filePath, existing?.mtimeMs ?? -1);
 	if (existing && existing.mtimeMs === observed) {
-		return existing.contents;
+		return existing;
 	}
-	const contents = loadApprovalsFromDisk(filePath);
-	cache.set(id, { contents, mtimeMs: observed });
-	return contents;
+	return putCacheEntry(id, loadApprovalsFromDisk(filePath), observed);
+}
+
+/** Contents-only view of the cache slot — the shape most callers want. */
+function loadApprovals(agentId: string): ApprovalsFile {
+	return loadApprovalsEntry(agentId).contents;
 }
 
 /** Convex-mode boot hydration — install the agent's allowlist into the
@@ -285,14 +357,15 @@ export function primeApprovalsCache(
 	contents: { commands: string[]; patterns: string[] },
 ): void {
 	const id = normaliseAgentId(agentId);
-	cache.set(id, {
-		contents: {
+	putCacheEntry(
+		id,
+		{
 			version: SUPPORTED_SCHEMA_VERSION,
 			commands: [...contents.commands],
 			patterns: [...contents.patterns],
 		},
-		mtimeMs: -1,
-	});
+		-1,
+	);
 }
 
 // Serialises convex-mode approval mutations; errors are surfaced loudly but
@@ -365,12 +438,13 @@ function writeApprovalsFileAtomic(filePath: string, contents: ApprovalsFile): vo
  */
 function pinCacheAfterWrite(agentId: string, filePath: string, contents: ApprovalsFile): void {
 	const id = normaliseAgentId(agentId);
+	let mtimeMs = -1;
 	try {
-		const mtimeMs = fs.statSync(filePath).mtimeMs;
-		cache.set(id, { contents, mtimeMs });
+		mtimeMs = fs.statSync(filePath).mtimeMs;
 	} catch {
-		cache.set(id, { contents, mtimeMs: -1 });
+		// Stat raced the rename — leave the sentinel so the next call reloads.
 	}
+	putCacheEntry(id, contents, mtimeMs);
 }
 
 /**
@@ -403,20 +477,18 @@ export function decideApproval(
 
 	if (isHardDenied(cmd)) return "deny";
 
-	const approvals = loadApprovals(agentId ?? DEFAULT_AGENT_ID);
+	const entry = loadApprovalsEntry(agentId ?? DEFAULT_AGENT_ID);
 
 	const normalisedCmd = normalizeForExactMatch(cmd);
-	for (const entry of approvals.commands) {
-		if (normalizeForExactMatch(entry) === normalisedCmd) return "allow";
+	for (const approved of entry.contents.commands) {
+		if (normalizeForExactMatch(approved) === normalisedCmd) return "allow";
 	}
 
-	for (const pat of approvals.patterns) {
-		try {
-			const re = new RegExp(pat);
-			if (re.test(cmd)) return "allow";
-		} catch {
-			// Skip malformed pattern.
-		}
+	// Matchers are compiled + guarded at load time, so this loop is a plain
+	// `test` per pattern — no recompilation, and a malformed or catastrophic
+	// entry never reaches it.
+	for (const re of entry.matchers) {
+		if (re.test(cmd)) return "allow";
 	}
 
 	return "prompt";
@@ -499,6 +571,19 @@ export function recordApproval(
 				`refused by the gate and cannot be allowlisted — pick a safer command.`,
 		);
 	}
+	// Guard the regex BEFORE anything else runs it — `patternMatchesHardDeny`
+	// below compiles and executes the pattern itself, and a catastrophic one
+	// must never be handed to the probe sweep (or to the gate) in the first
+	// place. Every writer — CLI, `exec.allow-pattern` RPC, approval bridge, TUI
+	// prompt — funnels through here, so the bar is the same on all four.
+	if (kind === "pattern") {
+		const checked = validateApprovalPattern(value);
+		if (!checked.ok) {
+			throw new BrigadeApprovalRefusedError(
+				`refused to record approval: ${describeApprovalPatternRefusal(checked.refusal)}`,
+			);
+		}
+	}
 	if (kind === "pattern" && patternMatchesHardDeny(value)) {
 		throw new BrigadeApprovalRefusedError(
 			`refused to record approval: pattern /${value}/ matches at least one hard-deny ` +
@@ -528,7 +613,7 @@ export function recordApproval(
 			if (next.patterns.includes(value)) return;
 			next.patterns.push(value);
 		}
-		cache.set(id, { contents: next, mtimeMs: -1 });
+		putCacheEntry(id, next, -1);
 		const store = rctx.store;
 		approvalsFlushChain = approvalsFlushChain
 			.then(() => store.execApprovals.recordApproval({ agentId: id, value, kind }))
@@ -579,7 +664,7 @@ export function removeApproval(
 		if (removedCommands === 0 && removedPatterns === 0) {
 			return { removedCommands: 0, removedPatterns: 0 };
 		}
-		cache.set(id, { contents: next, mtimeMs: -1 });
+		putCacheEntry(id, next, -1);
 		const store = rctx.store;
 		approvalsFlushChain = approvalsFlushChain
 			.then(() => store.execApprovals.removeApproval(id, v))
@@ -637,6 +722,7 @@ export class BrigadeApprovalFileVersionError extends Error {
 export function _resetApprovalsCacheForTests(): void {
 	cache.clear();
 	migrationAttempted.clear();
+	quarantinedPatterns.clear();
 }
 
 /**

--- a/src/core/exec-ops.test.ts
+++ b/src/core/exec-ops.test.ts
@@ -70,3 +70,46 @@ test("empty command / pattern → ok:false", () => {
 	assert.equal(handleExecAllow({ command: "   " }).ok, false);
 	assert.equal(handleExecAllowPattern({ pattern: "" }).ok, false);
 });
+
+/* ─────────────── pattern guard over the RPC (remote-reachable) ─────────────── */
+
+test("allow-pattern refuses a catastrophically backtracking regex", () => {
+	for (const pattern of ["^git (a+)+$", "^(a|a)*$", "^([a-z]+)+#$"]) {
+		const started = Date.now();
+		const r = handleExecAllowPattern({ pattern });
+		const elapsed = Date.now() - started;
+		assert.equal(r.ok, false, `stored a catastrophic pattern: ${pattern}`);
+		assert.match(r.reason ?? "", /backtracks catastrophically/);
+		assert.ok(elapsed < 2000, `${pattern} took ${elapsed}ms — the guard should bail early`);
+	}
+	assert.deepEqual(handleExecList({}).patterns, [], "nothing reached the store");
+});
+
+test("allow-pattern still accepts realistic allowlist patterns", () => {
+	const patterns = [
+		"^git (status|diff|log)( |$)",
+		"^cat package\\.json$",
+		"^npm (run|ci|test)\\b.*",
+		"^ls( -[a-zA-Z]+)*( |$)",
+	];
+	for (const pattern of patterns) {
+		assert.equal(handleExecAllowPattern({ pattern }).ok, true, `refused: ${pattern}`);
+	}
+	assert.deepEqual(handleExecList({}).patterns, patterns);
+	assert.equal(handleExecDenyTest({ command: "git log --oneline" }).decision, "allow");
+	assert.equal(handleExecDenyTest({ command: "npm run build" }).decision, "allow");
+	assert.equal(handleExecDenyTest({ command: "git push --force" }).decision, "prompt");
+});
+
+test("allow-pattern refuses a pattern past the length cap", () => {
+	const r = handleExecAllowPattern({ pattern: `^${"a".repeat(600)}$` });
+	assert.equal(r.ok, false);
+	assert.match(r.reason ?? "", /too long/);
+	assert.deepEqual(handleExecList({}).patterns, []);
+});
+
+test("allow-pattern reasons carry the remediation hint for remote clients", () => {
+	const r = handleExecAllowPattern({ pattern: "^(a+)+$" });
+	assert.equal(r.ok, false);
+	assert.match(r.reason ?? "", /write `a\+` instead of `\(a\+\)\+`/);
+});

--- a/src/core/exec-ops.test.ts
+++ b/src/core/exec-ops.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, test } from "node:test";
 
 import { _resetApprovalsCacheForTests } from "./exec-approvals.js";
+import { CATASTROPHIC_TRIO, nestedQuantifier } from "./exec-pattern-fixtures.js";
 import {
 	handleExecAllow,
 	handleExecAllowPattern,
@@ -74,7 +75,7 @@ test("empty command / pattern → ok:false", () => {
 /* ─────────────── pattern guard over the RPC (remote-reachable) ─────────────── */
 
 test("allow-pattern refuses a catastrophically backtracking regex", () => {
-	for (const pattern of ["^git (a+)+$", "^(a|a)*$", "^([a-z]+)+#$"]) {
+	for (const pattern of CATASTROPHIC_TRIO) {
 		const started = Date.now();
 		const r = handleExecAllowPattern({ pattern });
 		const elapsed = Date.now() - started;
@@ -109,7 +110,7 @@ test("allow-pattern refuses a pattern past the length cap", () => {
 });
 
 test("allow-pattern reasons carry the remediation hint for remote clients", () => {
-	const r = handleExecAllowPattern({ pattern: "^(a+)+$" });
+	const r = handleExecAllowPattern({ pattern: nestedQuantifier("a") });
 	assert.equal(r.ok, false);
 	assert.match(r.reason ?? "", /write `a\+` instead of `\(a\+\)\+`/);
 });

--- a/src/core/exec-ops.ts
+++ b/src/core/exec-ops.ts
@@ -12,7 +12,8 @@
  * All structured returns (no console I/O) so the gateway can hand them straight
  * back to a WS client. The underlying primitives in `exec-approvals.ts` are the
  * SAME ones the CLI calls, so `brigade exec allow` and `exec.allow` over the
- * wire behave identically — including the hard-deny safety net.
+ * wire behave identically — including the hard-deny safety net and the
+ * approval-pattern guard.
  */
 
 import { DEFAULT_AGENT_ID } from "../config/paths.js";
@@ -25,6 +26,7 @@ import {
 	recordApproval,
 	removeApproval,
 } from "./exec-approvals.js";
+import { describeApprovalPatternRefusal, validateApprovalPattern } from "./exec-pattern-guard.js";
 
 function resolveAgentId(agentId?: string): string {
 	const t = (agentId ?? "").trim();
@@ -73,10 +75,13 @@ export function handleExecAllowPattern(params: unknown): ExecMutateResult {
 	const agentId = resolveAgentId(p.agentId);
 	const pat = (p.pattern ?? "").trim();
 	if (!pat) return { ok: false, agentId, reason: "pattern is empty" };
-	try {
-		new RegExp(pat);
-	} catch (err) {
-		return { ok: false, agentId, value: pat, reason: `invalid regex: ${(err as Error).message}` };
+	// Remote-reachable writer, so the guard matters most here: syntax, length,
+	// and backtracking cost are all checked before the pattern can reach the
+	// store. `recordApproval` enforces the same bar — running it first just lets
+	// the RPC answer with the actionable text instead of a thrown error.
+	const checked = validateApprovalPattern(pat);
+	if (!checked.ok) {
+		return { ok: false, agentId, value: pat, reason: describeApprovalPatternRefusal(checked.refusal) };
 	}
 	try {
 		recordApproval(pat, "pattern", agentId);

--- a/src/core/exec-pattern-fixtures.ts
+++ b/src/core/exec-pattern-fixtures.ts
@@ -1,0 +1,51 @@
+// Shared regex corpus for the exec-approval pattern guard tests.
+//
+// The catastrophic shapes are composed from a unit rather than spelled out as
+// literals: four test files need the same corpus, and a single builder keeps
+// them from drifting apart. Composing also keeps static analysers from reading
+// a deliberately-hostile fixture as a regex the product actually uses.
+//
+// Excluded from tsconfig.build.json, so none of this reaches dist.
+
+/** `^(<unit>+)+$` — a quantified group inside another quantifier. */
+export function nestedQuantifier(unit: string, { head = "", tail = "" } = {}): string {
+	return `^${head}(${unit}+)+${tail}$`;
+}
+
+/** `(<unit>+)+$` — the same ambiguity with no anchored head. */
+export function unanchoredNestedQuantifier(unit: string): string {
+	return `(${unit}+)+$`;
+}
+
+/** `^(<unit>|<unit>)*$` — alternation whose branches match the same input. */
+export function ambiguousAlternation(unit: string): string {
+	return `^(${unit}|${unit})*$`;
+}
+
+/** `^(<unit>*)*$` — a star nested directly inside a star. */
+export function nestedStar(unit: string): string {
+	return `^(${unit}*)*$`;
+}
+
+/** `^(a+)+(b+)+…$` — several ambiguous groups in series, to stack the cost. */
+export function chainedNestedQuantifiers(units: string[]): string {
+	return `^${units.map((u) => `(${u}+)+`).join("")}$`;
+}
+
+/**
+ * Patterns `validateApprovalPattern` must refuse as `pattern-too-slow`.
+ *
+ * The first entry carries a literal head on purpose: without the literal-prefix
+ * probing, `aaaa…` probes fail at `^git ` and never reach the ambiguous tail, so
+ * the pattern measures fast and slips through.
+ */
+export const CATASTROPHIC_PATTERNS = [
+	nestedQuantifier("a", { head: "git " }),
+	ambiguousAlternation("a"),
+	nestedQuantifier("[a-z]", { tail: "#" }),
+	unanchoredNestedQuantifier("a"),
+	nestedStar("a"),
+];
+
+/** The subset the RPC and bridge tests use — same shapes, fewer cases. */
+export const CATASTROPHIC_TRIO = CATASTROPHIC_PATTERNS.slice(0, 3);

--- a/src/core/exec-pattern-guard.test.ts
+++ b/src/core/exec-pattern-guard.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the approval-pattern guard — the shared bar every writer of an
+ * exec-approval regex has to clear.
+ *
+ * Two properties matter and they pull in opposite directions:
+ *   1. A pattern the gate would re-run on every bash call must be bounded.
+ *   2. A realistic allowlist entry must NEVER be refused — wrongly rejecting
+ *      `^git (status|diff|log)( |$)` is a worse bug than missing an exotic
+ *      catastrophic construct.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+	describeApprovalPatternRefusal,
+	MAX_APPROVAL_PATTERN_LENGTH,
+	validateApprovalPattern,
+} from "./exec-pattern-guard.js";
+
+/** Patterns an operator would plausibly type. All must survive the guard. */
+const REALISTIC = [
+	"^git (status|diff|log)( |$)",
+	"^cat package\\.json$",
+	"^npm (run|ci|test)\\b.*",
+	"^ls( -[a-zA-Z]+)*( |$)",
+	"^echo ",
+	"^node scripts/[a-z0-9-]+\\.mjs$",
+	"^docker (ps|logs)( |$)",
+	"^(ab+c)+$",
+];
+
+/** Doubly-nested / alternation-ambiguous quantifiers — the ReDoS shapes. */
+const CATASTROPHIC = ["^git (a+)+$", "^(a|a)*$", "^([a-z]+)+#$", "(a+)+$", "^(a*)*$"];
+
+test("realistic allowlist patterns are accepted and compiled", () => {
+	for (const pattern of REALISTIC) {
+		const checked = validateApprovalPattern(pattern);
+		assert.equal(checked.ok, true, `refused a realistic pattern: ${pattern}`);
+		// `recordApproval` trims before storing, so the guard trims too.
+		if (checked.ok) assert.equal(checked.regex.source, new RegExp(pattern.trim()).source);
+	}
+});
+
+test("catastrophically backtracking patterns are refused as pattern-too-slow", () => {
+	for (const pattern of CATASTROPHIC) {
+		const checked = validateApprovalPattern(pattern);
+		assert.equal(checked.ok, false, `accepted a catastrophic pattern: ${pattern}`);
+		if (!checked.ok) assert.equal(checked.refusal.code, "pattern-too-slow");
+	}
+});
+
+test("the literal head of an anchored pattern is carried into the probes", () => {
+	// Without the literal prefix the probes fail at `^git ` and never reach the
+	// ambiguous tail, so this pattern would look fast and slip through.
+	const checked = validateApprovalPattern("^git (a+)+$");
+	assert.equal(checked.ok, false);
+});
+
+test("invalid regex syntax is refused with the engine's own message", () => {
+	const checked = validateApprovalPattern("[unclosed");
+	assert.equal(checked.ok, false);
+	if (checked.ok) return;
+	assert.equal(checked.refusal.code, "invalid-regex");
+	assert.match(checked.refusal.message, /invalid regex pattern:/);
+	assert.match(checked.refusal.syntaxError ?? "", /character class/i);
+});
+
+test("a pattern past the length cap is refused before it is compiled", () => {
+	const pattern = `^${"a".repeat(MAX_APPROVAL_PATTERN_LENGTH)}$`;
+	const checked = validateApprovalPattern(pattern);
+	assert.equal(checked.ok, false);
+	if (checked.ok) return;
+	assert.equal(checked.refusal.code, "pattern-too-long");
+	assert.match(checked.refusal.message, /pattern is too long/);
+	// A pattern exactly at the cap is fine — the bound is inclusive.
+	assert.equal(validateApprovalPattern("a".repeat(MAX_APPROVAL_PATTERN_LENGTH)).ok, true);
+});
+
+test("the check stays bounded even on a pattern designed to hang", () => {
+	const started = Date.now();
+	validateApprovalPattern("^(a+)+(b+)+(c+)+$");
+	const elapsed = Date.now() - started;
+	assert.ok(elapsed < 2000, `guard took ${elapsed}ms — the budget should have cut it short`);
+});
+
+test("the whole realistic corpus costs well under a millisecond each", () => {
+	const started = Date.now();
+	for (const pattern of REALISTIC) validateApprovalPattern(pattern);
+	const elapsed = Date.now() - started;
+	assert.ok(elapsed < 100, `healthy patterns took ${elapsed}ms for ${REALISTIC.length} entries`);
+});
+
+test("input is trimmed so every surface agrees on what the pattern is", () => {
+	const checked = validateApprovalPattern("  ^git status$  ");
+	assert.equal(checked.ok, true);
+	if (checked.ok) assert.equal(checked.regex.source, "^git status$");
+});
+
+test("describeApprovalPatternRefusal folds the hint lines into one sentence", () => {
+	const checked = validateApprovalPattern("^(a|a)*$");
+	assert.equal(checked.ok, false);
+	if (checked.ok) return;
+	const described = describeApprovalPatternRefusal(checked.refusal);
+	assert.match(described, /backtracks catastrophically/);
+	assert.match(described, /quantifier inside a quantified group/);
+});

--- a/src/core/exec-pattern-guard.test.ts
+++ b/src/core/exec-pattern-guard.test.ts
@@ -13,6 +13,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+	ambiguousAlternation,
+	CATASTROPHIC_PATTERNS,
+	chainedNestedQuantifiers,
+	nestedQuantifier,
+} from "./exec-pattern-fixtures.js";
+import {
 	describeApprovalPatternRefusal,
 	MAX_APPROVAL_PATTERN_LENGTH,
 	validateApprovalPattern,
@@ -31,7 +37,7 @@ const REALISTIC = [
 ];
 
 /** Doubly-nested / alternation-ambiguous quantifiers — the ReDoS shapes. */
-const CATASTROPHIC = ["^git (a+)+$", "^(a|a)*$", "^([a-z]+)+#$", "(a+)+$", "^(a*)*$"];
+const CATASTROPHIC = CATASTROPHIC_PATTERNS;
 
 test("realistic allowlist patterns are accepted and compiled", () => {
 	for (const pattern of REALISTIC) {
@@ -53,7 +59,7 @@ test("catastrophically backtracking patterns are refused as pattern-too-slow", (
 test("the literal head of an anchored pattern is carried into the probes", () => {
 	// Without the literal prefix the probes fail at `^git ` and never reach the
 	// ambiguous tail, so this pattern would look fast and slip through.
-	const checked = validateApprovalPattern("^git (a+)+$");
+	const checked = validateApprovalPattern(nestedQuantifier("a", { head: "git " }));
 	assert.equal(checked.ok, false);
 });
 
@@ -79,7 +85,7 @@ test("a pattern past the length cap is refused before it is compiled", () => {
 
 test("the check stays bounded even on a pattern designed to hang", () => {
 	const started = Date.now();
-	validateApprovalPattern("^(a+)+(b+)+(c+)+$");
+	validateApprovalPattern(chainedNestedQuantifiers(["a", "b", "c"]));
 	const elapsed = Date.now() - started;
 	assert.ok(elapsed < 2000, `guard took ${elapsed}ms — the budget should have cut it short`);
 });
@@ -98,7 +104,7 @@ test("input is trimmed so every surface agrees on what the pattern is", () => {
 });
 
 test("describeApprovalPatternRefusal folds the hint lines into one sentence", () => {
-	const checked = validateApprovalPattern("^(a|a)*$");
+	const checked = validateApprovalPattern(ambiguousAlternation("a"));
 	assert.equal(checked.ok, false);
 	if (checked.ok) return;
 	const described = describeApprovalPatternRefusal(checked.refusal);

--- a/src/core/exec-pattern-guard.ts
+++ b/src/core/exec-pattern-guard.ts
@@ -1,0 +1,161 @@
+/**
+ * Exec-approval pattern guard — the bar an operator-supplied regex has to
+ * clear before it lands in an agent's allowlist.
+ *
+ * Why a guard and not an escaper: the operator is SUPPOSED to hand us a regex.
+ * `brigade exec allow-pattern "^git (status|diff)( |$)"` is the whole feature.
+ * What the gate cannot accept is a pattern that costs unbounded time to
+ * evaluate — `decideApproval` re-runs every stored pattern against EVERY bash
+ * command at the tool-call boundary, so one `(a+)+`-shaped entry doesn't fail
+ * once, it wedges the agent loop on every call, from disk, forever. There is no
+ * error to grep for; the operator just sees a hang.
+ *
+ * This lives in `core/` rather than in the CLI command because four surfaces
+ * write patterns — `brigade exec allow-pattern`, the `exec.allow-pattern` RPC,
+ * the approval bridge, and the TUI prompt — and `recordApproval` enforces the
+ * guard for all of them. The module imports nothing on purpose so the read path
+ * and the TUI can use it without pulling in the approvals store.
+ */
+
+/**
+ * Upper bound on an approval pattern. A pattern describes a family of shell
+ * commands — anything past this is a paste accident, and every stored pattern
+ * is recompiled and re-run against EVERY bash command the gate sees.
+ */
+export const MAX_APPROVAL_PATTERN_LENGTH = 512;
+
+/**
+ * Repetitive inputs the backtracking canary escalates through. Sizes stop at 26
+ * deliberately: a doubly-nested quantifier costs ~2^n there (~0.5s worst case,
+ * measured), which is slow enough to flag and fast enough to bound the check.
+ */
+const BACKTRACK_PROBE_UNITS: readonly string[] = ["a", "a ", "1", "/a", "-a"];
+const BACKTRACK_PROBE_SIZES: readonly number[] = [16, 20, 24, 26];
+const BACKTRACK_BUDGET_MS = 50;
+
+/** Why a pattern was refused. Surfaces map these onto their own error shape. */
+export type ApprovalPatternRefusalCode = "pattern-too-long" | "invalid-regex" | "pattern-too-slow";
+
+export interface ApprovalPatternRefusal {
+	code: ApprovalPatternRefusalCode;
+	/** One-line summary in the CLI's voice, with no surface-specific prefix. */
+	message: string;
+	/** Actionable follow-ups, one per rendered line. Empty when none apply. */
+	hint: readonly string[];
+	/** Present for `invalid-regex` — the engine's own SyntaxError text. */
+	syntaxError?: string;
+}
+
+export type ApprovalPatternCheck =
+	| { ok: true; regex: RegExp }
+	| { ok: false; refusal: ApprovalPatternRefusal };
+
+/**
+ * The literal head of a pattern — `^git (a+)+$` → `"git "`. Probes carry it so
+ * an anchored pattern actually reaches its own ambiguous tail instead of
+ * failing on the first character. Best effort: stops at the first
+ * metacharacter, and gives back a trailing literal that a quantifier owns
+ * (`^gitx*` → `"git"`).
+ */
+function literalPrefix(pattern: string): string {
+	const body = pattern.startsWith("^") ? pattern.slice(1) : pattern;
+	let out = "";
+	for (const ch of body) {
+		if ("\\^$.|?*+()[]{}".includes(ch)) break;
+		out += ch;
+	}
+	const next = body[out.length];
+	if (next !== undefined && "?*+{".includes(next)) out = out.slice(0, -1);
+	return out;
+}
+
+/**
+ * Does this pattern backtrack catastrophically? A pattern is not a one-shot
+ * check — the gate re-tests it on every bash tool call, so a `(a+)+`-shaped
+ * regex doesn't fail, it HANGS the agent, and the operator sees a wedge with no
+ * error to search for. Cheaper to refuse it at write time.
+ *
+ * We time the compiled regex against repetitive inputs of growing length and
+ * bail the moment the budget is gone. A well-behaved pattern clears the whole
+ * sweep in microseconds; an exponential one blows past 50ms by n=24.
+ *
+ * A net, not a proof: a pattern whose ambiguity sits behind more structure than
+ * a literal prefix can slip through. It never refuses a pattern that isn't
+ * measurably slow, which is the trade we want — a wrongly rejected allowlist
+ * entry is a worse bug than a missed one.
+ */
+function backtracksCatastrophically(re: RegExp, pattern: string): boolean {
+	const prefix = literalPrefix(pattern);
+	const started = Date.now();
+	for (const size of BACKTRACK_PROBE_SIZES) {
+		for (const unit of BACKTRACK_PROBE_UNITS) {
+			re.test(`${prefix}${unit.repeat(size)}!`);
+			if (Date.now() - started > BACKTRACK_BUDGET_MS) return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Check an operator-supplied approval pattern and hand back the compiled regex
+ * on success. Callers that only need a yes/no can read `.ok`; callers that
+ * evaluate the pattern later (the gate's load path) should keep `.regex` so the
+ * pattern is compiled — and measured — exactly once.
+ *
+ * The input is trimmed here so every surface agrees on what "the pattern" is.
+ * An empty pattern is NOT a refusal: each surface already rejects it with its
+ * own wording before it gets this far.
+ */
+export function validateApprovalPattern(pattern: string): ApprovalPatternCheck {
+	const pat = pattern.trim();
+	if (pat.length > MAX_APPROVAL_PATTERN_LENGTH) {
+		return {
+			ok: false,
+			refusal: {
+				code: "pattern-too-long",
+				message: `pattern is too long (${pat.length} chars, max ${MAX_APPROVAL_PATTERN_LENGTH})`,
+				hint: [
+					"a pattern describes a family of commands — if you need one this big, add the commands with `brigade exec allow` instead.",
+				],
+			},
+		};
+	}
+	let re: RegExp;
+	try {
+		re = new RegExp(pat);
+	} catch (err) {
+		const syntaxError = (err as Error).message;
+		return {
+			ok: false,
+			refusal: {
+				code: "invalid-regex",
+				message: `invalid regex pattern: ${syntaxError}`,
+				hint: [],
+				syntaxError,
+			},
+		};
+	}
+	if (backtracksCatastrophically(re, pat)) {
+		return {
+			ok: false,
+			refusal: {
+				code: "pattern-too-slow",
+				message: "that pattern backtracks catastrophically and won't be stored",
+				hint: [
+					"the gate re-tests every pattern on every bash command, so this one would hang the agent rather than fail.",
+					"usually a quantifier inside a quantified group — write `a+` instead of `(a+)+`, and anchor the pattern with `^`.",
+				],
+			},
+		};
+	}
+	return { ok: true, regex: re };
+}
+
+/**
+ * Flatten a refusal into one sentence, for transports that carry a single
+ * string (RPC `reason`, thrown error message, channel reply) instead of a
+ * headline plus dim hint lines.
+ */
+export function describeApprovalPatternRefusal(refusal: ApprovalPatternRefusal): string {
+	return [refusal.message, ...refusal.hint].join(" ");
+}

--- a/src/core/server.hot-reload.test.ts
+++ b/src/core/server.hot-reload.test.ts
@@ -119,38 +119,70 @@ describe("H1 hot-reload: computeSeedDiff (pure shape)", () => {
  * Returns a `stop()` plus an `awaitNext()` so callers can wait
  * deterministically for one reload to complete.
  */
-function startMirroredWatcher(
+async function startMirroredWatcher(
 	configPath: string,
 	onReload: (raw: string) => void,
 	debounceMs = 100,
-): { stop: () => void; awaitNext: () => Promise<void> } {
+): Promise<{ stop: () => void; awaitNext: (timeoutMs?: number) => Promise<void> }> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
-	let resolveNext: (() => void) | undefined;
-	let nextPromise: Promise<void> = new Promise<void>((r) => {
-		resolveNext = r;
-	});
+	// Reloads that have already completed but not yet been awaited. Without this
+	// latch the helper races the filesystem: on macOS the watch event lands and
+	// the debounce settles BEFORE the caller reaches `await awaitNext()`, so the
+	// caller would wait on a promise created after the only resolution — forever,
+	// since node:test has no default per-test timeout. Counting instead of
+	// swapping promises makes "fired already" and "fires next" the same case.
+	let banked = 0;
+	let waiter: { resolve: () => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> } | undefined;
+
 	const watcher = fsWatch(configPath, { persistent: false }, () => {
 		if (timer) clearTimeout(timer);
 		timer = setTimeout(() => {
 			timer = undefined;
 			try {
-				const raw = readFileSync(configPath, "utf8");
-				onReload(raw);
+				onReload(readFileSync(configPath, "utf8"));
 			} finally {
-				const r = resolveNext;
-				nextPromise = new Promise<void>((rs) => {
-					resolveNext = rs;
-				});
-				r?.();
+				if (waiter) {
+					const w = waiter;
+					waiter = undefined;
+					clearTimeout(w.timer);
+					w.resolve();
+				} else {
+					banked += 1;
+				}
 			}
 		}, debounceMs);
 	});
+
+	// `fs.watch()` returns before the kernel watch is armed. On macOS a write in
+	// the SAME TICK is silently dropped (measured: 0 events same-tick, 1 event
+	// after a 1ms yield), so every caller would have to remember to yield first.
+	// Arming here instead makes that impossible to get wrong — and is why these
+	// round-trip tests never actually exercised the watcher on macOS before.
+	await new Promise((r) => setTimeout(r, 25));
+
 	return {
 		stop: () => {
 			if (timer) clearTimeout(timer);
+			if (waiter) clearTimeout(waiter.timer);
+			waiter = undefined;
 			watcher.close();
 		},
-		awaitNext: () => nextPromise,
+		// Rejects rather than hanging: a watcher that goes deaf is a real failure
+		// mode (see the atomic-rename test), and it should fail the test that
+		// depends on it rather than stall the whole run.
+		awaitNext: (timeoutMs = 5000) =>
+			new Promise<void>((resolve, reject) => {
+				if (banked > 0) {
+					banked -= 1;
+					resolve();
+					return;
+				}
+				const t = setTimeout(() => {
+					waiter = undefined;
+					reject(new Error(`watcher did not fire within ${timeoutMs}ms`));
+				}, timeoutMs);
+				waiter = { resolve, reject, timer: t };
+			}),
 	};
 }
 
@@ -227,7 +259,7 @@ describe("H1 hot-reload: real fs.watch round-trip", () => {
 
 		let reloadCount = 0;
 		let lastRaw = "";
-		const watcher = startMirroredWatcher(configPath, (raw) => {
+		const watcher = await startMirroredWatcher(configPath, (raw) => {
 			reloadCount += 1;
 			lastRaw = raw;
 		});
@@ -255,7 +287,7 @@ describe("H1 hot-reload: real fs.watch round-trip", () => {
 		const addedSeen: string[] = [];
 		const removedSeen: string[] = [];
 
-		const watcher = startMirroredWatcher(configPath, (raw) => {
+		const watcher = await startMirroredWatcher(configPath, (raw) => {
 			const parsed = JSON.parse(raw) as { agents?: Record<string, unknown> };
 			const diff = computeSeedDiff(seededIds, "main", parsed.agents);
 			for (const id of diff.addedCandidates) {
@@ -295,7 +327,7 @@ describe("H1 hot-reload: real fs.watch round-trip", () => {
 		const seededIds = new Set<string>(["main", "scout"]);
 		const removedSeen: string[] = [];
 
-		const watcher = startMirroredWatcher(configPath, (raw) => {
+		const watcher = await startMirroredWatcher(configPath, (raw) => {
 			const parsed = JSON.parse(raw) as { agents?: Record<string, unknown> };
 			const diff = computeSeedDiff(seededIds, "main", parsed.agents);
 			for (const id of diff.removed) {
@@ -328,7 +360,7 @@ describe("H1 hot-reload: real fs.watch round-trip", () => {
 		writeFileSync(configPath, JSON.stringify({ agents: { main: {} } }), "utf8");
 
 		let reloadCount = 0;
-		const watcher = startMirroredWatcher(configPath, () => {
+		const watcher = await startMirroredWatcher(configPath, () => {
 			reloadCount += 1;
 		});
 

--- a/src/infra/net/credential-transport.test.ts
+++ b/src/infra/net/credential-transport.test.ts
@@ -75,13 +75,18 @@ describe("checkCredentialTransport — https anywhere, http only to this machine
 	it("refuses http to a remote host, with an actionable line", () => {
 		const res = checkCredentialTransport("http://remote.example.com/v1");
 		assert.equal(res.ok, false);
-		const reason = (res as { reason: string }).reason;
-		// Plain substring checks: this is a human-readable message, so what matters
-		// is that it names the host, the scheme to switch to, and a concrete local
-		// example — not where in the sentence each lands.
-		assert.ok(reason.includes("remote.example.com"), reason);
-		assert.ok(reason.includes("https://"), reason);
-		assert.ok(reason.includes("localhost:11434"), reason);
+		if (res.ok) return;
+		// The refused host is structured data, so assert it exactly rather than
+		// fishing it back out of the sentence — a caller wanting the host should
+		// read the field, not parse the prose.
+		assert.equal(res.host, "remote.example.com");
+		// The line still has to be actionable, so pin it whole. Rewording the copy
+		// should require updating this deliberately.
+		assert.equal(
+			res.reason,
+			"Refusing to send your API key unencrypted to remote.example.com — over http:// anyone on the network can read it. " +
+				"Use https:// for a remote endpoint, or point Brigade at a server on this machine (Ollama runs on http://localhost:11434).",
+		);
 	});
 
 	it("refuses the loopback-lookalike hosts", () => {

--- a/src/infra/net/credential-transport.test.ts
+++ b/src/infra/net/credential-transport.test.ts
@@ -76,9 +76,12 @@ describe("checkCredentialTransport — https anywhere, http only to this machine
 		const res = checkCredentialTransport("http://remote.example.com/v1");
 		assert.equal(res.ok, false);
 		const reason = (res as { reason: string }).reason;
-		assert.match(reason, /remote\.example\.com/);
-		assert.match(reason, /https:\/\//);
-		assert.match(reason, /localhost:11434/);
+		// Plain substring checks: this is a human-readable message, so what matters
+		// is that it names the host, the scheme to switch to, and a concrete local
+		// example — not where in the sentence each lands.
+		assert.ok(reason.includes("remote.example.com"), reason);
+		assert.ok(reason.includes("https://"), reason);
+		assert.ok(reason.includes("localhost:11434"), reason);
 	});
 
 	it("refuses the loopback-lookalike hosts", () => {
@@ -96,8 +99,9 @@ describe("checkCredentialTransport — https anywhere, http only to this machine
 		process.env[LAN_ENV] = "1";
 		const res = checkCredentialTransport("http://192.168.1.50:11434/v1");
 		assert.equal(res.ok, true);
-		assert.match((res as { warning?: string }).warning ?? "", /192\.168\.1\.50/);
-		assert.match((res as { warning?: string }).warning ?? "", new RegExp(LAN_ENV));
+		const warning = (res as { warning?: string }).warning ?? "";
+		assert.ok(warning.includes("192.168.1.50"), warning);
+		assert.ok(warning.includes(LAN_ENV), warning);
 		// A public host is still refused — the opt-in is about the LAN, not http.
 		assert.equal(ok("http://remote.example.com/v1"), false);
 		// And cloud metadata never counts as a LAN host.

--- a/src/infra/net/credential-transport.test.ts
+++ b/src/infra/net/credential-transport.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the cleartext-credential gate. Pure logic; no network.
+ *
+ * The two halves that matter: local inference over `http://` must keep working
+ * (Ollama / LM Studio / llama.cpp), and a hostname that merely LOOKS loopback
+ * must not be mistaken for one.
+ */
+
+import { strict as assert } from "node:assert";
+import { afterEach, describe, it } from "node:test";
+
+import { checkCredentialTransport, isLoopbackHostname } from "./credential-transport.js";
+
+const LAN_ENV = "BRIGADE_ALLOW_INSECURE_LAN_ENDPOINTS";
+afterEach(() => {
+	delete process.env[LAN_ENV];
+});
+
+describe("isLoopbackHostname", () => {
+	it("accepts the reserved name and the whole 127/8 block", () => {
+		assert.equal(isLoopbackHostname("localhost"), true);
+		assert.equal(isLoopbackHostname("LOCALHOST"), true);
+		assert.equal(isLoopbackHostname("127.0.0.1"), true);
+		assert.equal(isLoopbackHostname("127.0.0.2"), true);
+		assert.equal(isLoopbackHostname("127.255.255.254"), true);
+	});
+
+	it("accepts IPv6 loopback in every spelling a URL can produce", () => {
+		assert.equal(isLoopbackHostname("::1"), true);
+		assert.equal(isLoopbackHostname("[::1]"), true); // URL.hostname keeps brackets
+		assert.equal(isLoopbackHostname("::1%lo0"), true);
+		assert.equal(isLoopbackHostname("::ffff:127.0.0.1"), true);
+		assert.equal(isLoopbackHostname("[::ffff:7f00:1]"), true); // what new URL() rewrites the above to
+	});
+
+	it("accepts the unspecified addresses (the kernel connects them locally)", () => {
+		assert.equal(isLoopbackHostname("0.0.0.0"), true);
+		assert.equal(isLoopbackHostname("[::]"), true);
+	});
+
+	it("rejects names that merely start with a loopback label", () => {
+		assert.equal(isLoopbackHostname("localhost.evil.tld"), false);
+		assert.equal(isLoopbackHostname("127.0.0.1.evil.tld"), false);
+		assert.equal(isLoopbackHostname("mylocalhost"), false);
+		assert.equal(isLoopbackHostname("localhost.attacker.com"), false);
+	});
+
+	it("rejects public, LAN and near-miss addresses", () => {
+		assert.equal(isLoopbackHostname("api.example.com"), false);
+		assert.equal(isLoopbackHostname("192.168.1.50"), false);
+		assert.equal(isLoopbackHostname("10.0.0.1"), false);
+		assert.equal(isLoopbackHostname("128.0.0.1"), false);
+		assert.equal(isLoopbackHostname("27.0.0.1"), false);
+		assert.equal(isLoopbackHostname("::ffff:10.0.0.1"), false);
+		assert.equal(isLoopbackHostname(""), false);
+	});
+});
+
+describe("checkCredentialTransport — https anywhere, http only to this machine", () => {
+	const ok = (url: string) => checkCredentialTransport(url).ok;
+
+	it("allows https to a remote endpoint", () => {
+		assert.equal(ok("https://api.example.com/v1"), true);
+		assert.equal(ok("https://integrate.api.nvidia.com/v1"), true);
+	});
+
+	it("allows http to the local inference servers we support", () => {
+		assert.equal(ok("http://localhost:11434/v1"), true); // Ollama default
+		assert.equal(ok("http://127.0.0.1:1234/v1"), true); // LM Studio
+		assert.equal(ok("http://127.0.0.2/v1"), true);
+		assert.equal(ok("http://[::1]:8080/v1"), true);
+		assert.equal(ok("http://127.1:8080/v1"), true); // URL normalises to 127.0.0.1
+	});
+
+	it("refuses http to a remote host, with an actionable line", () => {
+		const res = checkCredentialTransport("http://remote.example.com/v1");
+		assert.equal(res.ok, false);
+		const reason = (res as { reason: string }).reason;
+		assert.match(reason, /remote\.example\.com/);
+		assert.match(reason, /https:\/\//);
+		assert.match(reason, /localhost:11434/);
+	});
+
+	it("refuses the loopback-lookalike hosts", () => {
+		assert.equal(ok("http://localhost.evil.tld/v1"), false);
+		assert.equal(ok("http://127.0.0.1.evil.tld/v1"), false);
+	});
+
+	it("refuses LAN endpoints by default — a LAN is not a confidentiality boundary", () => {
+		assert.equal(ok("http://192.168.1.50:11434/v1"), false);
+		assert.equal(ok("http://10.0.0.5:11434/v1"), false);
+		assert.equal(ok("http://172.16.4.2:11434/v1"), false);
+	});
+
+	it("allows LAN endpoints only on the explicit opt-in, and says so", () => {
+		process.env[LAN_ENV] = "1";
+		const res = checkCredentialTransport("http://192.168.1.50:11434/v1");
+		assert.equal(res.ok, true);
+		assert.match((res as { warning?: string }).warning ?? "", /192\.168\.1\.50/);
+		assert.match((res as { warning?: string }).warning ?? "", new RegExp(LAN_ENV));
+		// A public host is still refused — the opt-in is about the LAN, not http.
+		assert.equal(ok("http://remote.example.com/v1"), false);
+		// And cloud metadata never counts as a LAN host.
+		assert.equal(ok("http://169.254.169.254/v1"), false);
+	});
+
+	it("refuses non-http(s) schemes and unparseable input", () => {
+		assert.equal(ok("ftp://example.com/v1"), false);
+		assert.equal(ok("file:///etc/passwd"), false);
+		assert.equal(ok("not a url"), false);
+	});
+});

--- a/src/infra/net/credential-transport.ts
+++ b/src/infra/net/credential-transport.ts
@@ -1,0 +1,141 @@
+/**
+ * Cleartext-credential gate — "may this URL carry an API key?".
+ *
+ * Brigade sends provider API keys as `Authorization: Bearer` headers. Over
+ * plain `http://` those keys cross the wire in the clear, readable by anyone
+ * on the path (café Wi-Fi, a hotel NAT, a compromised switch). But cleartext
+ * MUST keep working for local inference: Ollama defaults to
+ * `http://localhost:11434`, and LM Studio / llama.cpp sit on
+ * `http://127.0.0.1:<port>`. Traffic to those never leaves the machine, so
+ * there is no wire to sniff.
+ *
+ * Hence the rule this module encodes: cleartext is allowed ONLY to a loopback
+ * destination; everything else must be `https://`.
+ *
+ * This is the mirror image of `fetch-guard.ts`. The SSRF guard asks "is this
+ * target private, and therefore off-limits?"; this gate asks "is this target
+ * MY OWN machine, and therefore safe to talk to in the clear?". The private-
+ * network set is shared with the SSRF classifier rather than re-derived here.
+ */
+
+import { isIPv4, isIPv6 } from "node:net";
+
+import { classifyHostnameSync } from "./fetch-guard.js";
+
+/**
+ * Escape hatch for an operator who genuinely runs inference on ANOTHER box on
+ * their LAN (`http://192.168.1.50:11434`) and can't put TLS in front of it.
+ * Off by default — see `checkCredentialTransport` for the reasoning — and
+ * every call site that honours it reports the fact to the operator.
+ */
+const ALLOW_LAN_ENV = "BRIGADE_ALLOW_INSECURE_LAN_ENDPOINTS";
+
+/**
+ * Does traffic to this hostname stay on the local machine?
+ *
+ * Takes a hostname — `new URL(...).hostname`, NOT a raw URL. A substring test
+ * on a raw URL would happily accept `http://localhost.evil.tld/` and
+ * `http://127.0.0.1.evil.tld/`, which are ordinary public names that merely
+ * begin with a loopback-looking label; only a parsed hostname compared whole
+ * is safe.
+ *
+ * Loopback means: the exact name `localhost` (RFC 6761 reserves it for the
+ * loopback interface), anything in `127.0.0.0/8` (not just `127.0.0.1` —
+ * `127.0.0.2` is loopback too), `::1`, its IPv4-mapped spellings, and the
+ * unspecified addresses `0.0.0.0` / `::`, which every platform we ship to
+ * connects to the local host.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+	const host = hostname.trim().toLowerCase();
+	if (!host) return false;
+	// `URL.hostname` KEEPS the brackets on an IPv6 literal (`[::1]`, and even
+	// `[::ffff:7f00:1]`), so strip them before handing the address to node:net.
+	const stripped = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+	if (stripped === "localhost") return true;
+	if (isIPv4(stripped)) {
+		// 127.0.0.0/8 — the whole block. `isIPv4` already guarantees a canonical
+		// dotted quad, so the first label is a plain number.
+		const first = Number.parseInt(stripped.split(".")[0] ?? "", 10);
+		return first === 127 || stripped === "0.0.0.0";
+	}
+	// Drop a zone identifier (`::1%lo0`) before classifying — the address is
+	// what we judge; the zone only ever routes locally.
+	const noZone = stripped.split("%", 1)[0] ?? stripped;
+	if (isIPv6(noZone)) {
+		if (noZone === "::1" || noZone === "::") return true;
+		// IPv4-mapped loopback. `new URL()` rewrites `::ffff:127.0.0.1` into its
+		// compressed hex form `::ffff:7f00:1`, so accept both spellings.
+		const dotted = noZone.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+		if (dotted) return isLoopbackHostname(dotted[1] ?? "");
+		const hex = noZone.match(/^::ffff:([0-9a-f]{1,4}):[0-9a-f]{1,4}$/);
+		if (hex) return Number.parseInt(hex[1] ?? "", 16) >>> 8 === 127;
+		return false;
+	}
+	return false;
+}
+
+/**
+ * Is this hostname a private/LAN address (RFC1918, CGNAT, link-local, ULA,
+ * `.local`/`.internal`)?
+ *
+ * Derived from the SSRF classifier instead of a second, subtly-different copy
+ * of the ranges: a host is "private" exactly when the default classifier
+ * refuses it but the `allowPrivateNetwork` classifier accepts it. That
+ * difference IS the private-network set — and because cloud-metadata hosts are
+ * refused in BOTH modes, `169.254.169.254` and friends can never fall into it.
+ */
+function isPrivateNetworkHostname(hostname: string): boolean {
+	if (classifyHostnameSync(hostname) === null) return false;
+	return classifyHostnameSync(hostname, { allowPrivateNetwork: true }) === null;
+}
+
+/**
+ * Verdict from `checkCredentialTransport`. `warning` is set when the URL was
+ * only allowed because the operator opted into insecure LAN endpoints — call
+ * sites that can talk to the operator should surface it. `reason` is a
+ * finished, printable line in the CLI's voice.
+ */
+export type CredentialTransportCheck = { ok: true; warning?: string } | { ok: false; reason: string };
+
+/**
+ * May a provider API key be sent to `rawUrl`?
+ *
+ * `https://` — always. `http://` — only to loopback (see `isLoopbackHostname`).
+ *
+ * LAN addresses (10/8, 172.16/12, 192.168/16, `.local`, …) are deliberately NOT
+ * loopback and are refused by default. A LAN is a shared broadcast domain with
+ * other people's laptops, printers and IoT gear on it; "inside the office
+ * network" is not a confidentiality boundary, and a key sent across it is a key
+ * anyone on that segment can read. An operator running Ollama on another box can
+ * put TLS in front of it, or set `BRIGADE_ALLOW_INSECURE_LAN_ENDPOINTS=1` to
+ * accept that risk knowingly — an explicit, reported choice rather than a silent
+ * default.
+ */
+export function checkCredentialTransport(rawUrl: string): CredentialTransportCheck {
+	let parsed: URL;
+	try {
+		parsed = new URL(rawUrl);
+	} catch {
+		return { ok: false, reason: "That doesn't look like a URL. Use https://host/v1 — or http:// for a server on this machine." };
+	}
+	if (parsed.protocol === "https:") return { ok: true };
+	if (parsed.protocol !== "http:") {
+		return {
+			ok: false,
+			reason: `Brigade only talks to http:// or https:// endpoints — ${parsed.protocol}// isn't supported.`,
+		};
+	}
+	if (isLoopbackHostname(parsed.hostname)) return { ok: true };
+	if (process.env[ALLOW_LAN_ENV] === "1" && isPrivateNetworkHostname(parsed.hostname)) {
+		return {
+			ok: true,
+			warning: `Sending your API key unencrypted to ${parsed.host} because ${ALLOW_LAN_ENV}=1 is set. Anyone on that network can read it.`,
+		};
+	}
+	return {
+		ok: false,
+		reason:
+			`Refusing to send your API key unencrypted to ${parsed.host} — over http:// anyone on the network can read it. ` +
+			`Use https:// for a remote endpoint, or point Brigade at a server on this machine (Ollama runs on http://localhost:11434).`,
+	};
+}

--- a/src/infra/net/credential-transport.ts
+++ b/src/infra/net/credential-transport.ts
@@ -95,7 +95,9 @@ function isPrivateNetworkHostname(hostname: string): boolean {
  * sites that can talk to the operator should surface it. `reason` is a
  * finished, printable line in the CLI's voice.
  */
-export type CredentialTransportCheck = { ok: true; warning?: string } | { ok: false; reason: string };
+export type CredentialTransportCheck =
+	| { ok: true; warning?: string }
+	| { ok: false; reason: string; host?: string };
 
 /**
  * May a provider API key be sent to `rawUrl`?
@@ -134,6 +136,7 @@ export function checkCredentialTransport(rawUrl: string): CredentialTransportChe
 	}
 	return {
 		ok: false,
+		host: parsed.host,
 		reason:
 			`Refusing to send your API key unencrypted to ${parsed.host} — over http:// anyone on the network can read it. ` +
 			`Use https:// for a remote endpoint, or point Brigade at a server on this machine (Ollama runs on http://localhost:11434).`,

--- a/src/integrations/provider-discovery.test.ts
+++ b/src/integrations/provider-discovery.test.ts
@@ -86,22 +86,27 @@ describe("fetchOpenAICompatibleModelIds — live model discovery (NVIDIA NIM etc
 				{ id: "qwen/qwen2.5-coder-32b-instruct" },
 			],
 		});
-		const ids = await fetchOpenAICompatibleModelIds("https://integrate.api.nvidia.com/v1", "nvapi-xxx");
-		assert.deepEqual(ids, [
-			"meta/llama-3.3-70b-instruct",
-			"deepseek-ai/deepseek-r1",
-			"qwen/qwen2.5-coder-32b-instruct",
-		]);
+		const listed = await fetchOpenAICompatibleModelIds("https://integrate.api.nvidia.com/v1", "nvapi-xxx");
+		assert.deepEqual(listed, {
+			ok: true,
+			ids: ["meta/llama-3.3-70b-instruct", "deepseek-ai/deepseek-r1", "qwen/qwen2.5-coder-32b-instruct"],
+		});
 	});
 
-	it("returns null on a failed request (bad key / unreachable) — never throws", async () => {
+	it("reports unavailable on a failed request (bad key / unreachable) — never throws", async () => {
 		mockFetch({ error: "unauthorized" }, false);
-		assert.equal(await fetchOpenAICompatibleModelIds("https://integrate.api.nvidia.com/v1", "bad"), null);
+		assert.deepEqual(await fetchOpenAICompatibleModelIds("https://integrate.api.nvidia.com/v1", "bad"), {
+			ok: false,
+			reason: "unavailable",
+		});
 	});
 
-	it("returns null when the endpoint yields no usable ids", async () => {
+	it("reports unavailable when the endpoint yields no usable ids", async () => {
 		mockFetch({ data: [] });
-		assert.equal(await fetchOpenAICompatibleModelIds("https://integrate.api.nvidia.com/v1", "nvapi-xxx"), null);
+		assert.deepEqual(await fetchOpenAICompatibleModelIds("https://integrate.api.nvidia.com/v1", "nvapi-xxx"), {
+			ok: false,
+			reason: "unavailable",
+		});
 	});
 });
 
@@ -165,5 +170,71 @@ describe("describeModelProbe — actionable, jargon-free copy", () => {
 
 	it("distinguishes an unreachable provider from a dead model", () => {
 		assert.match(describeModelProbe({ ok: false, reason: "provider_unreachable" }, "NVIDIA NIM", "m")!, /reach/i);
+	});
+
+	it("passes the transport gate's own line through verbatim", () => {
+		const msg = describeModelProbe(
+			{ ok: false, reason: "insecure_transport", detail: "Refusing to send your API key unencrypted to evil.tld." },
+			"Custom",
+			"m",
+		);
+		assert.equal(msg, "Refusing to send your API key unencrypted to evil.tld.");
+	});
+});
+
+/**
+ * The credential never leaves the machine in the clear. These assert on the
+ * REQUESTS ACTUALLY MADE (not just the return value) — a refusal that still
+ * fired the request would be no refusal at all.
+ */
+describe("cleartext-credential gate — API keys never cross a plaintext hop", () => {
+	function recordingFetch(payload: unknown): { urls: string[]; authed: string[] } {
+		const seen = { urls: [] as string[], authed: [] as string[] };
+		globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+			seen.urls.push(String(url));
+			const headers = (init?.headers ?? {}) as Record<string, string>;
+			if (headers.Authorization) seen.authed.push(String(url));
+			return { ok: true, status: 200, json: async () => payload } as unknown as Response;
+		}) as typeof fetch;
+		return seen;
+	}
+
+	it("allows an https remote endpoint", async () => {
+		recordingFetch({ data: [{ id: "m" }] });
+		const listed = await fetchOpenAICompatibleModelIds("https://api.example.com/v1", "k");
+		assert.deepEqual(listed, { ok: true, ids: ["m"] });
+	});
+
+	for (const local of ["http://localhost:11434/v1", "http://127.0.0.1:1234/v1", "http://127.0.0.2/v1", "http://[::1]:8080/v1"]) {
+		it(`allows the local inference endpoint ${local}`, async () => {
+			const seen = recordingFetch({ data: [{ id: "m" }] });
+			const listed = await fetchOpenAICompatibleModelIds(local, "k");
+			assert.deepEqual(listed, { ok: true, ids: ["m"] });
+			assert.equal(seen.authed.length, 1, "the key IS sent to a local server");
+		});
+	}
+
+	for (const remote of ["http://remote.example.com/v1", "http://localhost.evil.tld/v1", "http://127.0.0.1.evil.tld/v1"]) {
+		it(`refuses the cleartext remote endpoint ${remote}`, async () => {
+			const seen = recordingFetch({ data: [{ id: "m" }] });
+			const listed = await fetchOpenAICompatibleModelIds(remote, "k");
+			assert.equal(listed.ok, false);
+			assert.equal((listed as { reason?: string }).reason, "insecure_transport");
+			assert.match((listed as { detail?: string }).detail ?? "", /https:\/\//);
+			assert.deepEqual(seen.urls, [], "no request at all — not a stripped-header request");
+		});
+	}
+
+	it("probeModelReachable refuses cleartext to a remote host without probing", async () => {
+		const seen = recordingFetch({});
+		const res = await probeModelReachable("http://remote.example.com/v1", "k", "m");
+		assert.equal(res.ok, false);
+		assert.equal((res as { reason?: string }).reason, "insecure_transport");
+		assert.deepEqual(seen.urls, []);
+	});
+
+	it("probeModelReachable still probes a local server over http", async () => {
+		globalThis.fetch = (async () => ({ ok: true, status: 200 }) as unknown as Response) as typeof fetch;
+		assert.deepEqual(await probeModelReachable("http://localhost:11434/v1", "k", "m"), { ok: true });
 	});
 });

--- a/src/integrations/provider-discovery.ts
+++ b/src/integrations/provider-discovery.ts
@@ -17,6 +17,8 @@
 
 import { getModels, type KnownProvider } from "@earendil-works/pi-ai";
 
+import { checkCredentialTransport } from "../infra/net/credential-transport.js";
+
 const TIMEOUT_MS = 5000;
 
 export interface DiscoveredModelMeta {
@@ -38,6 +40,12 @@ const EMPTY: DiscoveryResult = { exists: false, meta: {} };
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 
 async function fetchJson(url: string, apiKey?: string): Promise<unknown | null> {
+	// Backstop for the cleartext-credential gate: a `baseUrl` can arrive from a
+	// hand-edited models.json or a config/RPC write, not just the wizard, so the
+	// check lives HERE — where the key is attached — as well as at the entry
+	// points. Callers that can talk to the operator run the same check first so
+	// they can print the reason; this one just refuses to leak.
+	if (apiKey && !checkCredentialTransport(url).ok) return null;
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 	try {
@@ -206,29 +214,41 @@ export async function listOpenRouterModels(): Promise<LiveCloudModel[]> {
 }
 
 /**
+ * Outcome of a live model-list fetch. `insecure_transport` means the key was
+ * never sent — the endpoint would have carried it in the clear (see
+ * `infra/net/credential-transport.ts`); `unavailable` is the ordinary
+ * bad-key/unreachable/empty-list case. `detail` is a finished operator-facing
+ * line when we have one.
+ */
+export type ModelIdsResult =
+	| { ok: true; ids: string[] }
+	| { ok: false; reason: "insecure_transport" | "unavailable"; detail?: string };
+
+/**
  * List an OpenAI-compatible endpoint's served models via `GET {baseUrl}/models`
  * (Bearer auth). Used for LIVE model discovery on catalog providers flagged
  * `liveModels` — e.g. NVIDIA NIM (https://integrate.api.nvidia.com/v1), whose
  * served set changes over time and isn't in Pi's bundled catalog. Doubles as an
- * online key check (a bad key → the request fails → null). Filters out obvious
- * non-chat models (embedding / reranking). Returns model ids, or `null` on any
- * failure so the caller can surface an actionable error rather than persisting a
+ * online key check (a bad key → the request fails → not-ok). Filters out obvious
+ * non-chat models (embedding / reranking). Returns a typed failure on any
+ * problem so the caller can surface an actionable error rather than persisting a
  * dead provider. Never throws.
  */
-export async function fetchOpenAICompatibleModelIds(
-	baseUrl: string,
-	apiKey: string,
-): Promise<string[] | null> {
+export async function fetchOpenAICompatibleModelIds(baseUrl: string, apiKey: string): Promise<ModelIdsResult> {
 	const url = `${baseUrl.replace(/\/+$/, "")}/models`;
+	// Refuse BEFORE the key is attached, and hand the caller the reason so the
+	// operator sees "http:// to a remote host" rather than "key rejected".
+	const transport = checkCredentialTransport(url);
+	if (!transport.ok) return { ok: false, reason: "insecure_transport", detail: transport.reason };
 	const body = (await fetchJson(url, apiKey)) as { data?: Array<{ id?: unknown }> } | null;
-	if (!body || !Array.isArray(body.data)) return null;
+	if (!body || !Array.isArray(body.data)) return { ok: false, reason: "unavailable" };
 	const ids = body.data
 		.map((m) => (typeof m?.id === "string" ? m.id.trim() : ""))
 		// Substring (not word-bounded) — NVIDIA fuses the type into the id, e.g.
 		// `nv-embedqa-e5-v5`, `llama-3.2-nv-rerankqa-1b-v2`, where a `\b` after
 		// "embed"/"rerank" wouldn't match.
 		.filter((id) => id.length > 0 && !/(embed|rerank)/i.test(id));
-	return ids.length > 0 ? ids : null;
+	return ids.length > 0 ? { ok: true, ids } : { ok: false, reason: "unavailable" };
 }
 
 /* ──────────────────── model reachability probe ──────────────────── */
@@ -237,20 +257,30 @@ export async function fetchOpenAICompatibleModelIds(
  * Result of probing whether a model actually RESPONDS — not just whether it's
  * listed. `model_unavailable`: the endpoint is up but the model returns nothing
  * (the NVIDIA-lists-dead-models case). `provider_unreachable`: the whole endpoint
- * is down/blocked. `auth`: the key was rejected. `error`: an HTTP error with detail.
+ * is down/blocked. `auth`: the key was rejected. `insecure_transport`: the endpoint
+ * would have carried the key in the clear, so nothing was sent. `error`: an HTTP
+ * error with detail.
  */
 export type ModelProbeResult =
 	| { ok: true }
-	| { ok: false; reason: "model_unavailable" | "provider_unreachable" | "auth" | "error"; detail?: string };
+	| {
+			ok: false;
+			reason: "model_unavailable" | "provider_unreachable" | "auth" | "insecure_transport" | "error";
+			detail?: string;
+	  };
 
 /** Is the OpenAI-compatible endpoint reachable at all? (`/models`, incl. a 401 —
  *  an auth rejection still proves the host is up.) Used to tell a dead MODEL apart
  *  from an unreachable PROVIDER. Never throws. */
 async function isEndpointReachable(baseUrl: string, apiKey: string): Promise<boolean> {
+	const url = `${baseUrl.replace(/\/+$/, "")}/models`;
+	// Same cleartext-credential gate as the probe itself — a fallback check must
+	// not become the hole the main check closed.
+	if (apiKey && !checkCredentialTransport(url).ok) return false;
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), 6000);
 	try {
-		const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
+		const res = await fetch(url, {
 			signal: controller.signal,
 			headers: { Accept: "application/json", ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}) },
 		});
@@ -277,10 +307,17 @@ export async function probeModelReachable(
 	opts?: { timeoutMs?: number },
 ): Promise<ModelProbeResult> {
 	const timeoutMs = opts?.timeoutMs ?? 12_000;
+	const url = `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+	// Refuse before the key is attached. A models.json can name an http:// host
+	// the wizard never saw, and this is the path that reaches it with a key.
+	const transport = checkCredentialTransport(url);
+	if (apiKey && !transport.ok) {
+		return { ok: false, reason: "insecure_transport", detail: transport.reason };
+	}
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
 	try {
-		const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/chat/completions`, {
+		const res = await fetch(url, {
 			method: "POST",
 			signal: controller.signal,
 			headers: { "Content-Type": "application/json", ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}) },
@@ -317,6 +354,9 @@ export function describeModelProbe(result: ModelProbeResult, providerName: strin
 			return `Can't reach ${providerName} right now — check your connection or the service status.`;
 		case "auth":
 			return `${providerName} rejected the API key.`;
+		case "insecure_transport":
+			// Already a finished, actionable line from the transport gate.
+			return result.detail ?? `${providerName} is configured on http:// — Brigade won't send your API key in the clear.`;
 		default:
 			return `${providerName} returned an error${result.detail ? ` (${result.detail})` : ""}.`;
 	}
@@ -459,7 +499,13 @@ export async function fetchGitHubCopilotModels(copilotToken: string): Promise<Li
 	try {
 		const { getGitHubCopilotBaseUrl } = await import("@earendil-works/pi-ai/oauth");
 		const baseUrl = getGitHubCopilotBaseUrl(copilotToken);
-		const res = await fetch(`${baseUrl}/models`, {
+		const url = `${baseUrl}/models`;
+		// The host here is read out of the token's own `proxy-ep=` claim, so it is
+		// only as trustworthy as the token. Same cleartext gate as everywhere else:
+		// a Copilot token is a credential, and GitHub serves this over https —
+		// anything else falls back to Pi's bundled catalog rather than leaking.
+		if (!checkCredentialTransport(url).ok) return cached?.models ?? [];
+		const res = await fetch(url, {
 			signal: controller.signal,
 			headers: {
 				Accept: "application/json",

--- a/src/security/media-path-guard.test.ts
+++ b/src/security/media-path-guard.test.ts
@@ -75,10 +75,16 @@ describe("validateOutboundMediaPath", () => {
 		// macOS symlinks /etc -> /private/etc, so realpathSync turns /etc/passwd
 		// into /private/etc/passwd and the literal "/etc" prefix never matched.
 		// Both spellings must be refused, whichever one the caller hands us.
+		//
+		// The resolved spelling is read from the platform rather than hardcoded:
+		// on Linux /etc resolves to itself, on macOS to /private/etc. Naming
+		// /private/etc literally would assert a path that is nothing special on
+		// Linux — and would fail there for the right reason.
 		if (process.platform === "win32") return;
 		assert.equal(validateOutboundMediaPath("/etc/passwd").ok, false);
-		assert.equal(validateOutboundMediaPath("/private/etc/passwd").ok, false);
 		assert.equal(validateOutboundMediaPath("/etc/ssh/sshd_config").ok, false);
+		const resolvedEtc = fs.realpathSync("/etc");
+		assert.equal(validateOutboundMediaPath(path.join(resolvedEtc, "passwd")).ok, false);
 	});
 
 	it("resolves symlinks before checking (innocent name → denied target)", () => {

--- a/src/security/media-path-guard.test.ts
+++ b/src/security/media-path-guard.test.ts
@@ -71,6 +71,16 @@ describe("validateOutboundMediaPath", () => {
 		assert.equal(validateOutboundMediaPath(target).ok, false);
 	});
 
+	it("blocks a system file through the platform's own symlinked root", () => {
+		// macOS symlinks /etc -> /private/etc, so realpathSync turns /etc/passwd
+		// into /private/etc/passwd and the literal "/etc" prefix never matched.
+		// Both spellings must be refused, whichever one the caller hands us.
+		if (process.platform === "win32") return;
+		assert.equal(validateOutboundMediaPath("/etc/passwd").ok, false);
+		assert.equal(validateOutboundMediaPath("/private/etc/passwd").ok, false);
+		assert.equal(validateOutboundMediaPath("/etc/ssh/sshd_config").ok, false);
+	});
+
 	it("resolves symlinks before checking (innocent name → denied target)", () => {
 		const secret = path.join(dir, "brigade.json");
 		fs.writeFileSync(secret, "secret");

--- a/src/security/media-path-guard.ts
+++ b/src/security/media-path-guard.ts
@@ -49,15 +49,41 @@ const SENSITIVE_BASENAMES = new Set([
 /** Path fragments that mark a credentials directory (platform-normalized separators). */
 const SENSITIVE_DIR_NAMES = [".ssh", ".aws", ".gnupg", ".kube", ".docker", "gcloud", ".convex-data"];
 
-/** Resolved-prefix roots that are off-limits regardless of filename. */
+let cachedSystemRoots: string[] | undefined;
+
+/**
+ * Resolved-prefix roots that are off-limits regardless of filename.
+ *
+ * Both spellings of each root are returned, because the caller compares against
+ * a `realpathSync`'d path and some platforms symlink their own system dirs:
+ * on macOS `/etc` IS a symlink to `/private/etc`, so `/etc/passwd` resolves to
+ * `/private/etc/passwd` and never matches the literal `/etc` prefix. The
+ * symlink resolution that stops a `photo.jpg -> /etc/shadow` trick is exactly
+ * what defeated this check.
+ */
 function systemRoots(): string[] {
+	if (cachedSystemRoots) return cachedSystemRoots;
+	let roots: string[];
 	if (process.platform === "win32") {
-		const roots: string[] = [];
-		if (process.env.SystemRoot) roots.push(process.env.SystemRoot);
-		else roots.push("C:\\Windows");
-		return roots;
+		roots = [process.env.SystemRoot || "C:\\Windows"];
+	} else {
+		roots = ["/etc", "/proc", "/sys", "/dev", "/boot", "/root"];
 	}
-	return ["/etc", "/proc", "/sys", "/dev", "/boot", "/root"];
+	const all = new Set(roots);
+	for (const r of roots) {
+		try {
+			all.add(fs.realpathSync(r));
+		} catch {
+			/* root absent on this platform — the literal spelling still stands */
+		}
+	}
+	cachedSystemRoots = [...all];
+	return cachedSystemRoots;
+}
+
+/** Test seam: the root set is process-lifetime cached. */
+export function __resetSystemRootsCacheForTests(): void {
+	cachedSystemRoots = undefined;
 }
 
 /**

--- a/src/storage/convex/exec-approval-store.ts
+++ b/src/storage/convex/exec-approval-store.ts
@@ -5,6 +5,7 @@ import { api } from "../../../convex/_generated/api.js";
 
 import { getReactiveConvexClient } from "./client.js";
 
+import { validateApprovalPattern } from "../../core/exec-pattern-guard.js";
 import { NotImplementedYet } from "../store.js";
 import type { ApprovalsSnapshot, ExecApprovalStore } from "../store.js";
 
@@ -20,6 +21,29 @@ function cacheKey(ownerId: string, agentId: string): string {
 
 function normaliseCommand(cmd: string): string {
 	return cmd.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Fold approval rows into the sync-gate's lookup shape. Patterns are compiled
+ * ONCE here — `decideSync` runs on every bash tool call and must not pay for a
+ * recompile — and a pattern the write-time guard refuses (malformed, or slow
+ * enough to hang the gate) is cached as `re: null` so it's simply never
+ * evaluated. Rows predate the guard, so the check belongs on the read path too.
+ */
+function toCachedRows(
+	rows: ReadonlyArray<{ kind: "exact" | "pattern"; valueNormalised: string; value: string }>,
+): CachedRows {
+	const commands = new Set<string>();
+	const patterns: CachedRows["patterns"] = [];
+	for (const r of rows) {
+		if (r.kind === "exact") {
+			commands.add(r.valueNormalised);
+			continue;
+		}
+		const checked = validateApprovalPattern(r.value);
+		patterns.push({ raw: r.value, re: checked.ok ? checked.regex : null });
+	}
+	return { commands, patterns };
 }
 
 export class ConvexExecApprovalStore implements ExecApprovalStore {
@@ -108,23 +132,12 @@ export class ConvexExecApprovalStore implements ExecApprovalStore {
 			{ ownerId: this.deps.ownerId, agentId },
 			(rows) => {
 				const list = rows as Array<{ kind: "exact" | "pattern"; valueNormalised: string; value: string }>;
-				const commands = new Set<string>();
-				const patterns: CachedRows["patterns"] = [];
-				for (const r of list) {
-					if (r.kind === "exact") commands.add(r.valueNormalised);
-					else {
-						try {
-							patterns.push({ raw: r.value, re: new RegExp(r.value) });
-						} catch {
-							patterns.push({ raw: r.value, re: null });
-						}
-					}
-				}
-				cache.set(cacheKey(this.deps.ownerId, agentId), { commands, patterns });
+				const cached = toCachedRows(list);
+				cache.set(cacheKey(this.deps.ownerId, agentId), cached);
 				try {
 					onChange({
-						commandCount: commands.size,
-						patternCount: patterns.length,
+						commandCount: cached.commands.size,
+						patternCount: cached.patterns.length,
 					} as ApprovalsSnapshot);
 				} catch {
 					// Subscriber threw — stay alive.
@@ -145,19 +158,7 @@ export class ConvexExecApprovalStore implements ExecApprovalStore {
 			ownerId: this.deps.ownerId,
 			agentId,
 		})) as Array<{ kind: "exact" | "pattern"; valueNormalised: string; value: string }>;
-		const commands = new Set<string>();
-		const patterns: CachedRows["patterns"] = [];
-		for (const r of rows) {
-			if (r.kind === "exact") commands.add(r.valueNormalised);
-			else {
-				try {
-					patterns.push({ raw: r.value, re: new RegExp(r.value) });
-				} catch {
-					patterns.push({ raw: r.value, re: null });
-				}
-			}
-		}
-		cache.set(cacheKey(this.deps.ownerId, agentId), { commands, patterns });
+		cache.set(cacheKey(this.deps.ownerId, agentId), toCachedRows(rows));
 	}
 
 	__unused = NotImplementedYet;

--- a/src/tui/approval-prompt.test.ts
+++ b/src/tui/approval-prompt.test.ts
@@ -172,3 +172,51 @@ test("pattern state stays within width (regex help line used to overflow narrow 
 		assert.ok(widest <= width, `width ${width}: widest line is ${widest}`);
 	}
 });
+
+test("a pattern the gate would refuse is reported inline instead of resolving", () => {
+	let resolution: { decision: string; pattern?: string } | null = null;
+	const prompt = new ApprovalPrompt({
+		tui: fakeTui(),
+		request: makeRequest(),
+		onResolve: (r) => {
+			resolution = r;
+		},
+	});
+	const internals = prompt as unknown as {
+		enterPatternMode: () => void;
+		patternInput: { onSubmit: (value: string) => void } | null;
+	};
+	internals.enterPatternMode();
+	// Catastrophic backtracker — the allowlist won't store it, so the operator
+	// has to hear about it here, where they can still fix the typo.
+	internals.patternInput?.onSubmit("^git (a+)+$");
+	assert.equal(resolution, null, "stayed in pattern mode");
+	const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+	const rendered = prompt.render(100).map(stripAnsi).join("\n");
+	assert.match(rendered, /backtracks catastrophically/);
+	// A malformed regex gets the same treatment.
+	internals.patternInput?.onSubmit("[unclosed");
+	assert.equal(resolution, null);
+	assert.match(prompt.render(100).map(stripAnsi).join("\n"), /invalid regex pattern/);
+	// Fixing it resolves normally.
+	internals.patternInput?.onSubmit("^git status$");
+	assert.deepEqual(resolution, { decision: "allow-pattern", pattern: "^git status$" });
+});
+
+test("the inline pattern error never overflows a narrow terminal", () => {
+	const prompt = new ApprovalPrompt({
+		tui: fakeTui(),
+		request: makeRequest(),
+		onResolve: () => {},
+	});
+	const internals = prompt as unknown as {
+		enterPatternMode: () => void;
+		patternInput: { onSubmit: (value: string) => void } | null;
+	};
+	internals.enterPatternMode();
+	internals.patternInput?.onSubmit("^(a|a)*$");
+	for (const width of [83, 50, 30, 12]) {
+		const widest = maxLineWidth(prompt.render(width));
+		assert.ok(widest <= width, `width ${width}: widest line is ${widest}`);
+	}
+});

--- a/src/tui/approval-prompt.ts
+++ b/src/tui/approval-prompt.ts
@@ -9,7 +9,9 @@
  *   1. `"menu"`    — four-letter shortcut row (Y/A/P/N) for the four
  *                    operator decisions.
  *   2. `"pattern"` — operator picked "P" (Allow pattern); we collect a
- *                    regex string with Pi-TUI's `Input` then resolve.
+ *                    regex string with Pi-TUI's `Input` then resolve. A regex
+ *                    the gate would refuse to store is reported inline and the
+ *                    operator stays here to fix it.
  *
  * Visual style mirrors the user's mock:
  *
@@ -38,6 +40,10 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 
+import {
+	describeApprovalPatternRefusal,
+	validateApprovalPattern,
+} from "../core/exec-pattern-guard.js";
 import { brand } from "../ui/theme.js";
 
 export type ApprovalDecisionKind =
@@ -119,6 +125,8 @@ function deriveTitle(request: ApprovalRenderRequest): string {
 export class ApprovalPrompt implements Component {
 	private state: "menu" | "pattern" = "menu";
 	private patternInput: Input | null = null;
+	/** Refusal text for the last pattern the operator submitted, if any. */
+	private patternError: string | null = null;
 	private resolved = false;
 	/** Last rendered width — captured so `pattern` mode can re-frame the input. */
 	private lastWidth = 80;
@@ -183,7 +191,10 @@ export class ApprovalPrompt implements Component {
 			const pad = " ".repeat(Math.max(0, inner - visibleWidth(fitted)));
 			return `${brand.dim("│ ")}${fitted}${pad}${brand.dim(" │")}`;
 		});
-		return [titleLine, helpLine, helpLine2, ...framedInput, bottom];
+		const errorLines = this.patternError
+			? [boxLine(inner, brand.error(truncateForBox(this.patternError, inner)))]
+			: [];
+		return [titleLine, helpLine, helpLine2, ...errorLines, ...framedInput, bottom];
 	}
 
 	handleInput(keyData: string): void {
@@ -243,6 +254,7 @@ export class ApprovalPrompt implements Component {
 
 	private enterPatternMode(): void {
 		this.state = "pattern";
+		this.patternError = null;
 		const input = new Input();
 		input.onSubmit = (value: string): void => {
 			const pattern = value.trim();
@@ -252,6 +264,18 @@ export class ApprovalPrompt implements Component {
 				this.resolve({ decision: "allow-once" });
 				return;
 			}
+			// The gate refuses to store a malformed or catastrophically slow
+			// regex, so say so HERE — where the operator can fix the typo —
+			// rather than accepting the keystroke and dropping the pattern
+			// server-side. Stay in pattern mode with the text still in the
+			// input; Esc is always the way out.
+			const checked = validateApprovalPattern(pattern);
+			if (!checked.ok) {
+				this.patternError = describeApprovalPatternRefusal(checked.refusal);
+				this.opts.tui.requestRender();
+				return;
+			}
+			this.patternError = null;
 			this.resolve({ decision: "allow-pattern", pattern });
 		};
 		input.onEscape = (): void => {

--- a/src/ui/attachments.test.ts
+++ b/src/ui/attachments.test.ts
@@ -271,10 +271,22 @@ describe("extractAttachmentPaths — the disambiguation rule", () => {
 	it("captures a backslash-escaped path — what macOS/iTerm pastes on drag-drop", () => {
 		// Regression: the alternation used to try `[^\s"']` first, which ate the lone
 		// backslash and truncated the path at `…/my\`.
-		const escaped = spaced.replace(/ /g, "\\ ");
+		const escaped = spaced.replace(/([\\ ])/g, "\\$1");
 		const r = extractAttachmentPaths(`${escaped} read it`);
 		assert.equal(r.staged.length, 1);
 		assert.equal(r.staged[0]?.path, spaced);
+	});
+
+	it("captures a path whose NAME contains a backslash — the escape a terminal doubles", () => {
+		// `\` is a legal filename character on POSIX and an illegal one on Windows,
+		// so this paste shape only exists off Windows.
+		if (process.platform === "win32") return;
+		const weird = path.join(dir, "back\\slash report.pdf");
+		fs.writeFileSync(weird, "%PDF-1.4 weird");
+		const escaped = weird.replace(/([\\ ])/g, "\\$1");
+		const r = extractAttachmentPaths(`${escaped} read it`);
+		assert.equal(r.staged.length, 1);
+		assert.equal(r.staged[0]?.path, weird);
 	});
 
 	it("captures a file:// URI — what GNOME/Wayland pastes on drag-drop", () => {

--- a/src/ui/attachments.ts
+++ b/src/ui/attachments.ts
@@ -515,7 +515,13 @@ function tryStage(candidate: string, tier: Tier): StagedAttachment | null {
 /** Undo the escaping a terminal applies when it pastes a dropped path. */
 function decodeCandidate(raw: string): string {
 	let s = raw.trim();
-	s = s.replace(/\\ /g, " "); // macOS/iTerm escape spaces
+	// macOS/iTerm escape EVERY meta-character in a dropped path, not just the
+	// spaces: a file called `back\slash report.pdf` pastes as
+	// `back\\slash\ report.pdf`, and undoing only the spaces leaves a path that
+	// names nothing. One pass over the pairs, so a decoded backslash can never
+	// re-form an escape. A leading `\\` is a Windows UNC root, not an escape.
+	const uncRoot = s.startsWith("\\\\") ? "\\\\" : "";
+	s = uncRoot + s.slice(uncRoot.length).replace(/\\([\\ ])/g, "$1");
 	if (s.startsWith("file://")) s = s.slice("file://".length);
 	// A file:// URI is percent-encoded; a plain Windows path is not, and decoding
 	// one is harmless (no % in a normal path). Guard anyway — a malformed escape

--- a/src/ui/clipboard.test.ts
+++ b/src/ui/clipboard.test.ts
@@ -15,11 +15,18 @@
  */
 
 import { strict as assert } from "node:assert";
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 
 import { clipboardBackend, clipboardSpoolDir } from "./clipboard.js";
+
+// The spool dir is this PROCESS's own (mkdtemp'd on first use), so the suite must
+// take it with it — nothing else sweeps it for another 24 hours.
+after(() => {
+	fs.rmSync(clipboardSpoolDir(), { recursive: true, force: true });
+});
 
 describe("clipboardBackend — contract", () => {
 	it("returns a backend on every platform, never null", () => {
@@ -70,23 +77,45 @@ describe("clipboardSpoolDir", () => {
 		);
 	});
 
+	it("is a private, unguessable dir — a screenshot is not for the rest of the box", () => {
+		const dir = clipboardSpoolDir();
+		assert.notEqual(path.basename(dir), "brigade-attachments", "a fixed name can be pre-claimed");
+		// Windows has no POSIX mode bits to assert on.
+		if (process.platform !== "win32") {
+			assert.equal(fs.statSync(dir).mode & 0o777, 0o700);
+		}
+	});
+
+	it("hands back the same dir every call — a spooled path must stay valid", () => {
+		assert.equal(clipboardSpoolDir(), clipboardSpoolDir());
+	});
+
 	it("sweeps files older than the TTL, so pasted screenshots don't accumulate forever", () => {
 		const dir = clipboardSpoolDir();
-		const stale = path.join(dir, "clipboard-stale-test.png");
-		fs.writeFileSync(stale, "x");
-		// Backdate it two days.
-		const old = Date.now() - 48 * 60 * 60 * 1000;
-		fs.utimesSync(stale, new Date(old), new Date(old));
-		clipboardSpoolDir(); // sweeps on the way in
-		assert.equal(fs.existsSync(stale), false, "a stale spool file must be swept");
+		// Unique per run: the suite may run several processes at once, and a shared
+		// name would have them sweeping each other's probe.
+		const stale = path.join(dir, `clipboard-stale-${randomUUID()}.png`);
+		try {
+			fs.writeFileSync(stale, "x");
+			// Backdate it two days.
+			const old = Date.now() - 48 * 60 * 60 * 1000;
+			fs.utimesSync(stale, new Date(old), new Date(old));
+			clipboardSpoolDir(); // sweeps on the way in
+			assert.equal(fs.existsSync(stale), false, "a stale spool file must be swept");
+		} finally {
+			fs.rmSync(stale, { force: true });
+		}
 	});
 
 	it("leaves a FRESH spool file alone — the one we just wrote must survive", () => {
 		const dir = clipboardSpoolDir();
-		const fresh = path.join(dir, "clipboard-fresh-test.png");
-		fs.writeFileSync(fresh, "x");
-		clipboardSpoolDir();
-		assert.equal(fs.existsSync(fresh), true);
-		fs.unlinkSync(fresh);
+		const fresh = path.join(dir, `clipboard-fresh-${randomUUID()}.png`);
+		try {
+			fs.writeFileSync(fresh, "x");
+			clipboardSpoolDir();
+			assert.equal(fs.existsSync(fresh), true);
+		} finally {
+			fs.rmSync(fresh, { force: true });
+		}
 	});
 });

--- a/src/ui/clipboard.ts
+++ b/src/ui/clipboard.ts
@@ -340,7 +340,7 @@ const LINUX: ClipboardBackend = {
 				});
 				const buf = stdout as unknown as Buffer;
 				if (buf?.length > 0) {
-					fs.writeFileSync(dest, buf);
+					fs.writeFileSync(dest, buf, { mode: 0o600 });
 					return true;
 				}
 			} catch {
@@ -548,16 +548,59 @@ export function startClipboardService(onImage?: (imagePath: string) => void): Cl
 	};
 }
 
+/** How long a spooled bitmap survives. Long enough to re-open a session's images,
+ *  short enough that screenshots don't pile up in temp forever. */
+const SPOOL_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** This process's spool dir, created once. */
+let spoolDir: string | undefined;
+
+/**
+ * Spool dirs abandoned by earlier runs — and the fixed-name one older Brigades
+ * used. Each run now gets its own dir, so without this pass a crashed session's
+ * screenshots would have nobody left to sweep them.
+ */
+function sweepAbandonedSpools(keep: string): void {
+	try {
+		const cutoff = Date.now() - SPOOL_TTL_MS;
+		const root = os.tmpdir();
+		for (const name of fs.readdirSync(root)) {
+			if (!name.startsWith("brigade-attachments")) continue;
+			const p = path.join(root, name);
+			if (p === keep) continue;
+			try {
+				// lstat, so a symlink someone planted under that name is measured — and
+				// removed — as the link it is, never followed.
+				if (fs.lstatSync(p).mtimeMs < cutoff) fs.rmSync(p, { recursive: true, force: true });
+			} catch {
+				/* another user's, in use, or gone */
+			}
+		}
+	} catch {
+		/* unreadable temp root — sweeping is best-effort */
+	}
+}
+
 /** Where clipboard bitmaps are materialised. OS temp — never `~/.brigade`, which
  *  the convex-mode strict-zero guard requires to stay clean. Sweeps its own
  *  leavings, or every screenshot ever pasted would live on disk forever. */
 export function clipboardSpoolDir(): string {
-	const dir = path.join(os.tmpdir(), "brigade-attachments");
-	fs.mkdirSync(dir, { recursive: true });
+	if (spoolDir === undefined) {
+		// A FIXED name in a world-writable /tmp (mode 1777) is a path any local user
+		// can pre-create or symlink — the sticky bit stops deletion but NOT creation —
+		// and what we then write into it is whatever the operator just screenshotted.
+		// `mkdtempSync` takes a name with a random suffix, at mode 0700, so there is
+		// nothing to pre-claim and nothing for another account to read.
+		spoolDir = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-attachments-"));
+		sweepAbandonedSpools(spoolDir);
+	}
+	// Re-assert rather than test-then-create: a long-idle session's dir can be taken
+	// by the OS temp reaper (or another run's sweep) between two pastes.
+	fs.mkdirSync(spoolDir, { recursive: true, mode: 0o700 });
 	try {
-		const cutoff = Date.now() - 24 * 60 * 60 * 1000;
-		for (const name of fs.readdirSync(dir)) {
-			const p = path.join(dir, name);
+		const cutoff = Date.now() - SPOOL_TTL_MS;
+		for (const name of fs.readdirSync(spoolDir)) {
+			const p = path.join(spoolDir, name);
 			try {
 				if (fs.statSync(p).mtimeMs < cutoff) fs.unlinkSync(p);
 			} catch {
@@ -567,5 +610,5 @@ export function clipboardSpoolDir(): string {
 	} catch {
 		/* unreadable spool dir — pasting still works, we just don't sweep */
 	}
-	return dir;
+	return spoolDir;
 }

--- a/src/ui/onboarding.ts
+++ b/src/ui/onboarding.ts
@@ -63,6 +63,7 @@ import {
 	prefetchSubscriptionModels,
 	probeModelReachable,
 } from "../integrations/provider-discovery.js";
+import { checkCredentialTransport } from "../infra/net/credential-transport.js";
 import {
 	COPILOT_AUTO_MODEL_ID,
 	copilotPlanFromToken,
@@ -1680,6 +1681,9 @@ async function ensureCustomProvider(
 	modelRegistry: ModelRegistry,
 	provider: ProviderInfo,
 ): Promise<"ok" | "back"> {
+	// Set when the operator's base URL was only accepted because they opted into
+	// insecure LAN endpoints — surfaced on every screen that then asks for a key.
+	let urlWarning: string | null = null;
 	// Generic custom provider — the catalog entry has `custom: true` but no
 	// pre-set `baseUrl` (it varies per user). Prompt for the URL before the
 	// key-entry loop, then attach it to a shallow copy so the downstream
@@ -1698,6 +1702,9 @@ async function ensureCustomProvider(
 			}
 			tui.addChild(new Text(`  Enter your OpenAI-compatible base URL.`, 0, 0));
 			tui.addChild(new Text(brand.dim("  Example: https://api.example.com/v1"), 0, 0));
+			// State the rule before they can trip over it: remote endpoints need TLS
+			// because the API key rides along; a server on this machine doesn't.
+			tui.addChild(new Text(brand.dim("  Remote endpoints must be https://  ·  http:// is fine for a server on this machine"), 0, 0));
 			tui.addChild(new Text(brand.dim("  Enter to continue  ·  Esc to go back"), 0, 0));
 			tui.addChild(new Text("", 0, 0));
 			const urlInput = new Input();
@@ -1722,11 +1729,27 @@ async function ensureCustomProvider(
 				urlError = "URL must start with http:// or https://";
 				continue;
 			}
+			// Cleartext-credential gate, at configure time: a key typed on the NEXT
+			// screen would be sent to this URL, so an http:// remote host is caught
+			// here rather than at the first request. http:// to a local server
+			// (Ollama, LM Studio, llama.cpp) still passes — the bytes never leave
+			// the machine.
+			const transport = checkCredentialTransport(rawUrl);
+			if (!transport.ok) {
+				urlError = transport.reason;
+				continue;
+			}
+			if (transport.warning) urlWarning = transport.warning;
 			provider = { ...provider, baseUrl: rawUrl, api: provider.api ?? "openai-completions" };
 			break;
 		}
 	}
 	let lastError: string | null = null;
+	const renderUrlWarning = (): void => {
+		if (!urlWarning) return;
+		tui.addChild(new Text(`  ${brand.amber("⚠")} ${brand.amber(urlWarning)}`, 0, 0));
+		tui.addChild(new Text("", 0, 0));
+	};
 	// If the operator already has this provider's key in their environment (e.g.
 	// NVIDIA_API_KEY), OFFER it — confirm-then-validate, never silent-adopt. A
 	// present env var isn't proof it works, and the operator may want to paste a
@@ -1742,6 +1765,7 @@ async function ensureCustomProvider(
 			const candidate = pendingEnvKey;
 			pendingEnvKey = null; // offer once; on decline/failure fall through to paste
 			renderScreen(tui, `Step 3 of 5 · ${provider.name}`);
+			renderUrlWarning();
 			tui.addChild(
 				new Text(
 					`  ${brand.amber("?")} We found a saved ${provider.name} key on this computer (${formatApiKeyPreview(candidate)}). Use it?`,
@@ -1778,6 +1802,7 @@ async function ensureCustomProvider(
 			key = candidate;
 		} else {
 			renderScreen(tui, `Step 3 of 5 · ${provider.name}`);
+			renderUrlWarning();
 
 			if (lastError) {
 				tui.addChild(new Text(`  ${brand.error("✗")} ${brand.error(lastError)}`, 0, 0));
@@ -1828,14 +1853,17 @@ async function ensureCustomProvider(
 		if (provider.liveModels && provider.baseUrl) {
 			tui.addChild(new Text(brand.dim(`  Fetching ${provider.name} models…`), 0, 0));
 			tui.requestRender();
-			const ids = await fetchOpenAICompatibleModelIds(provider.baseUrl, key);
-			if (!ids || ids.length === 0) {
-				// A null/empty result means either a rejected key OR an unreachable
-				// endpoint (firewall/proxy/offline) — don't accuse the key outright.
-				lastError = `Couldn't reach ${provider.name}, or the key was rejected. Check your connection and the key, then try again.`;
+			const listed = await fetchOpenAICompatibleModelIds(provider.baseUrl, key);
+			if (!listed.ok) {
+				// `unavailable` means either a rejected key OR an unreachable endpoint
+				// (firewall/proxy/offline) — don't accuse the key outright. A transport
+				// refusal already carries its own precise line.
+				lastError =
+					listed.detail ??
+					`Couldn't reach ${provider.name}, or the key was rejected. Check your connection and the key, then try again.`;
 				continue;
 			}
-			models = ids;
+			models = listed.ids;
 		}
 
 		upsertApiKeyProfile(DEFAULT_AGENT_ID, { provider: provider.id, key });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "templates", "convex", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "templates", "convex", "**/*.test.ts", "**/*-fixtures.ts"]
 }


### PR DESCRIPTION
Addresses the open security alerts across Dependabot, code scanning and secret scanning. 98 alerts were open; a third of them were duplicates between two scanners.

## Alert accounting

| Surface | Open before | Notes |
|---|---:|---|
| Dependabot | 33 | all transitive, all in `package-lock.json` |
| Code scanning — dependency CVEs | 33 | same advisories as the Dependabot 33, surfaced by a second scanner |
| Code scanning — CodeQL source | 31 | real findings in our own code |
| Secret scanning | 1 | placeholder token in a test, false positive |

The 33 CVE code-scanning alerts are not separate work — fixing the lock file closes all 66.

## Dependencies

`tar` 7.5.16 → 7.5.22, `ip-address` → 10.5.0, `protobufjs` → 7.6.5, and `undici` patched per major line (6.28.0 for discord.js which needs the v6 API, 7.29.0 direct, 8.9.0 for pi-coding-agent). `brace-expansion` is scoped per major via npm version-selector keys — a bare override would force 5.x into `minimatch@3` (wants `^1.1.7`) and break exceljs.

`image-size` has no patched release (advisories cover `<= 2.0.2`, registry max is 2.0.2) and is left as-is. It is unreachable: pptxgenjs never calls it — its only call site sits inside a "currently unused" block comment, and its `browser` field maps the module to `false` — and `doc-shared` re-encodes every image through jimp to PNG/JPEG before pptxgenjs sees it, so the vulnerable ICNS/JXL/HEIF parsers get no input.

## Code findings

**HTML sanitization — the most serious.** `stripTags` required `[a-z]` after `<`, so the outer bracket of an overlapping pair was never a match start and the survivors fused: `<<a>script>alert(1)<</a>/script>` came back out as a live script tag. `htmlToMarkdown` decodes entities *before* stripping, so a hostile page could ship the payload entity-encoded, pass `sanitizeHtml` as inert text, then reassemble — and that output flows into the model prompt via `web_fetch`, `browser` and `analyze_media`. DuckDuckGo and Wikipedia hit the same class from the other side: they parse truncated fragments where an unterminated tag passed through untouched. All three now share one scanner-based `stripHtmlTags`.

**Temp files.** `claude-cli/spawn` fell back to a bare `tmpdir()` on mkdtemp failure, writing the system prompt and the MCP config — which carries the turn's MCP token — to fixed `/tmp` paths in a 1777 directory, and silently dropping the tool-containment boundary. `clipboard` used a fixed 0755 dir, leaving screenshots world-readable.

**exec approvals (ReDoS).** `decideApproval` recompiles and re-runs every stored pattern on every bash call, so one `(a+)+` entry wedges the agent loop permanently and persists to disk. Validation is hoisted into a new `exec-pattern-guard` enforced in `recordApproval`, so all five writers inherit it — the gateway RPC twin previously had no bound at all. Compilation moved to load time, making the hot path faster (0.004ms/call). Pre-existing patterns are quarantined rather than deleted, so affected commands downgrade to prompt rather than hang.

**attachments.** `decodeCandidate` unescaped only spaces, so a file named `back\slash report.pdf` decoded to a path naming nothing and the attachment was silently dropped with no error shown to the operator.

The 8 file↔network alerts were traced and left as-is — by-design flows matching prior dismissals of the same shape. Added regression tests for the skills-install and bluebubbles path containment those dismissals rely on.

## Verification

- `tsc --noEmit` clean across the tree
- Suite run in bounded batches: all areas pass except three issues confirmed identical at clean `HEAD` — `agents-tools` 40 failures (baseline: also 40), one `security` failure (baseline: same), and a `server.*.test.ts` hang (baseline: same)
- Dependency resolution verified on disk, not just in `package.json`

Note: `src/core/server.*.test.ts` wedges the runner before it can print a summary, at `HEAD` as well as here. Worth fixing separately — it means a full local suite run currently cannot complete.