### PR TITLE
chore(ci): keep dependencies current automatically instead of shepherding PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,40 @@
 # Dependabot configuration
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+#
+# Goal: dependencies stay current WITHOUT anyone shepherding pull requests, and
+# without routine bumps crowding out genuine contributions.
+#
+# How that works here:
+#   - grouped        one PR per group, not one per package (13 open PRs became
+#                    the norm before this; several sat stale for two months)
+#   - monthly        a cadence a person can actually absorb
+#   - cooldown       a release must age before Dependabot proposes it, so a
+#                    compromised or immediately-yanked version is caught by the
+#                    ecosystem before it can be auto-merged here
+#   - auto-merged    patch/minor land on their own once CI is green
+#                    (see .github/workflows/dependabot-auto-merge.yml)
+#
+# Majors deliberately still open a PR and wait for a human — auto-merging
+# zod 3 -> 4 or TypeScript 5 -> 6 would break the build, and that is a decision,
+# not a chore. The 30-day major cooldown keeps them rare.
+#
+# Security updates are a separate channel and are NOT affected by any of this:
+# a real advisory opens a PR immediately, ignoring cadence and cooldown.
 
 version: 2
 
-# Version updates are OFF; security updates are ON.
-#
-# `open-pull-requests-limit: 0` disables routine version-bump PRs for an
-# ecosystem. It has no effect on Dependabot SECURITY updates, which have their
-# own internal limit — so a real advisory still opens a PR, while "bump X from
-# 1.2.3 to 1.2.4" churn does not. Routine upgrades are done deliberately
-# instead, in batches, when someone is actually free to test them.
 updates:
   # npm dependencies
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 0
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 30
     groups:
       production:
         dependency-type: production
@@ -42,8 +60,10 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 0
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,20 @@
 
 version: 2
 
+# Version updates are OFF; security updates are ON.
+#
+# `open-pull-requests-limit: 0` disables routine version-bump PRs for an
+# ecosystem. It has no effect on Dependabot SECURITY updates, which have their
+# own internal limit — so a real advisory still opens a PR, while "bump X from
+# 1.2.3 to 1.2.4" churn does not. Routine upgrades are done deliberately
+# instead, in batches, when someone is actually free to test them.
 updates:
   # npm dependencies
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     groups:
       production:
         dependency-type: production
@@ -36,7 +43,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
       actions:
         patterns:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,48 @@
+name: Dependabot auto-merge
+
+# Lets grouped patch/minor updates land without a person shepherding them, so
+# dependencies stay current instead of rotting into one painful upgrade later.
+#
+# `--auto` does NOT bypass anything: the merge only happens once every required
+# check passes. This repo runs the full suite on two Node versions plus CodeQL,
+# OSV and the supply-chain audit, and dependabot.yml makes a release age before
+# it is even proposed. A bad version has to get past all of that.
+#
+# Majors are excluded on purpose — auto-merging zod 3 -> 4 would break the build.
+# They stay open for a human.
+#
+# `pull_request_target` is required because a workflow triggered BY Dependabot
+# receives a read-only GITHUB_TOKEN and could not merge. It is safe here for one
+# specific reason: this workflow never checks out or executes the PR's code. It
+# only reads metadata and calls the API. Do not add a checkout step.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge for patch/minor
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Leave majors for a human
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "::notice::${{ steps.meta.outputs.dependency-names }} is a major update — left open for review."


### PR DESCRIPTION
The PR list was 13 bot PRs deep, several stale since June, and closing them made room for six more the same afternoon.

The first pass at this set `open-pull-requests-limit: 0`, which fixes the symptom by switching version updates off. That is the wrong trade: dependencies drift until the next upgrade is one large risky batch, which is how 33 advisories accumulated in the first place.

## What this does instead

| | |
|---|---|
| **grouped** | one PR per group, not one per package |
| **monthly** | a cadence a person can absorb |
| **cooldown** | 3 days patch / 7 minor / 30 major before a release is even proposed |
| **auto-merge** | patch + minor merge themselves once CI is green |

Net effect: routine updates appear and disappear without anyone touching them, dependencies never rot, and the PR list stays for genuine contributions.

## On safety

`--auto` bypasses nothing — the merge waits for every required check: the full suite on Node 22.12 and 24, CodeQL, OSV, and the supply-chain audit. [Cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) means a compromised or yanked release is caught by the ecosystem before it is ever proposed here, which is the usual objection to auto-merging production dependencies.

Majors are excluded on purpose and still wait for a human — auto-merging zod 3 → 4 or TypeScript 5 → 6 would break the build. That is a decision, not a chore.

Security updates are a separate channel, unaffected by cadence or cooldown, and still open a PR the moment an advisory lands. That setting was enabled today and already closed #101/#102 by itself.

## Note on the workflow

It uses `pull_request_target` because a Dependabot-triggered run receives a read-only token and could not merge. That is safe here only because the workflow never checks out or executes PR code — it reads metadata and calls the API. Called out in the file so nobody adds a checkout step later.

Repo setting `allow_auto_merge` has been enabled, which `gh pr merge --auto` requires.