### PR TITLE
fix(tui): deliver Ctrl+C to the exit path

### DIFF
--- a/src/cli/commands/connect.attachments.test.ts
+++ b/src/cli/commands/connect.attachments.test.ts
@@ -318,3 +318,25 @@ describe("TUI attachments — Ctrl+V fires the paste hook", () => {
 		assert.equal(fired, 0);
 	});
 });
+
+/**
+ * Ctrl+C has to travel from the terminal, through the focused editor, to the SIGINT
+ * handler in `runConnectCommand`. `src/ui/editor.test.ts` covers the editor end of
+ * that trip; this covers whether `wireConnectUi` connects it to the process at all.
+ */
+describe("TUI interrupt — end to end, real editor + real wiring", () => {
+	it("a bare Ctrl+C raises the SIGINT that runConnectCommand's handler owns", async () => {
+		const { editor } = await bootUi();
+		let raised = 0;
+		const listener = (): void => {
+			raised += 1;
+		};
+		process.on("SIGINT", listener);
+		try {
+			editor.handleInput("\x03");
+		} finally {
+			process.off("SIGINT", listener);
+		}
+		assert.equal(raised, 1);
+	});
+});

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -197,7 +197,10 @@ export async function runConnectCommand(opts: ConnectCommandOptions = {}): Promi
 		if (chatHandle) {
 			const wasRunning = chatHandle.abort();
 			if (!wasRunning) {
-				void chatHandle.close().then(() => {
+				// `.finally`, not `.then`: this listener is a `once` and is already
+				// consumed here, so a rejected close() would leave the TUI with Ctrl+C
+				// permanently dead and no way out but another terminal. Exit either way.
+				void chatHandle.close().finally(() => {
 					tui.stop();
 					// tui.stop() already runs Pi-TUI's cleanup (kitty pop on
 					// the happy path); restoreTerminal() is the broader safety
@@ -2296,6 +2299,17 @@ export async function wireConnectUi(
 			editor.insertTextAtCursor(a.kind === "image" ? `[image #${i + 1}] ` : `[${a.fileName}] `);
 		}
 		tui.requestRender();
+	};
+
+	// In raw mode Ctrl+C (and Ctrl+D on an empty line) arrive as keypresses, never as
+	// signals, so raise the signal ourselves and let `runConnectCommand`'s `onSigint`
+	// do the rest: abort a running turn, or close and exit when the agent is idle.
+	//
+	// `process.emit`, not `process.kill(process.pid, "SIGINT")`: on Windows the latter
+	// terminates instead of running the handler, turning "abort this turn" into "kill
+	// the client mid-stream".
+	editor.onInterrupt = () => {
+		process.emit("SIGINT", "SIGINT");
 	};
 
 	// Ctrl+V / Alt+V raw keystroke — reaches us only in terminals that DON'T bind

--- a/src/ui/editor.test.ts
+++ b/src/ui/editor.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Key routing for `BrigadeEditor`: which keypresses reach `onInterrupt` and which
+ * must not. What the host then does with an interrupt lives in `connect.ts`; these
+ * only check that the key gets forwarded to it.
+ */
+
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import type { TUI } from "@earendil-works/pi-tui";
+
+import { BrigadeEditor } from "./editor.js";
+import { editorTheme } from "./theme.js";
+
+// `Editor` only reaches for `tui.requestRender` on input; `tui.terminal` is
+// render/page-scroll territory, which these tests never enter.
+const tui = { requestRender: () => {} } as unknown as TUI;
+
+function make(): { editor: BrigadeEditor; interrupts: () => number } {
+	const editor = new BrigadeEditor(tui, editorTheme);
+	let count = 0;
+	editor.onInterrupt = () => {
+		count += 1;
+	};
+	return { editor, interrupts: () => count };
+}
+
+function type(editor: BrigadeEditor, text: string): void {
+	for (const ch of text) editor.handleInput(ch);
+}
+
+describe("BrigadeEditor — interrupt key", () => {
+	it("forwards a bare Ctrl+C (0x03) to the host", () => {
+		const { editor, interrupts } = make();
+		type(editor, "hi");
+		editor.handleInput("\x03");
+		assert.equal(interrupts(), 1);
+		assert.equal(editor.getText(), "hi"); // the keypress must not edit the line
+	});
+
+	it("forwards Ctrl+C in the Kitty encoding the protocol negotiates", () => {
+		const { editor, interrupts } = make();
+		editor.handleInput("\x1b[99;5u");
+		assert.equal(interrupts(), 1);
+	});
+
+	it("leaves ordinary typing untouched", () => {
+		const { editor, interrupts } = make();
+		type(editor, "hello");
+		assert.equal(interrupts(), 0);
+		assert.equal(editor.getText(), "hello");
+	});
+
+	it("quits on Ctrl+D only when the line is empty", () => {
+		const withText = make();
+		type(withText.editor, "abc");
+		withText.editor.handleInput("\x1b[D"); // cursor between "ab" and "c"
+		withText.editor.handleInput("\x04");
+		assert.equal(withText.interrupts(), 0);
+		assert.equal(withText.editor.getText(), "ab"); // delete-forward, as before
+
+		const empty = make();
+		empty.editor.handleInput("\x04");
+		assert.equal(empty.interrupts(), 1);
+	});
+
+	// Delete and Ctrl+D share the `tui.editor.deleteCharForward` binding. Matching
+	// on the BINDING instead of the key would make Delete on an empty line quit.
+	it("never quits on the Delete key", () => {
+		const { editor, interrupts } = make();
+		editor.handleInput("\x1b[3~");
+		assert.equal(interrupts(), 0);
+	});
+});

--- a/src/ui/editor.ts
+++ b/src/ui/editor.ts
@@ -28,7 +28,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { Editor } from "@earendil-works/pi-tui";
+import { Editor, matchesKey } from "@earendil-works/pi-tui";
 
 /** Where `BRIGADE_DEBUG_INPUT=1` writes the raw input trace. */
 export const INPUT_TRACE_PATH = path.join(os.tmpdir(), "brigade-input-trace.log");
@@ -135,6 +135,22 @@ export class BrigadeEditor extends Editor {
 	 */
 	onPaste?: () => void;
 
+	/**
+	 * Fired when the operator presses Ctrl+C, or Ctrl+D on an empty line. What
+	 * "interrupt" should DO is the host's choice: `connect.ts` raises SIGINT, and its
+	 * handler aborts the turn or exits.
+	 *
+	 * Without this hook the keypress is simply lost. The terminal is in raw mode, so
+	 * the kernel never turns Ctrl+C into SIGINT, and Pi's own `Editor` ignores the
+	 * byte on purpose ("Ctrl+C - let parent handle (exit/clear)") to leave the
+	 * decision to the application. This editor IS the application's, so the key
+	 * travels no further unless it is forwarded from here.
+	 *
+	 * Hook the EDITOR, not the whole TUI: `ctrl+c` is also `tui.select.cancel`, so a
+	 * global interceptor would quit the app where `/model` just closes its list.
+	 */
+	onInterrupt?: () => void;
+
 	override handleInput(data: string): void {
 		// `BRIGADE_DEBUG_INPUT=1` appends every raw input chunk to a trace file.
 		//
@@ -149,6 +165,21 @@ export class BrigadeEditor extends Editor {
 		// image) and STILL fall through so the base editor inserts any pasted text —
 		// the two are complementary: text lands in the editor, an image gets attached.
 		if (data.includes("\x1b[200~") && this.onPaste) this.onPaste();
+
+		// Ctrl+C — see `onInterrupt`. `matchesKey` covers the bare `0x03` byte and the
+		// Kitty encoding (`ESC[99;5u`) alike.
+		if (this.onInterrupt && matchesKey(data, "ctrl+c")) {
+			this.onInterrupt();
+			return;
+		}
+
+		// Ctrl+D quits only on an EMPTY line; with text it stays Pi's delete-forward.
+		// Matched by key, not by the `tui.editor.deleteCharForward` binding — that
+		// binding also covers Delete, and Delete on an empty line must not quit.
+		if (this.onInterrupt && matchesKey(data, "ctrl+d") && this.getText() === "") {
+			this.onInterrupt();
+			return;
+		}
 
 		// Ctrl+V (0x16) and Alt+V (ESC v) both mean "paste an image from the clipboard".
 		//


### PR DESCRIPTION
## Problem

In the chat TUI (`brigade`, `brigade tui`, `brigade connect`) **Ctrl+C does
nothing** — it neither aborts the in-flight turn nor exits. Ctrl+D does not quit
either, although the in-chat `/help` advertises both:

```
- Ctrl+C — abort the current turn (same as /abort)
- Ctrl+D — quit
```

The only ways out today are `/exit`, `/quit`, or killing the process from another
terminal. Reproduced on macOS (Terminal.app, iTerm2); it is not terminal-specific,
since the cause is raw mode, which the TUI always enables.

Repro:

1. `brigade tui`
2. Press Ctrl+C — at the empty prompt, or while a turn is streaming.
3. Nothing happens. Ctrl+D likewise. The only way out is `/exit`.

The same check without a keyboard, for CI or a bug report: send one Ctrl+C byte
(`\003`) into a real pty and watch the process outlive it. The two `sleep`s wait for
the UI to start, then for an exit that never comes (macOS `script` syntax).

```bash
( sleep 14; printf '\003'; sleep 25 ) | script -q /dev/null brigade tui
```

## Root cause

The exit logic is already correct — nothing is wired to it.

1. Pi-TUI puts the terminal in raw mode (`ProcessTerminal.start()` →
   `setRawMode(true)`), so the kernel no longer turns Ctrl+C into `SIGINT`. The app
   receives the raw `0x03` byte (or `ESC[99;5u` under the Kitty keyboard protocol
   Pi-TUI negotiates).
2. `TUI.handleInput` forwards it to the focused component — *"Pass input to focused
   component (including Ctrl+C)"*.
3. Pi's own `Editor.handleInput` deliberately ignores it — *"Ctrl+C - let parent
   handle (exit/clear)"*.
4. `BrigadeEditor.handleInput` (`src/ui/editor.ts`) has no Ctrl+C branch, so the
   byte dies there.
5. `runConnectCommand`'s `onSigint` (`src/cli/commands/connect.ts`) implements
   exactly the documented behaviour — abort a running turn, close and exit when idle
   — but is bound to `process.on("SIGINT")`, a signal that never arrives in raw mode.

Ctrl+D misses the same path for a different reason: Pi binds `ctrl+d` to
`tui.editor.deleteCharForward`, so it deletes a character forward and, on an empty
line, does nothing at all.

This belongs in Brigade rather than in Pi-TUI: Pi is explicit that the *meaning* of
Ctrl+C (abort vs. clear vs. exit) is the host's decision, and Brigade already has
that decision implemented.

## Change

No new exit logic — only delivery of the event that was missing.

**`src/ui/editor.ts`** — add an `onInterrupt?: () => void` hook alongside the
existing `onPaste` / `onImagePaste` / `onTextChanged` hooks, and fire it on Ctrl+C;
`matchesKey` handles the bare `0x03` and the Kitty encoding alike. Fire it on Ctrl+D
too, but **only when the line is empty**, which makes the documented "Ctrl+D — quit"
true without touching delete-forward while typing. Ctrl+D is matched by key, not by
the `tui.editor.deleteCharForward` binding: that binding also covers the Delete key,
which must not quit.

**`src/cli/commands/connect.ts`** — wire the hook in `wireConnectUi`:
`editor.onInterrupt = () => { process.emit("SIGINT", "SIGINT"); }`. The existing
`onSigint` stays the single exit path. `process.emit` rather than
`process.kill(process.pid, "SIGINT")` because the latter is documented to terminate
unconditionally on Windows instead of running the handler, which would turn "abort
this turn" into "kill the client mid-stream". Separately, `onSigint`'s idle branch
now uses `.finally` instead of `.then` after `chatHandle.close()`: the listener is a
`process.once` and is already consumed at that point, so a rejection there would
leave the TUI with no working exit at all. That was unreachable from the keyboard
before this PR, and reachable the moment Ctrl+C is delivered.

**Tests** — `src/ui/editor.test.ts` (new) covers bare Ctrl+C, Kitty-encoded Ctrl+C,
plain typing unaffected, Ctrl+D quitting only on an empty line, and Delete never
quitting. `src/cli/commands/connect.attachments.test.ts` gains one end-to-end case on
the existing real-`TUI` harness: a keypress into the focused `BrigadeEditor` raises
the SIGINT `runConnectCommand` listens for. The unit tests cover the key handling;
this one covers the wire, which is where the bug actually was.

The hook is scoped to the editor rather than a global `tui.addInputListener` because
Ctrl+C is already bound to `tui.select.cancel` in the popups — a TUI-wide interceptor
would quit the app where `/model` and friends expect to close their list.

## Verification

- `npm run typecheck`, `npm test` (1749 tests, 294 suites, 0 failures) and
  `npm run build` all pass. `npm test` does not reach this PR's end-to-end case —
  see the first item under Other findings — so that file was run directly:

  ```bash
  npx tsx --test src/ui/editor.test.ts src/cli/commands/connect.attachments.test.ts
  ```

- Manually: Ctrl+C while idle exits cleanly; Ctrl+C during a streaming turn aborts the
  turn and leaves the TUI usable; Ctrl+D quits on an empty line and still deletes
  forward otherwise.
- The same logic was A/B-verified against the published 1.31.0 build in a real pty:
  with the interrupt delivered the TUI exits with code 0; with it disabled, the
  identical run leaves the process alive.

## Other findings

None of these are introduced or fixed by this PR.

**`npm test` runs less than a third of the suite.** `scripts/run-tests.mjs` spawns
`--test src/**/*.test.ts` with `shell: true`, and `/bin/sh` expands `**` as a plain
`*`, so the pattern matches exactly one directory level. 142 of the 471 `*.test.ts`
files in the tree actually run, and everything under `src/cli/commands/` — the
gateway client, the TUI wiring, this PR's end-to-end case — is silently skipped. A
green `npm test` therefore says much less than it appears to. Quoting the pattern so
Node does its own globbing fixes the glob, but it will also surface whatever has
drifted in the 329 files that have not been running, so it wants its own PR.

**An aborted turn is retried once.** Ctrl+C during a streaming turn stops that
attempt, and a fresh attempt starts on its own; a second Ctrl+C stops that one. The
`abort` RPC (`src/core/server.ts`, `case "abort"`) calls `liveSession.abort()` on the
Pi session but never fires the turn's `turnAbortController`, and the signal handed to
`runResilientTurn` is `turn.signal`, which only channel inbounds populate — for a TUI
turn it is `undefined`. The retry loop then evaluates
`policy.transient && remaining > 0 && !args.signal?.aborted` (`src/agents/retry-policy.ts`)
with no signal to consult, reads the torn-down stream as a transient failure, and
re-runs the attempt. Aborting the turn's controller in the `abort` handler would fix
it; that is a gateway change, not a TUI one.

**Ctrl+D means "interrupt" during a turn, and exit is one keystroke.** While a turn is
streaming the editor line is empty, so Ctrl+D takes the same path as Ctrl+C and aborts
the turn, where the convention (bash, readline) is that Ctrl+D is EOF and never an
interrupt. Splitting the two would mean giving the hook a reason —
`onInterrupt?: (reason: "interrupt" | "eof") => void` — and routing `"eof"` straight to
the close-and-exit branch. Related: on an empty line a single Ctrl+C or Ctrl+D exits
immediately, with no "press again to exit" confirmation, so one mistyped key ends the
session.
