### PR TITLE
fix(claude-cli): keep model discovery live instead of freezing to the…

### DIFF
--- a/src/agents/claude-cli/claude-config.test.ts
+++ b/src/agents/claude-cli/claude-config.test.ts
@@ -11,6 +11,7 @@ import {
 	clearClaudeKeychainShadow,
 	healClaudeKeychainShadow,
 	inspectClaudeKeychainShadow,
+	readEffectiveClaudeCredential,
 	hasBrigadeClaudeLogin,
 	readBrigadeClaudeCredential,
 	resolveBrigadeClaudeConfigDir,
@@ -145,5 +146,33 @@ test("healClaudeKeychainShadow: refuses to clear when OUR credential is unusable
 			JSON.stringify({ claudeAiOauth: { accessToken: "", refreshToken: "", expiresAt: 0 } }),
 		);
 		assert.equal(healClaudeKeychainShadow(), "none");
+	});
+});
+
+test("readEffectiveClaudeCredential: returns the file credential when no keychain shadow", () => {
+	withTempConfigDir(() => {
+		const exp = Date.now() + 3_600_000;
+		writeBrigadeClaudeCredential({ access: "acc-file", refresh: "ref-file", expires: exp });
+		const eff = readEffectiveClaudeCredential();
+		assert.equal(eff?.accessToken, "acc-file");
+		assert.equal(eff?.expiresAt, exp);
+	});
+});
+
+test("readEffectiveClaudeCredential: null when neither store has a usable credential", () => {
+	withTempConfigDir(() => {
+		assert.equal(readEffectiveClaudeCredential(), null);
+	});
+});
+
+test("readEffectiveClaudeCredential: an empty access token is not usable", () => {
+	withTempConfigDir((dir) => {
+		fs.writeFileSync(
+			path.join(dir, ".credentials.json"),
+			JSON.stringify({ claudeAiOauth: { accessToken: "", refreshToken: "r", expiresAt: Date.now() + 1000 } }),
+		);
+		// An empty token must never be handed to a caller as "the credential" —
+		// it would 401 and be misread as a dead login.
+		assert.equal(readEffectiveClaudeCredential(), null);
 	});
 });

--- a/src/agents/claude-cli/claude-config.ts
+++ b/src/agents/claude-cli/claude-config.ts
@@ -148,10 +148,8 @@ export type ClaudeKeychainShadowState =
  * operator's back — a doctor that silently changes state is a doctor you
  * cannot use to reproduce a bug.
  */
-export function inspectClaudeKeychainShadow(
-	dir: string = resolveBrigadeClaudeConfigDir(),
-): ClaudeKeychainShadowState {
-	if (os.platform() !== "darwin") return "unsupported";
+function readClaudeKeychainCredential(dir: string): ClaudeCodeCredentialFile["claudeAiOauth"] | undefined {
+	if (os.platform() !== "darwin") return undefined;
 	let raw: string;
 	try {
 		raw = execFileSync("security", ["find-generic-password", "-s", claudeKeychainService(dir), "-w"], {
@@ -160,15 +158,61 @@ export function inspectClaudeKeychainShadow(
 			timeout: KEYCHAIN_CMD_TIMEOUT_MS,
 		});
 	} catch {
-		return "none"; // no entry — the file is already authoritative
+		return undefined; // no entry
 	}
-	let token: unknown;
 	try {
-		token = (JSON.parse(raw.trim()) as { claudeAiOauth?: { accessToken?: unknown } }).claudeAiOauth?.accessToken;
+		return (JSON.parse(raw.trim()) as ClaudeCodeCredentialFile).claudeAiOauth;
 	} catch {
-		token = undefined; // unparseable shadow is by definition unusable
+		return undefined; // unparseable
 	}
+}
+
+export function inspectClaudeKeychainShadow(
+	dir: string = resolveBrigadeClaudeConfigDir(),
+): ClaudeKeychainShadowState {
+	if (os.platform() !== "darwin") return "unsupported";
+	const shadow = readClaudeKeychainCredential(dir);
+	if (!shadow) return "none"; // no entry — the file is already authoritative
+	const token = shadow.accessToken;
 	return typeof token === "string" && token.length > 0 ? "healthy" : "tombstoned";
+}
+
+/**
+ * The credential the `claude` binary is ACTUALLY using — the freshest of the
+ * two stores, never a refresh.
+ *
+ * Brigade writes `.credentials.json`, but the binary owns the grant from then
+ * on: on macOS it rotates into the keychain and leaves our file behind. So the
+ * file goes stale within hours of a healthy install, and anything of Brigade's
+ * that authenticates with it (live model discovery) starts getting 401s and
+ * silently degrades.
+ *
+ * Read, do not refresh. Refreshing here would make Brigade a SECOND refresher
+ * of one grant, and since refresh tokens rotate the two would invalidate each
+ * other — the split-brain the managed-config design exists to prevent. The
+ * binary refreshes on every turn, so simply looking in the right place keeps us
+ * current with no re-auth ever asked of the operator.
+ */
+export function readEffectiveClaudeCredential(
+	dir: string = resolveBrigadeClaudeConfigDir(),
+): ClaudeCodeCredentialFile["claudeAiOauth"] | null {
+	let file: ClaudeCodeCredentialFile["claudeAiOauth"] | undefined;
+	try {
+		file = (JSON.parse(fs.readFileSync(path.join(dir, ".credentials.json"), "utf8")) as ClaudeCodeCredentialFile)
+			.claudeAiOauth;
+	} catch {
+		file = undefined;
+	}
+	const shadow = readClaudeKeychainCredential(dir);
+	const usable = (c: ClaudeCodeCredentialFile["claudeAiOauth"] | undefined): boolean =>
+		!!c && typeof c.accessToken === "string" && c.accessToken.length > 0;
+	if (!usable(shadow)) return usable(file) ? (file as ClaudeCodeCredentialFile["claudeAiOauth"]) : null;
+	if (!usable(file)) return shadow as ClaudeCodeCredentialFile["claudeAiOauth"];
+	// Both usable — the later expiry is the one the binary rotated into most
+	// recently, whichever store it lives in.
+	const fileExp = typeof file?.expiresAt === "number" ? file.expiresAt : 0;
+	const shadowExp = typeof shadow?.expiresAt === "number" ? shadow.expiresAt : 0;
+	return (shadowExp >= fileExp ? shadow : file) as ClaudeCodeCredentialFile["claudeAiOauth"];
 }
 
 export function healClaudeKeychainShadow(dir: string = resolveBrigadeClaudeConfigDir()): "none" | "cleared" {

--- a/src/agents/claude-cli/models-live.test.ts
+++ b/src/agents/claude-cli/models-live.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { __resetClaudeCliModelsCache, fetchClaudeCliModelIds } from "./models-live.js";
+
+/**
+ * A model Anthropic shipped after this release. It is deliberately NOT in
+ * `CLAUDE_CLI_MODELS` — that is the whole point: the picker must surface models
+ * the catalog has never heard of.
+ */
+const POST_RELEASE_MODEL = "claude-opus-99";
+
+test("fetchClaudeCliModelIds: serves the DISCOVERED list when no token is available", async () => {
+	const cacheDir = mkdtempSync(path.join(tmpdir(), "brigade-mcache-"));
+	const credDir = mkdtempSync(path.join(tmpdir(), "brigade-nocred-"));
+	const prevCache = process.env.BRIGADE_CACHE_DIR;
+	const prevCred = process.env.BRIGADE_CLAUDE_CONFIG_DIR;
+	process.env.BRIGADE_CACHE_DIR = cacheDir;
+	process.env.BRIGADE_CLAUDE_CONFIG_DIR = credDir; // empty → no credential at all
+	__resetClaudeCliModelsCache();
+	try {
+		fs.writeFileSync(
+			path.join(cacheDir, "claude-cli-models.json"),
+			JSON.stringify({ atMs: Date.now(), ids: [POST_RELEASE_MODEL, "claude-sonnet-5"] }),
+		);
+		const ids = await fetchClaudeCliModelIds({ force: true });
+		// Without persistence this collapsed to the frozen catalog on every restart,
+		// silently dropping any model newer than the release.
+		assert.ok(ids.includes(POST_RELEASE_MODEL), `expected ${POST_RELEASE_MODEL} in ${ids.join(",")}`);
+	} finally {
+		if (prevCache === undefined) delete process.env.BRIGADE_CACHE_DIR;
+		else process.env.BRIGADE_CACHE_DIR = prevCache;
+		if (prevCred === undefined) delete process.env.BRIGADE_CLAUDE_CONFIG_DIR;
+		else process.env.BRIGADE_CLAUDE_CONFIG_DIR = prevCred;
+		__resetClaudeCliModelsCache();
+		rmSync(cacheDir, { recursive: true, force: true });
+		rmSync(credDir, { recursive: true, force: true });
+	}
+});

--- a/src/agents/claude-cli/models-live.ts
+++ b/src/agents/claude-cli/models-live.ts
@@ -9,9 +9,13 @@
 // back to the static catalog, so discovery is a pure upgrade — never a
 // regression.
 
+import fs from "node:fs";
+import path from "node:path";
+
+import { resolveOsCacheDir } from "../../config/paths.js";
 import { readClaudeCliLogin } from "../../integrations/cli-login.js";
 import { CLAUDE_CLI_MODELS } from "./catalog.js";
-import { readBrigadeClaudeCredential } from "./claude-config.js";
+import { readEffectiveClaudeCredential } from "./claude-config.js";
 
 const MODELS_URL = "https://api.anthropic.com/v1/models?limit=100";
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -23,9 +27,45 @@ interface ModelsCache {
 }
 let cache: ModelsCache | undefined;
 
-/** The static fallback ids (the catalog snapshot). */
+/** Last-resort seed. Frozen at release, so it is the WORST source — used only
+ *  when we have never once discovered the live list on this machine. */
 function staticModelIds(): string[] {
 	return CLAUDE_CLI_MODELS.map((m) => m.id);
+}
+
+// A discovered list, persisted across restarts. The in-memory cache alone meant
+// every gateway restart fell back to the frozen catalog until the next
+// successful fetch — so a model Anthropic shipped after this release would
+// disappear from the picker on any restart that raced a stale token. Lives in
+// the OS cache dir: reapable by design, and writable in convex mode where
+// `~/.brigade` must stay file-free.
+function discoveredCachePath(): string {
+	return path.join(resolveOsCacheDir(), "claude-cli-models.json");
+}
+
+function readDiscoveredModelIds(): string[] | undefined {
+	try {
+		const raw = JSON.parse(fs.readFileSync(discoveredCachePath(), "utf8")) as { ids?: unknown };
+		const ids = Array.isArray(raw.ids) ? raw.ids.filter((i): i is string => typeof i === "string") : [];
+		return ids.length > 0 ? ids : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function writeDiscoveredModelIds(ids: string[]): void {
+	try {
+		const target = discoveredCachePath();
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, JSON.stringify({ atMs: Date.now(), ids }), "utf8");
+	} catch {
+		/* a cache we cannot persist is still usable in memory — never throw */
+	}
+}
+
+/** Best list available WITHOUT a network call: last discovered, else the seed. */
+function fallbackModelIds(): string[] {
+	return readDiscoveredModelIds() ?? staticModelIds();
 }
 
 /**
@@ -34,7 +74,10 @@ function staticModelIds(): string[] {
  * when neither is present (→ caller uses the static list).
  */
 function readAccessToken(): string | undefined {
-	const managed = readBrigadeClaudeCredential();
+	// The EFFECTIVE credential, not the file: on macOS the binary rotates into
+	// the keychain and leaves `.credentials.json` stale, which 401s this call
+	// and silently froze the picker to the release-time catalog.
+	const managed = readEffectiveClaudeCredential();
 	if (managed?.accessToken) return managed.accessToken;
 	const own = readClaudeCliLogin();
 	if (own?.type === "oauth" && own.access) return own.access;
@@ -53,7 +96,7 @@ export async function fetchClaudeCliModelIds(opts: { force?: boolean; nowMs?: nu
 	if (!opts.force && cache && now - cache.atMs < CACHE_TTL_MS) return cache.ids;
 
 	const token = readAccessToken();
-	if (!token) return staticModelIds();
+	if (!token) return fallbackModelIds();
 
 	try {
 		const res = await fetch(MODELS_URL, {
@@ -67,20 +110,21 @@ export async function fetchClaudeCliModelIds(opts: { force?: boolean; nowMs?: nu
 			},
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		});
-		if (!res.ok) return staticModelIds();
+		if (!res.ok) return fallbackModelIds();
 		const body = (await res.json()) as { data?: Array<{ id?: unknown }> };
 		const ids = (body.data ?? [])
 			.map((m) => (typeof m.id === "string" ? m.id : ""))
 			.filter((id): id is string => id.startsWith("claude-"));
-		if (ids.length === 0) return staticModelIds();
+		if (ids.length === 0) return fallbackModelIds();
 		// Merge: live ids first (current), then any static id the API omitted, so a
 		// catalogued default never vanishes from the picker.
 		const seen = new Set(ids);
 		for (const s of staticModelIds()) if (!seen.has(s)) ids.push(s);
 		cache = { atMs: now, ids };
+		writeDiscoveredModelIds(ids);
 		return ids;
 	} catch {
-		return staticModelIds();
+		return fallbackModelIds();
 	}
 }
 


### PR DESCRIPTION
… catalog

Opus 5 stopped appearing in the picker. It was never a model problem — the account offers it, and `--model claude-opus-5` runs fine. Two things conspired:

  1. `readAccessToken()` read `.credentials.json`. On macOS the binary owns the grant and rotates it into the KEYCHAIN, so that file goes stale within hours of a healthy install. The models call 401'd.
  2. On any failure, discovery fell back to `CLAUDE_CLI_MODELS` — a catalog frozen at release, which predates Opus 5.

So the picker silently reverted to a release-time snapshot, and every model Anthropic has shipped since became invisible.

Read the EFFECTIVE credential — the freshest of the file and the keychain shadow — rather than whichever store we happened to write. Deliberately a READ, never a refresh: refreshing here would make Brigade a second refresher of one grant, and since refresh tokens rotate the two would invalidate each other. That is the split-brain the managed-config design exists to prevent. The binary refreshes on every turn, so looking in the right place keeps us current without ever asking the operator to re-authenticate.

Persist the discovered list to the OS cache dir. The cache was in-memory only, so every gateway restart fell back to the frozen catalog until the next successful fetch — a restart racing a stale token dropped new models from the picker. The static catalog is now a last-resort seed, used only on a machine that has never once reached the API.

Deliberately NOT adding `claude-opus-5` to the catalog. Hardcoding is the bug: a new model ships and the list is stale again. Discovery has to carry it.

Cache lives in the OS cache dir, not `~/.brigade` — reapable by design, and writable in convex mode where the state dir must stay file-free.

<!--
Thanks for contributing to Brigade! Please fill out the sections below.
Use a Conventional Commit style title (e.g. `feat(cron): ...`, `fix(channels): ...`).
-->

## Summary

<!-- What does this PR do and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `refactor` / `perf` / `test` / `chore` / `ci`

## Checklist

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` compiles
- [ ] Added/updated tests for the change
- [ ] No secrets, real personal data, or local absolute paths in the diff
- [ ] PR title follows Conventional Commits

## Notes for reviewers

<!-- Anything reviewers should focus on, trade-offs, follow-ups, etc. -->
