### PR TITLE
fix(claude-cli): bound and shape-check discovered model ids

### DIFF
--- a/src/agents/claude-cli/models-live.test.ts
+++ b/src/agents/claude-cli/models-live.test.ts
@@ -41,3 +41,48 @@ test("fetchClaudeCliModelIds: serves the DISCOVERED list when no token is availa
 		rmSync(credDir, { recursive: true, force: true });
 	}
 });
+
+test("fetchClaudeCliModelIds: a tampered cache file cannot inject malformed ids", async () => {
+	const cacheDir = mkdtempSync(path.join(tmpdir(), "brigade-mcache-"));
+	const credDir = mkdtempSync(path.join(tmpdir(), "brigade-nocred-"));
+	const prevCache = process.env.BRIGADE_CACHE_DIR;
+	const prevCred = process.env.BRIGADE_CLAUDE_CONFIG_DIR;
+	process.env.BRIGADE_CACHE_DIR = cacheDir;
+	process.env.BRIGADE_CLAUDE_CONFIG_DIR = credDir;
+	__resetClaudeCliModelsCache();
+	try {
+		// These ids reach the picker, `brigade.json`, and the binary's `--model`
+		// argv, so the cache is a trust boundary even though it is local.
+		fs.writeFileSync(
+			path.join(cacheDir, "claude-cli-models.json"),
+			JSON.stringify({
+				atMs: Date.now(),
+				ids: [
+					"../../etc/passwd",
+					"claude- rm -rf /",
+					"claude-a\nb",
+					"gpt-4",
+					`claude-${"x".repeat(200)}`,
+					POST_RELEASE_MODEL, // the one legitimate entry
+				],
+			}),
+		);
+		const ids = await fetchClaudeCliModelIds({ force: true });
+		assert.ok(ids.includes(POST_RELEASE_MODEL), "the well-formed id must survive");
+		for (const bad of ["../../etc/passwd", "claude- rm -rf /", "claude-a\nb", "gpt-4"]) {
+			assert.ok(!ids.includes(bad), `malformed id leaked: ${bad}`);
+		}
+		assert.ok(
+			ids.every((id) => id.length <= 128),
+			"an oversized id leaked",
+		);
+	} finally {
+		if (prevCache === undefined) delete process.env.BRIGADE_CACHE_DIR;
+		else process.env.BRIGADE_CACHE_DIR = prevCache;
+		if (prevCred === undefined) delete process.env.BRIGADE_CLAUDE_CONFIG_DIR;
+		else process.env.BRIGADE_CLAUDE_CONFIG_DIR = prevCred;
+		__resetClaudeCliModelsCache();
+		rmSync(cacheDir, { recursive: true, force: true });
+		rmSync(credDir, { recursive: true, force: true });
+	}
+});

--- a/src/agents/claude-cli/models-live.ts
+++ b/src/agents/claude-cli/models-live.ts
@@ -39,6 +39,31 @@ function staticModelIds(): string[] {
 // disappear from the picker on any restart that raced a stale token. Lives in
 // the OS cache dir: reapable by design, and writable in convex mode where
 // `~/.brigade` must stay file-free.
+// Model ids arrive from the network and from a cache file on disk, then flow
+// into the picker, into `brigade.json`, and onto the spawned binary's `--model`
+// argv. Neither source is trusted: bound and shape-check at BOTH boundaries so
+// nothing unbounded or malformed is ever persisted or propagated. (CodeQL:
+// "network data written to file system".)
+const MAX_MODEL_IDS = 200;
+const MAX_MODEL_ID_LEN = 128;
+/** Every Claude model id is `claude-` + printable id chars. No spaces, no
+ *  control characters, no path separators. */
+const MODEL_ID_RE = /^claude-[A-Za-z0-9._[\]-]{1,120}$/;
+
+/** Bound, shape-check and de-duplicate ids from any untrusted source. */
+function sanitizeModelIds(raw: readonly unknown[]): string[] {
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const value of raw) {
+		if (out.length >= MAX_MODEL_IDS) break;
+		if (typeof value !== "string" || value.length > MAX_MODEL_ID_LEN) continue;
+		if (!MODEL_ID_RE.test(value) || seen.has(value)) continue;
+		seen.add(value);
+		out.push(value);
+	}
+	return out;
+}
+
 function discoveredCachePath(): string {
 	return path.join(resolveOsCacheDir(), "claude-cli-models.json");
 }
@@ -46,7 +71,7 @@ function discoveredCachePath(): string {
 function readDiscoveredModelIds(): string[] | undefined {
 	try {
 		const raw = JSON.parse(fs.readFileSync(discoveredCachePath(), "utf8")) as { ids?: unknown };
-		const ids = Array.isArray(raw.ids) ? raw.ids.filter((i): i is string => typeof i === "string") : [];
+		const ids = sanitizeModelIds(Array.isArray(raw.ids) ? raw.ids : []);
 		return ids.length > 0 ? ids : undefined;
 	} catch {
 		return undefined;
@@ -112,9 +137,7 @@ export async function fetchClaudeCliModelIds(opts: { force?: boolean; nowMs?: nu
 		});
 		if (!res.ok) return fallbackModelIds();
 		const body = (await res.json()) as { data?: Array<{ id?: unknown }> };
-		const ids = (body.data ?? [])
-			.map((m) => (typeof m.id === "string" ? m.id : ""))
-			.filter((id): id is string => id.startsWith("claude-"));
+		const ids = sanitizeModelIds((body.data ?? []).map((m) => m.id));
 		if (ids.length === 0) return fallbackModelIds();
 		// Merge: live ids first (current), then any static id the API omitted, so a
 		// catalogued default never vanishes from the picker.


### PR DESCRIPTION
Closes CodeQL alert 205 (`js/http-to-file-access`), raised on #127.

**This commit was pushed to #127 but the PR merged before it landed**, so the sanitiser is missing from `main` and shipped in 1.31.3. The alert is correctly still open.

## The finding

CodeQL flagged the persisted model cache as *"network data written to file system depends on untrusted data"* — and it's a fair hit. The ids were filtered only by `startsWith("claude-")`: no length bound, no count bound, no shape check.

The exposure is wider than the write. These ids reach the model picker, get persisted into `brigade.json`, and end up on the spawned binary's `--model` argv. The cache file on disk is a **second** untrusted source feeding that same path.

## The fix

One shared sanitiser at **both** boundaries — network parse and cache read: 200 ids max, 128 chars each, `claude-` plus printable id characters, de-duplicated.

Verified against every id the API currently returns, so no legitimate model is rejected:

| Accepted | Blocked |
|---|---|
| `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5` | `../../etc/passwd` |
| `claude-opus-4-5-20251101` (dated snapshots) | `claude-` + 200 chars |
| `claude-fable-5[1m]` (bracket variant) | `claude- rm -rf /` |
| `claude-3-7-sonnet-20250219` (legacy) | `claude-a\nb`, `claude-$(whoami)`, `gpt-4` |

The tail of the pattern is deliberately permissive. An allowlist of known model names would reintroduce exactly the staleness #127 exists to fix — the guarantee here is *bounded and printable*, not *known*.

## Verification

- Typecheck clean; suite green
- Regression test covers a tampered cache file: the well-formed id survives, every malformed one is dropped
- Live discovery still returns 12 models with `claude-opus-5` present