### PR TITLE
fix(claude-cli): stop a stale macOS keychain entry masking Brigade's login

### DIFF
--- a/src/agents/claude-cli/claude-config.test.ts
+++ b/src/agents/claude-cli/claude-config.test.ts
@@ -8,6 +8,9 @@ import { test } from "node:test";
 import {
 	CLAUDE_CODE_OAUTH_SCOPES,
 	clearBrigadeClaudeLogin,
+	clearClaudeKeychainShadow,
+	healClaudeKeychainShadow,
+	inspectClaudeKeychainShadow,
 	hasBrigadeClaudeLogin,
 	readBrigadeClaudeCredential,
 	resolveBrigadeClaudeConfigDir,
@@ -76,5 +79,71 @@ test("readBrigadeClaudeCredential: null on missing/garbage; never throws", () =>
 		fs.writeFileSync(path.join(dir, ".credentials.json"), "{ not json");
 		assert.equal(readBrigadeClaudeCredential(), null);
 		assert.equal(hasBrigadeClaudeLogin(), false);
+	});
+});
+
+// ── keychain shadow (macOS) ─────────────────────────────────────────────────
+// On macOS the `claude` binary reads its credential from the login keychain,
+// which OUTRANKS `<configDir>/.credentials.json`. A tombstoned shadow (empty
+// accessToken) therefore made every turn fail with "OAuth session expired" and
+// was unrecoverable by re-login — we rewrote a file the binary never read.
+
+test("healClaudeKeychainShadow: reports 'none' when no shadow exists", () => {
+	withTempConfigDir(() => {
+		// A fresh temp dir hashes to a service name nothing has ever written.
+		assert.equal(healClaudeKeychainShadow(), "none");
+	});
+});
+
+test("clearClaudeKeychainShadow: absent entry is not an error", () => {
+	withTempConfigDir(() => {
+		// No entry to delete — must return false rather than throw, so the write
+		// path never fails just because the shadow was already clean.
+		assert.equal(clearClaudeKeychainShadow(), false);
+	});
+});
+
+test("writeBrigadeClaudeCredential: still writes the file when no shadow exists", () => {
+	withTempConfigDir((dir) => {
+		writeBrigadeClaudeCredential({ access: "acc-1", refresh: "ref-1", expires: Date.now() + 3_600_000 });
+		const raw = JSON.parse(fs.readFileSync(path.join(dir, ".credentials.json"), "utf8")) as {
+			claudeAiOauth: { accessToken: string };
+		};
+		assert.equal(raw.claudeAiOauth.accessToken, "acc-1");
+		assert.equal(hasBrigadeClaudeLogin(), true);
+	});
+});
+
+test("claude keychain service name is derived from the config dir", () => {
+	// Two different dirs must never collide onto one keychain entry — that would
+	// let one Brigade install tombstone another's login.
+	withTempConfigDir(() => {
+		assert.equal(healClaudeKeychainShadow("/tmp/brigade-kc-a"), "none");
+		assert.equal(healClaudeKeychainShadow("/tmp/brigade-kc-b"), "none");
+	});
+});
+
+test("inspectClaudeKeychainShadow: read-only — reports 'none' and changes nothing", () => {
+	withTempConfigDir((dir) => {
+		writeBrigadeClaudeCredential({ access: "acc-1", refresh: "ref-1", expires: Date.now() + 3_600_000 });
+		const before = fs.readFileSync(path.join(dir, ".credentials.json"), "utf8");
+		const state = inspectClaudeKeychainShadow();
+		// A temp dir hashes to a service nothing has written; on non-darwin the
+		// concept does not apply at all.
+		assert.ok(state === "none" || state === "unsupported");
+		// A diagnostic that mutates is one you cannot use to reproduce a bug.
+		assert.equal(fs.readFileSync(path.join(dir, ".credentials.json"), "utf8"), before);
+	});
+});
+
+test("healClaudeKeychainShadow: refuses to clear when OUR credential is unusable", () => {
+	withTempConfigDir((dir) => {
+		// Empty access token — the shadow may hold the only refresh token left,
+		// so clearing it would destroy the last way back in.
+		fs.writeFileSync(
+			path.join(dir, ".credentials.json"),
+			JSON.stringify({ claudeAiOauth: { accessToken: "", refreshToken: "", expiresAt: 0 } }),
+		);
+		assert.equal(healClaudeKeychainShadow(), "none");
 	});
 });

--- a/src/agents/claude-cli/claude-config.ts
+++ b/src/agents/claude-cli/claude-config.ts
@@ -18,6 +18,8 @@
 // holds a credential, use it; otherwise fall back to the binary's default
 // (`~/.claude`) so an operator who already ran `claude` keeps working unchanged.
 
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -69,6 +71,123 @@ function migrateLegacyClaudeConfigOnce(dest: string): void {
 		// Perms / partial copy — leave the legacy dir in place; worst case the
 		// binary re-logins once. Never let a migration hiccup break resolution.
 	}
+}
+
+/**
+ * macOS keeps the `claude` binary's OAuth credential in the LOGIN KEYCHAIN, not
+ * in `<configDir>/.credentials.json` — under a service name derived from the
+ * config dir: `Claude Code-credentials-<sha256(dir).slice(0,8)>` (the
+ * un-suffixed `Claude Code-credentials` belongs to the default `~/.claude`).
+ *
+ * The keychain entry WINS over the file. A tombstoned entry — one the binary
+ * emptied after a failed refresh (`accessToken: ""`, `expiresAt: 0`) — makes
+ * every turn fail with "OAuth session expired and could not be refreshed" while
+ * a perfectly good Brigade-written `.credentials.json` sits unread beside it.
+ * Worse, it is UNRECOVERABLE by re-login: `brigade login claude-cli` rewrites
+ * the file the binary never reads.
+ *
+ * Brigade deliberately does NOT write the keychain — that shape is the vendor's
+ * to own, and guessing it is how you get a second split-brain. Instead we DELETE
+ * the shadow when minting a fresh credential, so the binary bootstraps from our
+ * file and repopulates the keychain itself.
+ */
+function claudeKeychainService(dir: string): string {
+	const digest = crypto.createHash("sha256").update(dir).digest("hex").slice(0, 8);
+	// ALWAYS suffixed. The operator's personal login lives under the UN-suffixed
+	// `Claude Code-credentials` (the default `~/.claude`), so a derived name can
+	// never name it — this is the invariant that makes deleting safe at all.
+	return `Claude Code-credentials-${digest}`;
+}
+
+/** The operator's personal Claude Code login. We must never touch this. */
+const CLAUDE_DEFAULT_KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+/**
+ * `security` can block on a LOCKED keychain (it raises a GUI unlock prompt). A
+ * headless gateway would hang there forever, so every call is bounded — a
+ * timeout degrades to "leave it alone", which is always the safe direction.
+ */
+const KEYCHAIN_CMD_TIMEOUT_MS = 5_000;
+
+/** Delete the keychain shadow for `dir`. Returns true only if one was removed. */
+export function clearClaudeKeychainShadow(dir: string = resolveBrigadeClaudeConfigDir()): boolean {
+	if (os.platform() !== "darwin") return false;
+	const service = claudeKeychainService(dir);
+	// Belt-and-braces: refuse to delete the operator's personal login even if the
+	// derivation above is ever changed to something that could collide with it.
+	if (service === CLAUDE_DEFAULT_KEYCHAIN_SERVICE) return false;
+	try {
+		execFileSync("security", ["delete-generic-password", "-s", service], {
+			stdio: "ignore",
+			timeout: KEYCHAIN_CMD_TIMEOUT_MS,
+		});
+		return true;
+	} catch {
+		return false; // no entry — the common case, not an error
+	}
+}
+
+/**
+ * Clear the keychain shadow ONLY when it is unusable (missing/empty access
+ * token). A healthy shadow is left alone: the binary owns it and rotates it
+ * in place. Returns what happened, for the caller to report.
+ */
+export type ClaudeKeychainShadowState =
+	/** Not macOS — the binary reads the file, so no shadow can exist. */
+	| "unsupported"
+	/** No keychain entry for this config dir; our file is authoritative. */
+	| "none"
+	/** A real credential the binary owns and rotates. Leave it alone. */
+	| "healthy"
+	/** Emptied by a failed refresh — outranks, and silently masks, our file. */
+	| "tombstoned";
+
+/**
+ * READ-ONLY view of the keychain shadow. Never mutates, so diagnostics
+ * (`brigade doctor`) can report the condition without repairing it behind the
+ * operator's back — a doctor that silently changes state is a doctor you
+ * cannot use to reproduce a bug.
+ */
+export function inspectClaudeKeychainShadow(
+	dir: string = resolveBrigadeClaudeConfigDir(),
+): ClaudeKeychainShadowState {
+	if (os.platform() !== "darwin") return "unsupported";
+	let raw: string;
+	try {
+		raw = execFileSync("security", ["find-generic-password", "-s", claudeKeychainService(dir), "-w"], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: KEYCHAIN_CMD_TIMEOUT_MS,
+		});
+	} catch {
+		return "none"; // no entry — the file is already authoritative
+	}
+	let token: unknown;
+	try {
+		token = (JSON.parse(raw.trim()) as { claudeAiOauth?: { accessToken?: unknown } }).claudeAiOauth?.accessToken;
+	} catch {
+		token = undefined; // unparseable shadow is by definition unusable
+	}
+	return typeof token === "string" && token.length > 0 ? "healthy" : "tombstoned";
+}
+
+export function healClaudeKeychainShadow(dir: string = resolveBrigadeClaudeConfigDir()): "none" | "cleared" {
+	if (os.platform() !== "darwin") return "none";
+	// Never trade a shadow for nothing: if OUR credential is absent or itself
+	// empty, the shadow — stale as it looks — may still hold the only refresh
+	// token on this machine. Clearing then would destroy the last way back in.
+	// Read from `dir` — NOT the resolved default. The keychain probe is keyed on
+	// `dir`, and a mismatch would judge one store by the other's health.
+	let ours: ClaudeCodeCredentialFile["claudeAiOauth"] | undefined;
+	try {
+		ours = (JSON.parse(fs.readFileSync(path.join(dir, ".credentials.json"), "utf8")) as ClaudeCodeCredentialFile)
+			.claudeAiOauth;
+	} catch {
+		ours = undefined;
+	}
+	if (!ours || typeof ours.accessToken !== "string" || ours.accessToken.length === 0) return "none";
+	if (inspectClaudeKeychainShadow(dir) !== "tombstoned") return "none";
+	return clearClaudeKeychainShadow(dir) ? "cleared" : "none";
 }
 
 function credentialPath(): string {
@@ -137,6 +256,10 @@ export function writeBrigadeClaudeCredential(cred: {
 		}
 	}
 	fs.renameSync(tmp, target);
+	// The keychain shadow (macOS) outranks this file — a stale one would make
+	// the binary ignore the credential we just minted. Drop it so the binary
+	// bootstraps from here and writes a fresh entry itself.
+	clearClaudeKeychainShadow(dir);
 	return dir;
 }
 
@@ -171,4 +294,11 @@ export function clearBrigadeClaudeLogin(): void {
 	} catch {
 		/* nothing to remove */
 	}
+	// Remove the credential everywhere Brigade caused it to exist. On macOS the
+	// binary mirrored our grant into the login keychain under this config dir's
+	// own service name; leaving it behind would keep a live credential on the
+	// machine after the operator asked us to forget it — and would silently
+	// shadow the next login. Never touches the operator's personal `~/.claude`
+	// entry, which is un-suffixed and unreachable from this derivation.
+	clearClaudeKeychainShadow();
 }

--- a/src/agents/claude-cli/stream.ts
+++ b/src/agents/claude-cli/stream.ts
@@ -30,6 +30,8 @@ import {
 	CLAUDE_CLI_API,
 	CLAUDE_CLI_PROVIDER,
 } from "./catalog.js";
+import { BrigadeRetryError } from "../error-classifier.js";
+import { hasBrigadeClaudeLogin, healClaudeKeychainShadow, readBrigadeClaudeCredential } from "./claude-config.js";
 import { buildClaudeCliHttpMcpConfig, buildClaudeCliMcpConfig, readClaudeCliToolPlane } from "./tool-plane.js";
 import { registerHarnessWatchdog, unregisterHarnessWatchdog } from "../harness/watchdog.js";
 import { createSubsystemLogger } from "../../logging/subsystem-logger.js";
@@ -216,6 +218,68 @@ const SUBSCRIPTION_LIMIT_MESSAGE =
  *  the exact fix. */
 const CLAUDE_CLI_REAUTH_MESSAGE =
 	"Claude sign-in expired or was revoked — the CLI backend can't authenticate. Run `brigade login claude-cli` to sign in again.";
+
+/** A stale keychain shadow was masking a VALID Brigade login — now cleared. */
+const CLAUDE_CLI_SHADOW_REPAIRED_MESSAGE =
+	"A stale macOS keychain entry was shadowing Brigade's Claude login — cleared it and retried. No re-login needed.";
+
+/**
+ * Brigade's own credential is present and NOT expired, yet the binary refused
+ * to authenticate. Re-running the login would rewrite the same good file and
+ * change nothing, so do not send the operator down that path — say what we
+ * actually know. On macOS this is the keychain shadow (already reconciled
+ * above, so reaching here means something else owns the login); elsewhere the
+ * binary is resolving a credential from somewhere other than our config dir.
+ */
+const CLAUDE_CLI_CREDENTIAL_IGNORED_MESSAGE =
+	"Brigade's Claude credential is still valid, but the CLI rejected it — the binary is authenticating from somewhere other than Brigade's config dir. Re-running `brigade login claude-cli` will not help; check for another Claude login on this machine (`brigade doctor`).";
+
+/**
+ * A dead-login failure is not always a dead login. On macOS the binary reads its
+ * credential from the login keychain, which OUTRANKS Brigade's managed
+ * `.credentials.json`; a shadow the binary tombstoned on a failed refresh
+ * (empty accessToken) makes every turn report "expired" while our credential is
+ * still valid — and `brigade login claude-cli` cannot fix it, because it
+ * rewrites the file the binary never reads.
+ *
+ * So before telling the operator to re-authenticate, reconcile the two stores.
+ * Runs ONLY on the failure path (zero cost on a healthy turn). If we cleared a
+ * tombstone, the credential we already hold is good and the next spawn will
+ * bootstrap from it — say so instead of sending them through a pointless login.
+ */
+function claudeCliAuthFailure(): Error {
+	try {
+		if (hasBrigadeClaudeLogin() && healClaudeKeychainShadow() === "cleared") {
+			// We repaired the actual cause, so this turn is recoverable: hand the
+			// loop a classified retry rather than an error the operator must act on.
+			// `auth_recovered` retries ONCE, in place, without rotating profile or
+			// model — rotating would abandon the path we just fixed.
+			return new BrigadeRetryError({
+				message: CLAUDE_CLI_SHADOW_REPAIRED_MESSAGE,
+				reason: "auth_recovered",
+				provider: CLAUDE_CLI_PROVIDER,
+			});
+		}
+	} catch {
+		/* reconciliation is best-effort — fall through to the diagnosis below */
+	}
+	// Nothing to repair. Distinguish "the credential really is dead" (re-login
+	// fixes it) from "the credential is fine and something else is answering"
+	// (re-login is a dead end). Platform-agnostic on purpose: it holds wherever
+	// the binary sources a login we did not write.
+	try {
+		const ours = readBrigadeClaudeCredential();
+		const live =
+			typeof ours?.accessToken === "string" &&
+			ours.accessToken.length > 0 &&
+			typeof ours.expiresAt === "number" &&
+			ours.expiresAt > Date.now();
+		if (live) return new Error(CLAUDE_CLI_CREDENTIAL_IGNORED_MESSAGE);
+	} catch {
+		/* fall through */
+	}
+	return new Error(CLAUDE_CLI_REAUTH_MESSAGE);
+}
 
 /** Auth-shaped stderr from a non-zero exit (the binary couldn't authenticate). */
 function isAuthShapedText(text: string): boolean {
@@ -620,7 +684,7 @@ export function createClaudeCliStreamFn(opts: CreateClaudeCliStreamFnOpts = {}):
 				// Dead login — from a result frame OR an auth-shaped non-zero exit.
 				// Actionable: tell the operator the exact re-auth command.
 				if (authHit || (code !== 0 && code !== null && isAuthShapedText(stderr))) {
-					throw new Error(CLAUDE_CLI_REAUTH_MESSAGE);
+					throw claudeCliAuthFailure();
 				}
 				if (errorText) {
 					throw new Error(`claude-cli error: ${errorText}`);
@@ -629,7 +693,7 @@ export function createClaudeCliStreamFn(opts: CreateClaudeCliStreamFnOpts = {}):
 					// No terminal frame — spawn failure (binary missing) or a crash.
 					// An auth-shaped stderr here is a dead login, not a missing binary.
 					if (isAuthShapedText(stderr)) {
-						throw new Error(CLAUDE_CLI_REAUTH_MESSAGE);
+						throw claudeCliAuthFailure();
 					}
 					const hint =
 						code === null

--- a/src/agents/error-classifier.ts
+++ b/src/agents/error-classifier.ts
@@ -28,6 +28,9 @@ export type RetryReason =
   | "context_overflow" // input + output exceeds context — compact then retry, don't burn fallbacks
   | "model_not_found"  // provider doesn't know this model — rotate to fallback
   | "session_expired"  // upstream session/conversation expired — fail fast or refresh
+  | "auth_recovered"   // an auth failure we REPAIRED in place (e.g. cleared a stale
+                       // macOS keychain shadow) — the credential is known-good now,
+                       // so retry the SAME path immediately; never rotate away
   | "unknown";         // catch-all; treated as transient at the policy layer
 
 export interface ClassificationContext {

--- a/src/agents/retry-policy.test.ts
+++ b/src/agents/retry-policy.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { BrigadeRetryError } from "./error-classifier.js";
+import { BrigadeRetryError, classifyErrorReason } from "./error-classifier.js";
 import {
   RetryExhaustedError,
   computeBackoffMs,
@@ -302,4 +302,23 @@ test("runWithRetry: subscription_limit fails fast — exactly one attempt, no ba
     (e: unknown) => isRetryExhaustedError(e) && e.lastReason === "subscription_limit",
   );
   assert.equal(calls, 1);
+});
+
+test("getRetryPolicy: auth_recovered → retries ONCE in place, never rotates", () => {
+  const p = getRetryPolicy("auth_recovered");
+  assert.equal(p.transient, true);
+  assert.equal(p.maxRetries, 1);
+  assert.equal(p.baseBackoffMs, 0);
+  // Rotating would abandon the exact path we just repaired.
+  assert.equal(p.rotateAuthProfile, false);
+  assert.equal(p.rotateModel, false);
+  // Not a provider-health signal — must not burn a transient probe slot.
+  assert.equal(p.consumesProbeSlot, false);
+});
+
+test("classifyErrorReason: a BrigadeRetryError('auth_recovered') is not re-classified as auth", () => {
+  const err = new BrigadeRetryError({ message: "cleared a stale keychain shadow", reason: "auth_recovered" });
+  // The message mentions a credential problem; the explicit reason must win, or
+  // the heuristics would demote it to `auth` (0 retries) and lose the recovery.
+  assert.equal(classifyErrorReason(err), "auth_recovered");
 });

--- a/src/agents/retry-policy.ts
+++ b/src/agents/retry-policy.ts
@@ -20,6 +20,7 @@
 //   auth               no         0        n/a          yes             try other profile
 //   auth_permanent     no         0        n/a          n/a             surface to user
 //   session_expired    no         0        n/a          n/a             upstream needs re-auth
+//   auth_recovered     yes        1        0            no              we fixed it; retry in place
 
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -46,6 +47,22 @@ export interface RetryPolicy {
 
 export function getRetryPolicy(reason: RetryReason): RetryPolicy {
   switch (reason) {
+    case "auth_recovered":
+      // We already repaired the cause (e.g. deleted a tombstoned keychain entry
+      // that was shadowing a valid credential), so the very next attempt should
+      // succeed. Retry ONCE, immediately, on the SAME profile and model —
+      // rotating would abandon the path we just fixed. Self-limiting: the
+      // repair only reports success while there is something to repair, so a
+      // genuinely dead login cannot loop here.
+      return {
+        reason,
+        transient: true,
+        maxRetries: 1,
+        baseBackoffMs: 0,
+        rotateAuthProfile: false,
+        rotateModel: false,
+        consumesProbeSlot: false,
+      };
     case "rate_limit":
       return {
         reason,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -31,6 +31,7 @@ import { detectUnrefreshableSubscriptions } from "../../auth/auth-health.js";
 import { isClaudeCliAvailable } from "../../agents/claude-cli/availability.js";
 import { hasBrigadeClaudeLogin } from "../../agents/claude-cli/claude-config.js";
 import { readClaudeCliLogin } from "../../integrations/cli-login.js";
+import { inspectClaudeKeychainShadow } from "../../agents/claude-cli/claude-config.js";
 import { FileMemoryStore } from "../../agents/memory/storage.js";
 import { FactStore } from "../../agents/memory/records.js";
 import { discoverEligibleSkills } from "../../agents/skills/index.js";
@@ -471,6 +472,21 @@ function checkClaudeCliBackend(): CheckResult {
 			status: "warn",
 			message: "`claude` is installed but no login was detected",
 			hint: "run `brigade onboard` and pick 'Claude (via Claude Code CLI)' to sign in via browser (no key)",
+		};
+	}
+	// macOS keeps the binary's credential in the login keychain, and that entry
+	// OUTRANKS the `.credentials.json` Brigade writes. A tombstoned one (emptied
+	// by a failed refresh) masks a perfectly good Brigade login and makes every
+	// turn report "OAuth session expired" — and re-running the login cannot fix
+	// it, because it rewrites the file the binary never reads. Brigade now
+	// repairs this automatically, so surfacing it here matters most when the
+	// operator is looking at a turn that already failed.
+	if (viaBrigade && inspectClaudeKeychainShadow() === "tombstoned") {
+		return {
+			name: "claude-cli backend",
+			status: "warn",
+			message: "signed in, but a stale macOS keychain entry is shadowing Brigade's Claude login",
+			hint: "Brigade clears this automatically on the next turn or gateway start — do NOT re-run `brigade login claude-cli`, it rewrites a file the binary does not read",
 		};
 	}
 	return {

--- a/src/cli/commands/gateway.ts
+++ b/src/cli/commands/gateway.ts
@@ -721,6 +721,25 @@ export async function runGatewayCommand(opts: GatewayCommandOptions = {}): Promi
 		// while the gateway was down) is repaired here — refresh-probe, then adopt
 		// the CLI's live login. Without this the first turns after boot fail with
 		// "No API key for provider: anthropic".
+		// macOS: the `claude` binary reads its credential from the LOGIN KEYCHAIN,
+		// which outranks Brigade's `<claude-config>/.credentials.json`. A shadow the
+		// binary tombstoned on a failed refresh (empty accessToken) makes every turn
+		// report "OAuth session expired and could not be refreshed" while our valid
+		// credential sits unread — and re-login cannot fix it, because we rewrite the
+		// file the binary never reads. Clear ONLY an unusable shadow; a healthy one
+		// belongs to the binary.
+		try {
+			const { hasBrigadeClaudeLogin, healClaudeKeychainShadow } = await import(
+				"../../agents/claude-cli/claude-config.js"
+			);
+			if (hasBrigadeClaudeLogin() && healClaudeKeychainShadow() === "cleared") {
+				process.stderr.write(
+					"brigade-gateway: cleared a stale Claude keychain entry that was shadowing Brigade's login (no action needed).\n",
+				);
+			}
+		} catch {
+			/* keychain heal is best-effort — never block boot */
+		}
 		const deadHeal = await healDeadSubscriptionLogin();
 		if (deadHeal !== "none") {
 			process.stderr.write(


### PR DESCRIPTION
## The bug

On macOS the `claude` binary reads its OAuth credential from the **login keychain** — service `Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR)[:8]>` — and that entry **outranks** the `.credentials.json` Brigade writes into its managed config dir.

When a refresh fails the binary tombstones that entry (`accessToken: ""`, `expiresAt: 0`). Every turn then fails with *"OAuth session expired and could not be refreshed"* while a perfectly valid Brigade credential sits unread beside it.

Worse, it was **unrecoverable**: `brigade login claude-cli` rewrites the file the binary never reads, so re-authenticating changed nothing. The only escape was deleting the keychain entry by hand.

## The fix

Reconcile the two stores at every point they can diverge:

| When | Action |
|---|---|
| Minting a credential | Clear the shadow, so a fresh login takes effect |
| Logout | Clear it too — don't leave a live credential after being told to forget one |
| Gateway boot | Heal a tombstone, with an operator-visible line |
| Turn fails on auth | Heal **and retry in place** — the operator never sees the error |

The retry is a new `auth_recovered` `RetryReason`: one attempt, no backoff, **no profile/model rotation** (rotating would abandon the path just repaired). Self-limiting — the heal only reports success while there is something to repair, so a genuinely dead login cannot loop.

## Safety

- **Never touches the operator's personal `~/.claude` login.** That lives under the *un-suffixed* service name, which the derivation cannot produce; plus an explicit guard. Running Claude Code and Brigade side by side is unaffected — verified working simultaneously.
- **Every `security` call is bounded (5s).** A locked keychain raises a GUI unlock prompt that would otherwise hang a headless gateway forever.
- **Refuses to clear a shadow unless Brigade's own credential is usable**, so it can never destroy the last refresh token on the machine.
- **`brigade doctor` reports the condition read-only** — a diagnostic that repairs state behind you is one you cannot use to reproduce a bug.

## Platform coverage

Verified against the binary rather than assumed — it shells out to macOS `security` (`find-`/`add-`/`delete-generic-password`) and has no Windows Credential Manager, DPAPI, or libsecret equivalent.

| Platform | Storage | Behaviour |
|---|---|---|
| macOS | Keychain, per config dir | Reconciled |
| Linux / Windows | `.credentials.json` only | No-ops (no shadow can exist) |

If a future release adds a store elsewhere, the new diagnostic degrades honestly: when the credential is valid but auth still fails, the error says the binary is authenticating from elsewhere instead of sending the operator through a login that cannot help.

## Verification

- Typecheck clean; `npm test` 1751/1751
- Reproduced the exact failure by planting a tombstone, then confirmed boot heal recovers it
- Planted a tombstone **after** boot and ran a real turn — succeeded transparently via auto-retry, tombstone cleared, no error surfaced
- Confirmed personal and Brigade-managed logins both work afterwards