### PR TITLE
feat(sessions): name and delete threads from the TUI, gateway and agent

### DIFF
--- a/src/agents/claude-cli/models-live.test.ts
+++ b/src/agents/claude-cli/models-live.test.ts
@@ -72,10 +72,7 @@ test("fetchClaudeCliModelIds: a tampered cache file cannot inject malformed ids"
 		for (const bad of ["../../etc/passwd", "claude- rm -rf /", "claude-a\nb", "gpt-4"]) {
 			assert.ok(!ids.includes(bad), `malformed id leaked: ${bad}`);
 		}
-		assert.ok(
-			ids.every((id) => id.length <= 128),
-			"an oversized id leaked",
-		);
+		assert.ok(ids.every((id) => id.length <= 127), "an oversized id leaked");
 	} finally {
 		if (prevCache === undefined) delete process.env.BRIGADE_CACHE_DIR;
 		else process.env.BRIGADE_CACHE_DIR = prevCache;

--- a/src/agents/claude-cli/models-live.ts
+++ b/src/agents/claude-cli/models-live.ts
@@ -45,7 +45,9 @@ function staticModelIds(): string[] {
 // nothing unbounded or malformed is ever persisted or propagated. (CodeQL:
 // "network data written to file system".)
 const MAX_MODEL_IDS = 200;
-const MAX_MODEL_ID_LEN = 128;
+/** Fast path only — the regex below already caps at 127. Keeps a pathological
+ *  multi-MB string from ever reaching the regex engine. */
+const MAX_MODEL_ID_LEN = 127;
 /** Every Claude model id is `claude-` + printable id chars. No spaces, no
  *  control characters, no path separators. */
 const MODEL_ID_RE = /^claude-[A-Za-z0-9._[\]-]{1,120}$/;
@@ -141,8 +143,13 @@ export async function fetchClaudeCliModelIds(opts: { force?: boolean; nowMs?: nu
 		if (ids.length === 0) return fallbackModelIds();
 		// Merge: live ids first (current), then any static id the API omitted, so a
 		// catalogued default never vanishes from the picker.
-		const seen = new Set(ids);
-		for (const s of staticModelIds()) if (!seen.has(s)) ids.push(s);
+		// Merge the seed catalogue THROUGH the same sanitizer, so the cap and the
+		// shape check apply to what actually gets persisted. Appending past them
+		// wrote >200 ids to disk; the next start re-sanitized to 200 and dropped
+		// exactly the catalogue entries this merge exists to preserve.
+		const merged = sanitizeModelIds([...ids, ...staticModelIds()]);
+		ids.length = 0;
+		ids.push(...merged);
 		cache = { atMs: now, ids };
 		writeDiscoveredModelIds(ids);
 		return ids;

--- a/src/agents/tool-summaries.ts
+++ b/src/agents/tool-summaries.ts
@@ -47,6 +47,7 @@ export const BRIGADE_TOOL_SUMMARIES: Record<string, string> = {
   sessions_send: "Send a message to another session/sub-agent",
   sessions_history: "Fetch history for another session/sub-agent",
   sessions_spawn: "Spawn an isolated sub-agent session",
+  sessions_rename: "Name the conversation you are in, so it is recognisable in the thread list",
   subagents: "List, steer, or kill sub-agent runs for this requester session",
   spawn_agent: "Spawn a one-shot sub-agent for an independent, parallelisable subtask. Returns its final reply synchronously.",
   spawn_agents: "Spawn multiple independent sub-agents in parallel (one task each); returns their replies.",

--- a/src/agents/tools/sessions/index.ts
+++ b/src/agents/tools/sessions/index.ts
@@ -14,7 +14,7 @@
  *     sessionContext: buildSessionContext({ sessionKey }),
  *     callerDepth: resolveCallerDepth({ sessionKey }),
  *   });
- *   // tools is `{ send, spawn, list, history }` — each factory output
+ *   // tools is `{ send, spawn, list, history, rename }` — each factory output
  *   // is already wired with the caller's context.
  *   ```
  *
@@ -33,6 +33,7 @@ import type { SessionContext } from "../../session-context.js";
 import type { ChannelApprovalRoute } from "../../channels/approval-router.js";
 import { createSessionsHistoryTool } from "./history.js";
 import { createSessionsListTool } from "./list.js";
+import { createSessionsRenameTool } from "./rename.js";
 import { createSessionsSendTool } from "./send.js";
 import { createSessionsSpawnTool } from "./spawn.js";
 import type {
@@ -98,10 +99,11 @@ export interface SessionsToolsBundle {
 	spawn: ReturnType<typeof createSessionsSpawnTool>;
 	list: ReturnType<typeof createSessionsListTool>;
 	history: ReturnType<typeof createSessionsHistoryTool>;
+	rename: ReturnType<typeof createSessionsRenameTool>;
 }
 
 /**
- * Build the four-tool bundle the gateway dispatcher (Step 25) installs
+ * Build the sessions tool bundle the gateway dispatcher (Step 25) installs
  * for one agent turn. Every tool in the bundle is pre-wired with the
  * caller's session context — no further hand-threading needed.
  *
@@ -169,7 +171,15 @@ export function createSessionsToolsBundle(
 		agentSessionKey: sharedOpts.agentSessionKey,
 		...accessGuard,
 	});
-	return { send, spawn, list, history };
+	// No `accessGuard` spread: this tool can only ever touch the caller's OWN
+	// session, so visibility / A2A policy — which exist to gate reaching OTHER
+	// sessions — have nothing to decide. Requiring them would disable
+	// self-titling in legitimate configs for no security gain. The gateway's own
+	// access check still runs on the resulting `sessions.rename`.
+	const rename = createSessionsRenameTool({
+		agentSessionKey: sharedOpts.agentSessionKey,
+	});
+	return { send, spawn, list, history, rename };
 }
 
 /**
@@ -226,5 +236,6 @@ export function createSessionsBrigadeTools(
 		toBrigadeTool(bundle.spawn),
 		toBrigadeTool(bundle.list),
 		toBrigadeTool(bundle.history),
+		toBrigadeTool(bundle.rename),
 	];
 }

--- a/src/agents/tools/sessions/rename.test.ts
+++ b/src/agents/tools/sessions/rename.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { createSessionsRenameTool } from "./rename.js";
+
+test("sessions_rename: exposes no sessionKey parameter", () => {
+  const tool = createSessionsRenameTool({ agentSessionKey: "agent:main:main" });
+  const props = (tool.parameters as { properties?: Record<string, unknown>; additionalProperties?: boolean })
+    .properties;
+  // The bundle has NO owner gate, so a sessionKey argument would let an
+  // untrusted channel peer rename someone else's thread. Scoping to the
+  // caller's own session is the guard — it must not be re-introduced.
+  assert.deepEqual(Object.keys(props ?? {}), ["name"]);
+  assert.equal((tool.parameters as { additionalProperties?: boolean }).additionalProperties, false);
+});
+
+test("sessions_rename: fails closed with no caller session key", async () => {
+  const tool = createSessionsRenameTool({});
+  const res = await tool.execute({ name: "Anything" });
+  const payload = res.details?.payload as { status?: string; ok?: boolean } | undefined;
+  assert.ok(payload, "expected a structured payload");
+  assert.equal(payload.status, "forbidden");
+  assert.equal(payload.ok, false);
+});
+
+test("sessions_rename: malformed args are refused, never treated as a clear", async () => {
+  const tool = createSessionsRenameTool({ agentSessionKey: "agent:main:main" });
+  // Coercing non-strings to "" made every one of these a silent CLEAR that
+  // reported success — a model with a typo'd argument key erased the operator's
+  // thread name. Each must refuse instead.
+  for (const args of [{}, undefined, "Release prep", { title: "Release prep" }, { name: 42 }, { name: null }, []]) {
+    const res = await tool.execute(args);
+    const payload = res.details?.payload as { ok?: boolean; cleared?: boolean } | undefined;
+    assert.equal(payload?.ok, false, `accepted malformed args: ${JSON.stringify(args)}`);
+    assert.notEqual(payload?.cleared, true, `silently cleared the name for: ${JSON.stringify(args)}`);
+  }
+});
+
+test("sessions_rename: an explicit empty string is still an intentional clear", async () => {
+  const tool = createSessionsRenameTool({ agentSessionKey: "agent:main:main" });
+  const res = await tool.execute({ name: "" });
+  const payload = res.details?.payload as { ok?: boolean; error?: string } | undefined;
+  // Reaches the gateway (which is absent here, so it errors) rather than being
+  // rejected as malformed — clearing must remain expressible.
+  assert.ok(
+    !/must be a string|no `name` given|expects an object/.test(payload?.error ?? ""),
+    `an explicit "" must reach the gateway as a clear, not be refused: ${payload?.error}`,
+  );
+});

--- a/src/agents/tools/sessions/rename.ts
+++ b/src/agents/tools/sessions/rename.ts
@@ -1,0 +1,125 @@
+/**
+ * `sessions_rename` agent tool.
+ *
+ * Lets an agent name the thread it is ALREADY IN — "title this conversation
+ * from what we discussed" — so a history list reads as topics rather than
+ * opaque session keys.
+ *
+ * Deliberately takes NO `sessionKey` parameter. The target is always the
+ * caller's own `agentSessionKey`, for a specific reason: this bundle has no
+ * owner gate (`createSessionsBrigadeTools` receives no `senderIsOwner`, and no
+ * sessions tool declares `ownerOnly`), so any channel peer's turn can reach
+ * these tools. A `sessionKey` argument would therefore let an untrusted sender
+ * rename threads belonging to other people or other agents. Scoping to self
+ * removes that class of abuse entirely rather than trying to police it — and
+ * costs nothing, because titling the current thread is the whole use case.
+ *
+ * The gateway still enforces its own access check on the resulting
+ * `sessions.rename` call, so this is defence in depth, not the only guard.
+ *
+ * Output shape: `{ ok, name? }` — `name` absent when the name was cleared.
+ */
+
+import { callGateway } from "../../gateway-call.js";
+import {
+	jsonToolResult,
+	SESSIONS_RENAME_TOOL_DISPLAY_SUMMARY,
+	type ToolResultEnvelope,
+} from "./shared.js";
+
+export interface SessionsRenameToolArgs {
+	/** Empty / omitted CLEARS the name — the same verb removes it. */
+	name?: string;
+}
+
+export interface SessionsRenameToolOptions {
+	/** The caller's OWN session key. Absent → the tool refuses (fail-closed). */
+	agentSessionKey?: string;
+}
+
+export interface SessionsRenameToolDescriptor {
+	name: "sessions_rename";
+	displaySummary: string;
+	description: string;
+	parameters: Record<string, unknown>;
+	execute: (args: unknown) => Promise<ToolResultEnvelope>;
+}
+
+const SESSIONS_RENAME_SCHEMA: Record<string, unknown> = {
+	type: "object",
+	properties: {
+		name: {
+			type: "string",
+			maxLength: 120,
+			description:
+				"Short title for THIS conversation — a few words describing what it is about. Omit or pass an empty string to clear the name.",
+		},
+	},
+	additionalProperties: false,
+};
+
+function describeSessionsRenameTool(): string {
+	return [
+		"Name the conversation you are currently in, so it is recognisable in the thread list.",
+		"You can only name THIS thread — there is no way to name another one.",
+		"Use a short, specific title (a few words). Omit `name` to clear it.",
+	].join(" ");
+}
+
+export function createSessionsRenameTool(
+	opts: SessionsRenameToolOptions = {},
+): SessionsRenameToolDescriptor {
+	return {
+		name: "sessions_rename",
+		displaySummary: SESSIONS_RENAME_TOOL_DISPLAY_SUMMARY,
+		description: describeSessionsRenameTool(),
+		parameters: SESSIONS_RENAME_SCHEMA,
+		execute: async (args) => {
+			const sessionKey = opts.agentSessionKey;
+			// Fail-closed: with no caller key there is no "own thread" to name, and
+			// guessing one would be exactly the cross-thread write this tool avoids.
+			if (!sessionKey) {
+				return jsonToolResult({
+					status: "forbidden",
+					error: "sessions_rename forbidden: no caller session key",
+					ok: false,
+				});
+			}
+			// Coercing anything non-string to "" made EVERY malformed call a silent
+			// CLEAR: `{}`, `{title:"x"}`, `{name:42}` and a bare string argument all
+			// wiped the operator's name and reported success. Clearing must be an
+			// explicit empty string, and anything else is an input error.
+			if (args !== undefined && (typeof args !== "object" || args === null || Array.isArray(args))) {
+				return jsonToolResult({ ok: false, error: "sessions_rename expects an object with a `name` field" });
+			}
+			const raw = (args as { name?: unknown } | undefined)?.name;
+			if (raw !== undefined && typeof raw !== "string") {
+				return jsonToolResult({ ok: false, error: "`name` must be a string (pass \"\" to clear it)" });
+			}
+			if (raw === undefined) {
+				return jsonToolResult({
+					ok: false,
+					error: 'no `name` given — pass a title, or "" to clear the current one',
+				});
+			}
+			const name = raw;
+			try {
+				const res = await callGateway<{ ok?: boolean; name?: string }>({
+					method: "sessions.rename",
+					params: { sessionKey, name },
+				});
+				if (!res?.ok) {
+					// The thread has no store entry yet (no turn has been persisted).
+					// A miss, not an error — never worth failing the turn over.
+					return jsonToolResult({ ok: false, error: "this thread cannot be named yet" });
+				}
+				return jsonToolResult(res.name ? { ok: true, name: res.name } : { ok: true, cleared: true });
+			} catch (err) {
+				return jsonToolResult({
+					ok: false,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		},
+	};
+}

--- a/src/agents/tools/sessions/shared.ts
+++ b/src/agents/tools/sessions/shared.ts
@@ -390,6 +390,7 @@ export const SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY =
 export const SESSIONS_SEND_TOOL_DISPLAY_SUMMARY =
 	"Send a message to another visible session.";
 export const SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY = "Spawn a sub-agent session.";
+export const SESSIONS_RENAME_TOOL_DISPLAY_SUMMARY = "Name the current conversation.";
 
 export function describeSessionsListTool(): string {
 	return [

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -22,6 +22,8 @@
 import { COPILOT_AUTO_MODEL_ID } from "../../agents/github-copilot-transport.js";
 import process from "node:process";
 import { randomUUID } from "node:crypto";
+
+import { sanitizeSessionName } from "../../sessions/session-store.js";
 import * as nodePath from "node:path";
 
 import {
@@ -69,7 +71,16 @@ import { asstKey, clipOneLine, extractUserText } from "./connect-transcript.js";
 import { UPDATE_PRESERVES_MESSAGE } from "../../core/update-check.js";
 import { runUpdateCommand } from "./update.js";
 import { ApprovalPrompt, type ApprovalResolution } from "../../tui/approval-prompt.js";
-import type { AgentSummary, EventPayload, ModelSummary, PromptAttachment, SessionStateSnapshot, SessionSummary } from "../../protocol.js";
+import type {
+	AgentSummary,
+	EventPayload,
+	ModelSummary,
+	PromptAttachment,
+	SessionDeleteResult,
+	SessionRenameResult,
+	SessionStateSnapshot,
+	SessionSummary,
+} from "../../protocol.js";
 import {
 	computeExplain,
 	filterGraphToSubtree,
@@ -409,6 +420,23 @@ export async function wireConnectUi(
 	// Seeded by `--session <key>` (already resolved + verified against sessions.list).
 	// Left undefined, the first `state` snapshot seeds it with the agent's main thread.
 	let boundSessionKey: string | undefined = initialSessionKey;
+	// A name typed before the thread exists on the gateway. `/new` mints a key
+	// CLIENT-side and no store entry is written until the first turn, so
+	// "start a thread and name it" — the most natural order — had nothing to
+	// rename. Hold the name and apply it once the turn creates the entry.
+	//
+	// Bound to a SPECIFIC key, and re-checked at apply time: if the operator
+	// moves to another thread first, this must never land on the wrong one.
+	let pendingRename: { sessionKey: string; name: string } | undefined;
+	// Key awaiting a confirming repeat of `/delete`. Cleared on any other
+	// `/delete` form so a stale confirmation can never execute later.
+	let pendingDeleteKey: string | undefined;
+	/** Disarm a `/delete` confirmation. Called on EVERY other submitted line, so
+	 *  an armed key cannot survive unrelated work and fire on a later repeat that
+	 *  the operator expected to re-arm rather than execute. */
+	const disarmPendingDelete = (): void => {
+		pendingDeleteKey = undefined;
+	};
 	// Residual P0 (post-Wave K integration audit) — the WS broadcast filter
 	// at server.ts:903 keys on per-connection subscription Sets populated by
 	// the `subscribe` RPC. Without an explicit subscribe, the filter falls
@@ -886,6 +914,16 @@ export async function wireConnectUi(
 			argumentHint: "[--all]",
 		},
 		{
+			name: "rename",
+			description: "name this thread (no argument clears the name)",
+			argumentHint: "[<name>]",
+		},
+		{
+			name: "delete",
+			description: "permanently delete a thread and its transcript (confirm by repeating)",
+			argumentHint: "<session-key>",
+		},
+		{
 			name: "mute",
 			description: "unsubscribe from an agent id or session key",
 			argumentHint: "<agent-id|session-key>",
@@ -904,7 +942,7 @@ export async function wireConnectUi(
 	// providers still need `brigade onboard` on the gateway machine.
 	tui.addChild(
 		new Text(
-			brand.dim("  connect-mode: /new /agent /agents /session /sessions · /model /provider /thinking /reasoning · /abort /steer /compact · /usage /help"),
+			brand.dim("  connect-mode: /new /agent /agents /session /sessions /rename /delete · /model /provider /thinking /reasoning · /abort /steer /compact · /usage /help"),
 			0,
 			0,
 		),
@@ -1849,6 +1887,35 @@ export async function wireConnectUi(
 				agentStartedAt = null;
 				editor.disableSubmit = false;
 				activeAssistants.clear();
+				// The turn just created the store entry a pre-turn `/rename` had
+				// nothing to write to. Apply it now — but only if we are STILL on the
+				// thread the name was typed for; the operator may have moved on.
+				// Cleared either way: a queued name must not retry forever.
+				if (pendingRename && pendingRename.sessionKey === (boundSessionKey ?? lastSnapshot?.sessionKey)) {
+					const queued = pendingRename;
+					pendingRename = undefined;
+					void client
+						.request("sessions.rename", { sessionKey: queued.sessionKey, name: queued.name })
+						.then((r) => {
+							const res = r as SessionRenameResult | undefined;
+							if (res?.ok && res.name) {
+								insertBeforeEditor(new Text(`  ${brand.amber("✓")} renamed to ${brand.white(scrubRenderable(res.name))}`, 0, 0));
+							} else {
+								// We PROMISED this name would land. Silence here left the
+								// operator believing a rename happened that never did.
+								insertBeforeEditor(
+									new Text(`  ${brand.dim("could not name this thread — try /rename again")}`, 0, 0),
+								);
+							}
+							tui.requestRender();
+						})
+						.catch(() => {
+							insertBeforeEditor(
+								new Text(`  ${brand.dim("could not name this thread — try /rename again")}`, 0, 0),
+							);
+							tui.requestRender();
+						});
+				}
 				// Turn-end is the definitive flush point — even if every other
 				// path missed flushing, this guarantees the last paint of the
 				// turn lands before the editor re-enables for the operator.
@@ -2494,6 +2561,11 @@ export async function wireConnectUi(
 		// from a malicious page) can otherwise corrupt the terminal or smuggle control
 		// bytes into the transcript. The single submit chokepoint covers every path.
 		const trimmed = sanitizeTerminalInput(value).trim();
+		// Any line that is not a `/delete` disarms a pending confirmation. Without
+		// this the armed key survived arbitrary intervening work, so repeating the
+		// command an hour later — expecting the warning again — deleted on the
+		// first Enter. Irreversible operations must not stay armed in the dark.
+		if (!trimmed.startsWith("/delete")) disarmPendingDelete();
 		// An empty line normally does nothing. The ONE exception is a wordless send of
 		// staged files — "drop an image, press Enter" is a legitimate turn (the media
 		// note alone is a valid prompt, and the agent describes what it sees).
@@ -2588,6 +2660,8 @@ export async function wireConnectUi(
 						`- ${chalk.bold("/session [<key>]")} — show/bind the connection's active session\n` +
 						`- ${chalk.bold("/agents")} — list every agent the gateway knows about\n` +
 						`- ${chalk.bold("/sessions [--all]")} — list live sessions (bound agent or all)\n` +
+						`- ${chalk.bold("/rename [<name>]")} — name this thread (no argument clears the name)\n` +
+						`- ${chalk.bold("/delete <session-key>")} — permanently delete a thread + transcript (repeat to confirm)\n` +
 						`- ${chalk.bold("/mute <id|key>")} — unsubscribe from an agent id or session key\n` +
 						`- ${chalk.bold("/memory")} — list recent memories\n` +
 						`- ${chalk.bold("/memory search <q>")} — search memories by keyword\n` +
@@ -2750,6 +2824,153 @@ export async function wireConnectUi(
 			return;
 		}
 
+		// /delete <session-key> — delete a thread and its transcript.
+		//
+		// Requires an EXPLICIT key and a confirming repeat. Deletion is
+		// irreversible and there is no agent tool for it, so the two frictions
+		// are deliberate: no argument means the operator cannot fat-finger away
+		// the thread they are sitting in, and the repeat means a key pasted from
+		// `/sessions` is not executed on the first Enter.
+		if (trimmed === "/delete" || trimmed.startsWith("/delete ")) {
+			editor.setText("");
+			const key = trimmed === "/delete" ? "" : trimmed.slice("/delete ".length).trim();
+			if (!key) {
+				insertBeforeEditor(
+					new Text(
+						`  ${brand.dim("usage: /delete <session-key> — deletes the thread AND its transcript, permanently")}\n  ${brand.dim("(`/sessions` lists the keys)")}`,
+						0,
+						0,
+					),
+				);
+				pendingDeleteKey = undefined;
+				return;
+			}
+			if (pendingDeleteKey !== key) {
+				pendingDeleteKey = key;
+				insertBeforeEditor(
+					new Text(
+						`  ${brand.error("!")} ${brand.dim("this permanently deletes")} ${brand.white(key)} ${brand.dim("and its transcript.")}\n  ${brand.dim("run the same command again to confirm")}`,
+						0,
+						0,
+					),
+				);
+				return;
+			}
+			pendingDeleteKey = undefined;
+			try {
+				const res = (await client.request("sessions.delete", { sessionKey: key })) as SessionDeleteResult;
+				if (!res?.ok) {
+					insertBeforeEditor(
+						new Text(`  ${brand.error("✗")} ${brand.error(res?.reason ?? "could not delete that session")}`, 0, 0),
+					);
+					return;
+				}
+				// An orphaned transcript is a disk leak the operator should hear about
+				// — "deleted" must not quietly mean "mostly deleted".
+				const note =
+					res.transcriptRemoved === false
+						? ` ${brand.dim("(entry removed; its transcript may still be on disk)")}`
+						: "";
+				const wasBound = (boundSessionKey ?? lastSnapshot?.sessionKey) === key;
+				// The notice MUST come after any `clearTranscriptRegion()` below, which
+				// removes every child between the divider and the editor — printing it
+				// first wiped the "transcript may still be on disk" warning before it
+				// painted. `/new` carries the same warning about this exact ordering.
+				if (!wasBound) {
+					insertBeforeEditor(new Text(`  ${brand.amber("✓")} deleted ${brand.white(key)}${note}`, 0, 0));
+				}
+				if (wasBound) {
+					// Do NOT simply unbind: with no bound key the prompt handler falls
+					// back to the BOOT session, so the next message would land in
+					// `agent:main:main` with all its history — the opposite of what
+					// deleting the thread you were in should do. Mint a fresh key, as
+					// `/new` does.
+					const agentForNext = boundAgentId ?? lastSnapshot?.agentId ?? DEFAULT_AGENT_ID;
+					boundSessionKey = `agent:${agentForNext}:t-${randomUUID().slice(0, 8)}`;
+					clearTranscriptRegion();
+					insertBeforeEditor(new Text(`  ${brand.amber("✓")} deleted ${brand.white(key)}${note}`, 0, 0));
+					insertBeforeEditor(
+						new Text(`  ${brand.dim("moved to a new thread")} ${brand.amber(boundSessionKey)}`, 0, 0),
+					);
+					// The full context switch, matching `/new` / `/session` / `/agent`.
+					// Omitting these left files staged for the DELETED thread armed to
+					// upload into the new one, and the connection still subscribed to a
+					// key that no longer exists — so the next turn streamed nothing.
+					clearTrayForContextSwitch("the new thread");
+					updateHeader();
+					void applySubscription();
+				}
+				// A queued name for the deleted thread is dead regardless of whether we
+				// were sitting in it — otherwise it lingers and can later retitle a
+				// recreated thread with the same key.
+				if (pendingRename?.sessionKey === key) pendingRename = undefined;
+			} catch (err) {
+				insertBeforeEditor(
+					new Text(`  ${brand.error("✗")} ${brand.error(err instanceof Error ? err.message : String(err))}`, 0, 0),
+				);
+			}
+			return;
+		}
+
+		// /rename [name] — name the thread you are in. No argument CLEARS the
+		// name, so removing one is the same verb rather than a second command.
+		// Naming is metadata, not activity: the gateway deliberately does not
+		// touch `lastUsedAt`, so renaming never reorders the history.
+		if (trimmed === "/rename" || trimmed.startsWith("/rename ")) {
+			editor.setText("");
+			// `String.trim()` does not strip C0 controls, so `/rename <ctrl>` looked
+			// like a name here while the server's sanitizer reduced it to nothing and
+			// CLEARED the existing name. Normalise with the same rules the server
+			// applies so the branch below and the preview both match what is stored.
+			const raw = sanitizeSessionName(trimmed === "/rename" ? "" : trimmed.slice("/rename ".length)) ?? "";
+			const targetKey = boundSessionKey ?? lastSnapshot?.sessionKey;
+			if (!targetKey) {
+				insertBeforeEditor(
+					new Text(`  ${brand.dim("no session bound yet — send a message first, or /session <key>")}`, 0, 0),
+				);
+				return;
+			}
+			try {
+				const res = (await client.request("sessions.rename", {
+					sessionKey: targetKey,
+					name: raw,
+				})) as SessionRenameResult;
+				if (!res?.ok) {
+					// The thread has no store entry yet — almost always a `/new` key.
+					// Hold the name rather than dead-ending; the first turn creates the
+					// entry and `agent_end` flushes it. Clearing (empty argument) has
+					// nothing to hold: there is no name on a thread that does not exist.
+					if (!raw) {
+						pendingRename = undefined;
+						insertBeforeEditor(new Text(`  ${brand.dim("nothing to clear — this thread has no name yet")}`, 0, 0));
+						return;
+					}
+					pendingRename = { sessionKey: targetKey, name: raw };
+					insertBeforeEditor(
+						new Text(`  ${brand.amber("✓")} ${brand.dim("will name this thread")} ${brand.white(raw)} ${brand.dim("once you send a message")}`, 0, 0),
+					);
+					return;
+				}
+				// Supersede only a queue for THIS thread — a name waiting on a
+				// different, not-yet-persisted thread was promised and must survive.
+				if (pendingRename?.sessionKey === targetKey) pendingRename = undefined;
+				insertBeforeEditor(
+					new Text(
+						res.name
+							? `  ${brand.amber("✓")} renamed to ${brand.white(scrubRenderable(res.name))}`
+							: `  ${brand.amber("✓")} ${brand.dim("name cleared")}`,
+						0,
+						0,
+					),
+				);
+			} catch (err) {
+				insertBeforeEditor(
+					new Text(`  ${brand.error("✗")} ${brand.error(err instanceof Error ? err.message : String(err))}`, 0, 0),
+				);
+			}
+			return;
+		}
+
 		// /sessions [--all] — list live (in-flight Pi) sessions. Defaults to
 		// the bound agent's sessions; `--all` returns every agent's. Wave N5
 		// (bug #9). Combine with /session <key> to bind to one of them.
@@ -2792,7 +3013,21 @@ export async function wireConnectUi(
 			}
 			const boundKey = boundSessionKey ?? lastSnapshot?.sessionKey;
 			const lines = sessions.map((s) => {
-				const friendly = formatSessionLabel(s.sessionKey) ?? brand.dim("(home)");
+				// Show the name ALONGSIDE the derived label, never instead of it, and
+				// quote it so it reads as operator-supplied data. `sessions_rename`
+				// has no owner gate, so an untrusted channel peer can name their own
+				// thread — replacing the label would let them make it render as e.g.
+				// `Mom` in this picker. Scrubbed like every other gateway-pushed
+				// string before it reaches the screen.
+				const label = formatSessionLabel(s.sessionKey) ?? brand.dim("(home)");
+				// This row is rendered through `Markdown`, and the name is operator- OR
+				// channel-peer-supplied (`sessions_rename` has no owner gate). Escape
+				// the metacharacters and the quote, or a name can style itself, emit a
+				// link, or close the quoting and spoof the key / `← bound` marker.
+				const named = s.displayName
+					? scrubRenderable(s.displayName).replace(/[\\`*_[\]()"~|]/g, "\\$&")
+					: undefined;
+				const friendly = named ? `${label} ${brand.white(`"${named}"`)}` : label;
 				const here = s.sessionKey === boundKey ? " " + brand.amber("← bound") : "";
 				return `  ${brand.white(s.agentId)}  ${friendly}  ${brand.dim(s.sessionKey)}${here}`;
 			});
@@ -2801,7 +3036,7 @@ export async function wireConnectUi(
 				: `live sessions for agent ${boundAgentId ?? lastSnapshot?.agentId ?? "main"}:`;
 			insertBeforeEditor(
 				new Markdown(
-					`${brand.dim(scopeLine)}\n${lines.join("\n")}\n\n${brand.dim("usage: /session <key> to bind · /mute <id|key> to unsubscribe")}`,
+					`${brand.dim(scopeLine)}\n${lines.join("\n")}\n\n${brand.dim("usage: /session <key> to bind · /rename <name> to name this thread · /mute <id|key> to unsubscribe")}`,
 					1,
 					0,
 					markdownTheme,

--- a/src/core/server-methods/sessions-delete.test.ts
+++ b/src/core/server-methods/sessions-delete.test.ts
@@ -1,0 +1,156 @@
+import { strict as assert } from "node:assert";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { handleSessionsDelete } from "./sessions.js";
+import { readSessionStore, upsertSessionEntry } from "../../sessions/session-store.js";
+import { resolveSessionTranscriptPath } from "../../config/paths.js";
+
+async function withTempState(fn: () => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), "brigade-del-"));
+  const prev = process.env.BRIGADE_STATE_DIR;
+  process.env.BRIGADE_STATE_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) delete process.env.BRIGADE_STATE_DIR;
+    else process.env.BRIGADE_STATE_DIR = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function seedWithTranscript(agentId: string, key: string): string {
+  const entry = upsertSessionEntry(agentId, key, {});
+  const transcript = resolveSessionTranscriptPath(agentId, entry.sessionId);
+  mkdirSync(path.dirname(transcript), { recursive: true });
+  writeFileSync(transcript, '{"type":"session","id":"x"}\n');
+  writeFileSync(`${transcript}.lock`, "{}");
+  return transcript;
+}
+
+const noLive = (): boolean => false;
+
+/** Stands in for the runtime context's store — the ONLY correct way to remove a
+ *  transcript, since in convex mode it lives in a table, not on disk. */
+function fsStore(): { messages: { deleteTranscript: (a: string, s: string) => Promise<void> } } {
+  return {
+    messages: {
+      deleteTranscript: async (agentId: string, sessionId: string) => {
+        const t = resolveSessionTranscriptPath(agentId, sessionId);
+        rmSync(t, { force: true });
+        rmSync(`${t}.lock`, { force: true });
+      },
+    },
+  };
+}
+
+test("handleSessionsDelete: removes the entry AND the transcript", async () => {
+  await withTempState(async () => {
+    const transcript = seedWithTranscript("main", "agent:main:t-1111");
+    assert.equal(existsSync(transcript), true);
+
+    const res = await handleSessionsDelete({ sessionKey: "agent:main:t-1111" }, { isLive: noLive, store: fsStore() });
+    assert.equal(res.ok, true);
+    assert.equal(res.transcriptRemoved, true);
+    assert.equal(readSessionStore("main").sessions["agent:main:t-1111"], undefined);
+    // A half-delete — entry gone, megabytes of conversation still on disk — is
+    // the wrong outcome for someone who asked for it to be gone.
+    assert.equal(existsSync(transcript), false, "transcript survived the delete");
+    assert.equal(existsSync(`${transcript}.lock`), false, "stale write-lock survived");
+  });
+});
+
+test("handleSessionsDelete: refuses while a turn is running", async () => {
+  await withTempState(async () => {
+    const transcript = seedWithTranscript("main", "agent:main:t-2222");
+    const res = await handleSessionsDelete(
+      { sessionKey: "agent:main:t-2222" },
+      { isLive: () => true },
+    );
+    assert.equal(res.ok, false);
+    assert.match(res.reason ?? "", /active|running/i);
+    // Nothing may be destroyed on a refusal.
+    assert.notEqual(readSessionStore("main").sessions["agent:main:t-2222"], undefined);
+    assert.equal(existsSync(transcript), true);
+  });
+});
+
+test("handleSessionsDelete: unknown session is a clean miss", async () => {
+  await withTempState(async () => {
+    const res = await handleSessionsDelete({ sessionKey: "agent:main:ghost" }, { isLive: noLive, store: fsStore() });
+    assert.equal(res.ok, false);
+    assert.match(res.reason ?? "", /no such session/i);
+  });
+});
+
+test("handleSessionsDelete: refuses when the access guard denies", async () => {
+  await withTempState(async () => {
+    const transcript = seedWithTranscript("main", "agent:main:t-3333");
+    await assert.rejects(
+      () =>
+        handleSessionsDelete(
+          { sessionKey: "agent:main:t-3333" },
+          { isLive: noLive, store: fsStore(), accessCheck: () => ({ allowed: false, reason: "denied" }) },
+        ),
+      /denied|forbidden/i,
+    );
+    assert.equal(existsSync(transcript), true, "guard refusal must not delete anything");
+  });
+});
+
+test("handleSessionsDelete: deletes only the named thread", async () => {
+  await withTempState(async () => {
+    const keep = seedWithTranscript("main", "agent:main:t-keep");
+    seedWithTranscript("main", "agent:main:t-drop");
+    await handleSessionsDelete({ sessionKey: "agent:main:t-drop" }, { isLive: noLive, store: fsStore() });
+    const store = readSessionStore("main").sessions;
+    assert.notEqual(store["agent:main:t-keep"], undefined);
+    assert.equal(store["agent:main:t-drop"], undefined);
+    assert.equal(existsSync(keep), true);
+  });
+});
+
+test("handleSessionsDelete: filesystem-mode delete with no store still removes the JSONL", async () => {
+  await withTempState(async () => {
+    const transcript = seedWithTranscript("main", "agent:main:t-4444");
+    // No store wired (cold CLI). In filesystem mode the JSONL IS the transcript,
+    // so it must actually go — and the report must match. Claiming "may still be
+    // on disk" about a file we just deleted is the same lie as the reverse.
+    const res = await handleSessionsDelete({ sessionKey: "agent:main:t-4444" }, { isLive: noLive });
+    assert.equal(res.ok, true);
+    assert.equal(existsSync(transcript), false, "transcript survived");
+    assert.equal(res.transcriptRemoved, true);
+    assert.equal(existsSync(`${transcript}.lock`), false, "orphaned write-lock survived");
+  });
+});
+
+test("handleSessionsDelete: rejects a non-canonical key instead of hitting the default agent", async () => {
+  await withTempState(async () => {
+    const transcript = seedWithTranscript("main", "agent:main:t-5555");
+    // `resolveAgentIdFromSessionKey` collapses ANY unparseable key to `main`, so
+    // without the canonical-shape check `/delete legacy-main` on another agent's
+    // thread would destroy main's identically-keyed entry instead.
+    for (const bad of ["legacy-main", "constructor", "toString", "__proto__", ""]) {
+      const res = await handleSessionsDelete({ sessionKey: bad }, { isLive: noLive, store: fsStore() });
+      assert.equal(res.ok, false, `accepted a non-canonical key: ${bad}`);
+    }
+    // Nothing real may have been touched.
+    assert.notEqual(readSessionStore("main").sessions["agent:main:t-5555"], undefined);
+    assert.equal(existsSync(transcript), true);
+    // …and no phantom entries were conjured onto the prototype chain.
+    assert.deepEqual(
+      Object.keys(readSessionStore("main").sessions).filter((k) => !k.startsWith("agent:")),
+      [],
+    );
+  });
+});
+
+test("handleSessionsDelete: removes the write-lock sidecar the stores never own", async () => {
+  await withTempState(async () => {
+    const transcript = seedWithTranscript("main", "agent:main:t-6666");
+    await handleSessionsDelete({ sessionKey: "agent:main:t-6666" }, { isLive: noLive, store: fsStore() });
+    assert.equal(existsSync(`${transcript}.lock`), false, "orphaned write-lock survived");
+  });
+});

--- a/src/core/server-methods/sessions-rename.test.ts
+++ b/src/core/server-methods/sessions-rename.test.ts
@@ -1,0 +1,113 @@
+import { strict as assert } from "node:assert";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { handleSessionsRename } from "./sessions.js";
+import { readSessionStore, upsertSessionEntry } from "../../sessions/session-store.js";
+
+function withTempState(fn: (dir: string) => Promise<void> | void): Promise<void> | void {
+  const dir = mkdtempSync(path.join(tmpdir(), "brigade-rename-h-"));
+  const prev = process.env.BRIGADE_STATE_DIR;
+  process.env.BRIGADE_STATE_DIR = dir;
+  const restore = (): void => {
+    if (prev === undefined) delete process.env.BRIGADE_STATE_DIR;
+    else process.env.BRIGADE_STATE_DIR = prev;
+    rmSync(dir, { recursive: true, force: true });
+  };
+  try {
+    const out = fn(dir);
+    return out instanceof Promise ? out.finally(restore) : (restore(), undefined);
+  } catch (err) {
+    restore();
+    throw err;
+  }
+}
+
+test("handleSessionsRename: renames the session named by the key", async () => {
+  await withTempState(async () => {
+    upsertSessionEntry("main", "agent:main:main", {});
+    const res = await handleSessionsRename({ sessionKey: "agent:main:main", name: "  Release   prep " });
+    assert.equal(res.ok, true);
+    assert.equal(res.name, "Release prep");
+    assert.equal(readSessionStore("main").sessions["agent:main:main"]?.name, "Release prep");
+  });
+});
+
+test("handleSessionsRename: unknown session is a clean miss, never a create", async () => {
+  await withTempState(async () => {
+    const res = await handleSessionsRename({ sessionKey: "agent:main:ghost", name: "Nope" });
+    assert.equal(res.ok, false);
+    assert.equal(readSessionStore("main").sessions["agent:main:ghost"], undefined);
+  });
+});
+
+test("handleSessionsRename: refuses when the access guard denies", async () => {
+  await withTempState(async () => {
+    upsertSessionEntry("main", "agent:main:main", {});
+    await assert.rejects(
+      () =>
+        handleSessionsRename(
+          { sessionKey: "agent:main:main", name: "Nope" },
+          { accessCheck: () => ({ allowed: false, reason: "denied" }) },
+        ),
+      /denied|forbidden/i,
+    );
+    assert.equal(readSessionStore("main").sessions["agent:main:main"]?.name, undefined);
+  });
+});
+
+test("handleSessionsRename: a caller-supplied agentId cannot redirect the write", async () => {
+  await withTempState(async (dir) => {
+    upsertSessionEntry("main", "agent:main:main", {});
+    // The access guard is handed only `sessionKey`. If the handler honoured an
+    // `agentId` param it would write to a store the guard never authorised —
+    // and `resolveAgentDir` path-joins the id unvalidated, so `../../outside`
+    // escapes the state dir entirely. The agent MUST come from the key.
+    await handleSessionsRename({
+      sessionKey: "agent:main:main",
+      name: "Owned",
+      // @ts-expect-error — deliberately passing a param the type no longer has
+      agentId: "../../outside",
+    });
+    assert.equal(readSessionStore("main").sessions["agent:main:main"]?.name, "Owned");
+    assert.equal(existsSync(path.join(dir, "..", "outside")), false, "escaped the state dir");
+  });
+});
+
+test("handleSessionsRename: the /new → send → named sequence", async () => {
+  await withTempState(async () => {
+    const key = "agent:main:t-abc12345"; // what `/new` mints, client-side only
+
+    // 1. Typed before the thread exists: a clean miss, and nothing conjured.
+    //    This is what makes the TUI hold the name instead of dead-ending.
+    const early = await handleSessionsRename({ sessionKey: key, name: "Release prep" });
+    assert.equal(early.ok, false);
+    assert.equal(readSessionStore("main").sessions[key], undefined);
+
+    // 2. The first turn writes the entry (this is what the agent loop does).
+    upsertSessionEntry("main", key, { provider: "claude-cli" });
+
+    // 3. The queued name now lands — this is the `agent_end` flush.
+    const late = await handleSessionsRename({ sessionKey: key, name: "Release prep" });
+    assert.equal(late.ok, true);
+    assert.equal(late.name, "Release prep");
+    assert.equal(readSessionStore("main").sessions[key]?.name, "Release prep");
+    // The turn's own fields must be untouched by the rename.
+    assert.equal(readSessionStore("main").sessions[key]?.provider, "claude-cli");
+  });
+});
+
+test("handleSessionsRename: a queued name must not land on a different thread", async () => {
+  await withTempState(async () => {
+    upsertSessionEntry("main", "agent:main:t-aaaa1111", {});
+    upsertSessionEntry("main", "agent:main:t-bbbb2222", {});
+    // The TUI re-checks the bound key before flushing; this asserts the server
+    // half — a rename is scoped to the key it names and touches nothing else.
+    await handleSessionsRename({ sessionKey: "agent:main:t-aaaa1111", name: "First" });
+    const store = readSessionStore("main").sessions;
+    assert.equal(store["agent:main:t-aaaa1111"]?.name, "First");
+    assert.equal(store["agent:main:t-bbbb2222"]?.name, undefined);
+  });
+});

--- a/src/core/server-methods/sessions.ts
+++ b/src/core/server-methods/sessions.ts
@@ -29,13 +29,25 @@
 
 import { dispatchAgentRun, type DispatchAgentRunDeps } from "../agent-dispatcher.js";
 import {
+	hasLiveSession,
 	listLiveSessions,
 	type LiveSessionRecord,
 } from "../../agents/session-registry.js";
 import { resolveAgentIdFromSessionKey } from "../../agents/routing/session-key.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
-import { listSessionEntries, readSessionStore, upsertSessionEntry } from "../../sessions/session-store.js";
-import { DEFAULT_AGENT_ID } from "../../config/paths.js";
+import {
+	listSessionEntries,
+	readSessionStore,
+	deleteSessionEntry,
+	renameSessionEntry,
+	sanitizeSessionName,
+	upsertSessionEntry,
+} from "../../sessions/session-store.js";
+import fs from "node:fs";
+
+import { DEFAULT_AGENT_ID, resolveSessionTranscriptPath } from "../../config/paths.js";
+import { tryGetRuntimeContext } from "../../storage/runtime-context.js";
 
 /**
  * Wave O0.5: server-side access guard.
@@ -164,7 +176,22 @@ export async function handleSessionsList(
 			continue; // an unreadable store must never fail the list
 		}
 		for (const { sessionKey, entry } of entries) {
-			if (liveKeys.has(sessionKey)) continue;
+			if (liveKeys.has(sessionKey)) {
+				// The live row wins on runtime state, but the NAME only exists in the
+				// persisted store — carry it across rather than skipping outright, so a
+				// renamed thread reads the same whether or not a turn is in flight.
+				// Sanitise on READ too: the store is a plain JSON file an operator can
+				// hand-edit, and a name containing \n would inject a fake row into
+				// `/sessions` while \r or ESC corrupts the rows around it.
+				const liveName = sanitizeSessionName(entry.name);
+				if (liveName) {
+					// Match on agent too: with `--all` a non-canonical key could otherwise
+					// label another agent's live thread with this agent's name.
+					const liveRow = rows.find((r) => r.sessionKey === sessionKey && r.agentId === agentId);
+					if (liveRow) liveRow.displayName = liveName;
+				}
+				continue;
+			}
 			// Sub-agent and isolated-cron threads are machinery, not conversations an
 			// operator picks up — they never appeared in the live view either.
 			if (entry.subagent) continue;
@@ -181,6 +208,7 @@ export async function handleSessionsList(
 				...(Number.isFinite(startedAt) ? { startedAt } : {}),
 				...(Number.isFinite(updatedAt) ? { updatedAt } : {}),
 				...(typeof entry.modelId === "string" ? { model: entry.modelId } : {}),
+				...(sanitizeSessionName(entry.name) ? { displayName: sanitizeSessionName(entry.name) } : {}),
 			});
 		}
 	}
@@ -378,6 +406,175 @@ export async function handleSessionsPatch(
 	const entry = upsertSessionEntry(agentId, sessionKey, patch);
 	const created = new Date(entry.createdAt).getTime() >= beforeCreate - 1_000;
 	return { ok: true, created, sessionId: entry.sessionId };
+}
+
+/**
+ * Shared preamble for the mutating session methods.
+ *
+ * Requires a CANONICAL `agent:<id>:<rest>` key and derives the agent from it.
+ * Two bugs made this non-negotiable rather than tidy-up:
+ *
+ *   - `resolveAgentIdFromSessionKey` is total — it collapses ANY unparseable
+ *     key to the default agent. `/delete legacy-main` for a thread owned by
+ *     `riley` therefore read main's store and, if main held a same-named entry,
+ *     destroyed THAT one instead. Refusing is the only safe answer.
+ *   - The store is a plain object, so a wire key like `constructor` or
+ *     `toString` reached the prototype chain. Requiring the canonical shape
+ *     rejects those at the door, above the own-property guards in the store.
+ *
+ * Returns null when the key is unusable; the caller reports a clean miss.
+ */
+function resolveMutationTarget(
+	rawKey: unknown,
+	accessCheck: SessionsHandlerAccessCheck | undefined,
+): { sessionKey: string; agentId: string } | null {
+	const sessionKey = typeof rawKey === "string" ? rawKey.trim() : "";
+	const parsed = parseAgentSessionKey(sessionKey);
+	if (!parsed) return null;
+	enforceAccess(accessCheck, "patch", sessionKey);
+	return { sessionKey, agentId: resolveAgentIdFromSessionKey(sessionKey) };
+}
+
+export interface SessionsRenameHandlerDeps {
+	/** Wave O0.5 access guard — refused calls throw. */
+	accessCheck?: SessionsHandlerAccessCheck;
+}
+
+/**
+ * Set or clear a session's display name.
+ *
+ * Deliberately NOT routed through `sessions.patch`: that calls
+ * `upsertSessionEntry`, which both stamps `lastUsedAt` and MINTS the entry when
+ * it is missing. Renaming must do neither — bumping recency would jump the row
+ * to the top of the history under the operator's cursor, and naming a session
+ * that does not exist should be a clean miss, not a way to conjure one.
+ *
+ * Reuses the `patch` access action: this is a mutation of session metadata, and
+ * inventing a new verb here would silently bypass every policy already written
+ * against `patch`.
+ */
+export async function handleSessionsRename(
+	params: { sessionKey: string; name?: string },
+	deps: SessionsRenameHandlerDeps = {},
+): Promise<{ ok: boolean; sessionKey: string; agentId: string; name?: string }> {
+	const target = resolveMutationTarget(params?.sessionKey, deps.accessCheck);
+	if (!target) {
+		return { ok: false, sessionKey: typeof params?.sessionKey === "string" ? params.sessionKey : "", agentId: DEFAULT_AGENT_ID };
+	}
+	const { sessionKey, agentId } = target;
+	const entry = renameSessionEntry(agentId, sessionKey, params?.name);
+	// Unknown session — a clean miss, not an error: the caller may be racing a
+	// deletion, and a rename is never worth failing a turn over.
+	if (!entry) return { ok: false, sessionKey, agentId };
+	return { ok: true, sessionKey, agentId, ...(entry.name ? { name: entry.name } : {}) };
+}
+
+export interface SessionsDeleteHandlerDeps {
+	/** Wave O0.5 access guard — refused calls throw. */
+	accessCheck?: SessionsHandlerAccessCheck;
+	/** Injectable for tests; defaults to the in-process run registry. */
+	isLive?: (sessionKey: string) => boolean;
+	/** Injectable for tests; defaults to the boot runtime context's store. */
+	store?: { messages?: { deleteTranscript?: (agentId: string, sessionId: string) => Promise<unknown> } };
+}
+
+/**
+ * Delete a session and its transcript. OPERATOR-ONLY by construction: there is
+ * deliberately no agent tool for this.
+ *
+ * Rename is recoverable; deletion is not. The sessions tool bundle has no owner
+ * gate, so exposing deletion there would let any channel peer's turn — or one
+ * prompt injection — destroy conversation history. The gateway RPC and the TUI
+ * `/delete` command are the only callers.
+ *
+ * Refuses while a turn is in flight: removing the entry and transcript under a
+ * running turn would strand its writer on a file that no longer exists, and the
+ * operator almost certainly meant a thread they are finished with.
+ */
+export async function handleSessionsDelete(
+	params: { sessionKey: string },
+	deps: SessionsDeleteHandlerDeps = {},
+): Promise<{ ok: boolean; sessionKey: string; agentId: string; reason?: string; transcriptRemoved?: boolean }> {
+	const target = resolveMutationTarget(params?.sessionKey, deps.accessCheck);
+	if (!target) {
+		return {
+			ok: false,
+			sessionKey: typeof params?.sessionKey === "string" ? params.sessionKey : "",
+			agentId: DEFAULT_AGENT_ID,
+			reason: "not a canonical agent:<id>:<rest> session key",
+		};
+	}
+	const { sessionKey, agentId } = target;
+
+	// `hasLiveSession` is the established predicate — it treats every state except
+	// `terminated` as live. Matching only `state === "running"` let a `draining`
+	// turn (mid-abort, shutdown flush) through, which is precisely the writer the
+	// doc above promises not to strand.
+	const isLive = deps.isLive ?? hasLiveSession;
+	if (isLive(sessionKey)) {
+		return { ok: false, sessionKey, agentId, reason: "a turn is still active in this session" };
+	}
+
+	// Read the sessionId BEFORE deleting — it is the only link to the transcript,
+	// and once the entry is gone the transcript can no longer be located.
+	const existing = readSessionStore(agentId).sessions[sessionKey];
+	const sessionId = typeof existing?.sessionId === "string" ? existing.sessionId : undefined;
+
+	// Entry first. `deleteSessionEntry` is backend-aware (writeSessionStore routes
+	// through the write-through cache in convex mode). If the transcript removal
+	// then fails we leak an orphaned transcript, which is reported; the reverse
+	// order would leave an entry pointing at a transcript that no longer exists.
+	const deleted = deleteSessionEntry(agentId, sessionKey);
+	if (!deleted) return { ok: false, sessionKey, agentId, reason: "no such session" };
+
+	// Delete the transcript through the STORE, never raw `fs`. In convex mode the
+	// transcript lives in the Convex `messages` table — an `fs.rmSync` there
+	// silently no-ops, and reporting `transcriptRemoved: true` would tell the
+	// operator a conversation was permanently deleted while it is retained in
+	// full. Absent a store (cold CLI / unit test) there is nothing to consult, so
+	// report honestly rather than guessing.
+	let transcriptRemoved = false;
+	if (sessionId) {
+		const store = deps.store ?? tryGetRuntimeContext()?.store;
+		let storeDeleted = false;
+		if (store?.messages?.deleteTranscript) {
+			try {
+				await store.messages.deleteTranscript(agentId, sessionId);
+				storeDeleted = true;
+			} catch {
+				/* orphaned transcript — reported below, never thrown after the entry went */
+			}
+		}
+		// Start from what the store confirmed; the filesystem check below can both
+		// downgrade this (store resolved but the bytes are still there) and, when
+		// there is no store at all, establish it (filesystem mode, where the JSONL
+		// IS the transcript). Reporting "may still be on disk" about a file we just
+		// removed is the same lie as the reverse.
+		transcriptRemoved = storeDeleted;
+		// `LocalMessageStore.deleteTranscript` wraps its `rm` in a bare try/catch,
+		// so a resolved promise is NOT evidence the bytes are gone — on EPERM or a
+		// Windows lock it resolves having deleted nothing. Since this flag is the
+		// operator's only signal that "permanently deleted" was true, verify it.
+		// Also clears the write-lock sidecar, which no store implementation owns.
+		try {
+			const local = resolveSessionTranscriptPath(agentId, sessionId);
+			fs.rmSync(`${local}.lock`, { force: true });
+			// In convex mode this path is the regenerable OS-cache mirror, which the
+			// session reaper also drops; in filesystem mode it IS the transcript.
+			const existedBefore = fs.existsSync(local);
+			fs.rmSync(local, { force: true });
+			const goneNow = !fs.existsSync(local);
+			if (!goneNow) transcriptRemoved = false;
+			else if (!storeDeleted && existedBefore) {
+				// No store, but the transcript was here and now is not — in filesystem
+				// mode that IS the whole transcript, so the claim is true.
+				transcriptRemoved = tryGetRuntimeContext()?.mode !== "convex";
+			}
+		} catch {
+			transcriptRemoved = false;
+		}
+	}
+	return { ok: true, sessionKey, agentId, transcriptRemoved };
 }
 
 export async function handleSessionsSpawn(

--- a/src/core/server.guard-sweep.test.ts
+++ b/src/core/server.guard-sweep.test.ts
@@ -144,6 +144,8 @@ const KNOWN_GUARDED_SESSIONS_METHODS = new Set<string>([
 	"sessions.send",
 	"sessions.spawn",
 	"sessions.patch",
+	"sessions.rename",
+	"sessions.delete",
 	"agent",
 	"cron.add",
 	"cron.update",

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -211,7 +211,9 @@ import type { SkillInstallSpec } from "../agents/skills/install-spec.js";
 import { applySkillUpdate } from "../agents/skills/update-config.js";
 import {
 	handleSessionsHistory,
+	handleSessionsDelete,
 	handleSessionsList,
+	handleSessionsRename,
 	handleSessionsPatch,
 	handleSessionsSend,
 	handleSessionsSpawn,
@@ -4418,6 +4420,22 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		registerGatewayHandler("sessions.list", (params: unknown) =>
 			handleSessionsList(
 				params as Parameters<typeof handleSessionsList>[0],
+				{ accessCheck: sessionsAccessCheck },
+			),
+		),
+	);
+	disposeHandlers.push(
+		registerGatewayHandler("sessions.rename", (params: unknown) =>
+			handleSessionsRename(
+				params as Parameters<typeof handleSessionsRename>[0],
+				{ accessCheck: sessionsAccessCheck },
+			),
+		),
+	);
+	disposeHandlers.push(
+		registerGatewayHandler("sessions.delete", (params: unknown) =>
+			handleSessionsDelete(
+				params as Parameters<typeof handleSessionsDelete>[0],
 				{ accessCheck: sessionsAccessCheck },
 			),
 		),

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -217,6 +217,18 @@ export type RequestMethod =
 	 * sessions. Used by the connect TUI's `/sessions` slash command.
 	 */
 	| "sessions.list"
+	/**
+	 * Set or clear a session's display name. Naming is metadata about a
+	 * conversation, not activity in it, so this deliberately does NOT touch
+	 * `lastUsedAt` — a rename must not reorder a recency-sorted history.
+	 */
+	| "sessions.rename"
+	/**
+	 * Delete a session and its transcript. OPERATOR-ONLY — there is deliberately
+	 * no agent tool for this: deletion is irreversible and the sessions tool
+	 * bundle has no owner gate. Refuses while a turn is running.
+	 */
+	| "sessions.delete"
 	/* ─── Cron methods (Wave N6 — full reference parity) ────────── */
 	/** Service-level snapshot — job count, next wake, running. */
 	| "cron.status"
@@ -311,6 +323,8 @@ export const REQUEST_METHODS = [
 	"unsubscribe",
 	"agents.list",
 	"sessions.list",
+	"sessions.rename",
+	"sessions.delete",
 	"cron.status",
 	"cron.list",
 	"cron.add",
@@ -621,6 +635,20 @@ export interface RequestParams {
 		/** When true, ignore `agentId` and return every agent's live sessions. */
 		all?: boolean;
 	} | void;
+	"sessions.delete": {
+		/** The session to delete. The owning agent is derived from it. */
+		sessionKey: string;
+	};
+	"sessions.rename": {
+		/** The session to rename. */
+		sessionKey: string;
+		/**
+		 * New display name. Empty / whitespace-only CLEARS the name, so
+		 * `/rename` with no argument is a natural "remove it" rather than a
+		 * second command. Sanitised and length-capped server-side.
+		 */
+		name?: string;
+	};
 	/* ─── Cron methods (Wave N6) — wire shapes owned by the handler module. */
 	"cron.status": CronStatusParamsV2 | void;
 	"cron.list": CronListParamsV2 | void;
@@ -675,6 +703,8 @@ export interface ResponseFor {
 	unsubscribe: void;
 	"agents.list": AgentSummary[];
 	"sessions.list": SessionSummary[];
+	"sessions.rename": SessionRenameResult;
+	"sessions.delete": SessionDeleteResult;
 	/* ─── Cron methods (Wave N6) ─────────────────────────────── */
 	"cron.status": CronStatusResultV2;
 	"cron.list": CronListResultV2;
@@ -944,6 +974,40 @@ export interface AgentSummary {
 export interface SessionSummary {
 	sessionKey: string;
 	agentId: string;
+	/**
+	 * Operator-chosen display name, sanitised. Absent means unnamed — render the
+	 * derived label or the key, as every surface did before names existed.
+	 */
+	displayName?: string;
+}
+
+export interface SessionDeleteResult {
+	/** False on a miss, a bad key, or a session with a turn still running. */
+	ok: boolean;
+	sessionKey: string;
+	agentId: string;
+	/** Why it was refused. Absent on success. */
+	reason?: string;
+	/**
+	 * False when the index entry went but the JSONL could not be removed — an
+	 * orphaned file nothing references. Surfaced rather than hidden so the
+	 * operator knows the bytes are still on disk.
+	 */
+	transcriptRemoved?: boolean;
+}
+
+export interface SessionRenameResult {
+	/**
+	 * False when the session does not exist — a clean miss rather than an error,
+	 * since the caller may be racing a deletion and a rename is never worth
+	 * failing a turn over. Typed clients MUST branch on this: without it a
+	 * successful rename and an unknown-session miss are indistinguishable.
+	 */
+	ok: boolean;
+	sessionKey: string;
+	agentId: string;
+	/** The stored name AFTER sanitising. Absent when the name was cleared. */
+	name?: string;
 }
 
 export function modelToSummary(model: Model<any>): ModelSummary {

--- a/src/sessions/session-rename.test.ts
+++ b/src/sessions/session-rename.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+	MAX_SESSION_NAME_LENGTH,
+	readSessionStore,
+	renameSessionEntry,
+	sanitizeSessionName,
+	upsertSessionEntry,
+} from "./session-store.js";
+
+function withTempState(fn: () => void): void {
+	const dir = mkdtempSync(path.join(tmpdir(), "brigade-rename-"));
+	const prev = process.env.BRIGADE_STATE_DIR;
+	process.env.BRIGADE_STATE_DIR = dir;
+	try {
+		fn();
+	} finally {
+		if (prev === undefined) delete process.env.BRIGADE_STATE_DIR;
+		else process.env.BRIGADE_STATE_DIR = prev;
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+test("sanitizeSessionName: trims, collapses whitespace, caps length", () => {
+	assert.equal(sanitizeSessionName("  my   thread  "), "my thread");
+	assert.equal(sanitizeSessionName("x".repeat(500))?.length, MAX_SESSION_NAME_LENGTH);
+});
+
+test("sanitizeSessionName: strips control characters rather than rejecting", () => {
+	// These names are printed into a TUI — a stray \r or escape would corrupt the
+	// rendering of every row around it.
+	// The escape becomes a SPACE, not nothing — dropping it would fuse the
+	// words either side and silently change what the operator typed.
+	assert.equal(sanitizeSessionName("a\u001b[31mb"), "a [31mb");
+	assert.equal(sanitizeSessionName("line\r\nbreak"), "line break");
+});
+
+test("sanitizeSessionName: empty / whitespace-only / non-string clears the name", () => {
+	for (const input of ["", "   ", "\n\t", undefined, null, 42, {}]) {
+		assert.equal(sanitizeSessionName(input), undefined, `expected clear for ${JSON.stringify(input)}`);
+	}
+});
+
+test("renameSessionEntry: sets, then clears, the name", () => {
+	withTempState(() => {
+		upsertSessionEntry("main", "agent:main:main", {});
+		assert.equal(renameSessionEntry("main", "agent:main:main", "Release prep")?.name, "Release prep");
+		const cleared = renameSessionEntry("main", "agent:main:main", "");
+		assert.equal(cleared?.name, undefined);
+		assert.ok(!("name" in (readSessionStore("main").sessions["agent:main:main"] ?? {})));
+	});
+});
+
+test("renameSessionEntry: does NOT bump lastUsedAt", () => {
+	withTempState(() => {
+		const before = upsertSessionEntry("main", "agent:main:main", {}).lastUsedAt;
+		const after = renameSessionEntry("main", "agent:main:main", "Named")?.lastUsedAt;
+		// Naming is metadata, not activity. Bumping recency here would jump the row
+		// to the top of a recency-sorted history under the operator's cursor.
+		assert.equal(after, before);
+	});
+});
+
+test("renameSessionEntry: unknown session is a clean miss, not a create", () => {
+	withTempState(() => {
+		assert.equal(renameSessionEntry("main", "agent:main:ghost", "Nope"), null);
+		// Must not conjure the entry the way upsert would.
+		assert.equal(readSessionStore("main").sessions["agent:main:ghost"], undefined);
+	});
+});
+
+test("renameSessionEntry: preserves the rest of the entry", () => {
+	withTempState(() => {
+		upsertSessionEntry("main", "agent:main:main", { provider: "claude-cli", modelId: "claude-opus-5" });
+		const renamed = renameSessionEntry("main", "agent:main:main", "Kept");
+		assert.equal(renamed?.provider, "claude-cli");
+		assert.equal(renamed?.modelId, "claude-opus-5");
+	});
+});
+
+test("sanitizeSessionName: strips C1 controls and bidi overrides", () => {
+	// C1 still carries escape semantics in some terminals, and a bidi override can
+	// visually reverse a name so it reads as something else entirely in a list.
+	assert.equal(sanitizeSessionName("a\u0085b"), "a b");
+	assert.equal(sanitizeSessionName("safe\u202ereversed"), "safe reversed");
+	assert.equal(sanitizeSessionName("x\u2066y\u2069z"), "x y z");
+});
+
+test("sanitizeSessionName: strips zero-width and invisible marks", () => {
+	// None of these are matched by \\s, so without an explicit class an entirely
+	// invisible name was stored as non-empty and rendered as nothing.
+	for (const invisible of ["\u200b", "\u061c", "\u200e", "\u202e", "\u200c\u200d"]) {
+		assert.equal(sanitizeSessionName(invisible), undefined, `stored an invisible name: ${escape(invisible)}`);
+	}
+});
+
+test("sanitizeSessionName: caps by code point, never splitting a surrogate pair", () => {
+	const name = "a".repeat(MAX_SESSION_NAME_LENGTH - 1) + "\u{1F600}";
+	const out = sanitizeSessionName(name);
+	assert.equal([...(out ?? "")].length, MAX_SESSION_NAME_LENGTH);
+	// A UTF-16 slice would leave a lone high surrogate that becomes U+FFFD on any
+	// UTF-8 round-trip — sessions.json, or the sealed convex `extra` blob.
+	assert.equal(out, Buffer.from(out ?? "", "utf8").toString("utf8"));
+	assert.ok(!/[\uD800-\uDBFF]$/.test(out ?? ""), "trailing lone high surrogate");
+});
+
+test("renameSessionEntry: prototype-chain keys never mint a phantom entry", () => {
+	withTempState(() => {
+		upsertSessionEntry("main", "agent:main:main", {});
+		for (const key of ["constructor", "toString", "__proto__", "valueOf"]) {
+			assert.equal(renameSessionEntry("main", key, "PWNED"), null, `minted an entry for ${key}`);
+		}
+		const keys = Object.keys(readSessionStore("main").sessions);
+		assert.deepEqual(keys, ["agent:main:main"], `phantom entries persisted: ${keys.join(",")}`);
+	});
+});
+
+test("sanitizeSessionName: ZWJ and ZWNJ are text, not formatting", () => {
+	// Stripping them tore "family" into three separate people, split the pride
+	// flag into two glyphs, and broke Devanagari conjuncts. Emptiness is decided
+	// by visible content instead, so these must round-trip byte-for-byte.
+	for (const name of ["\u{1F468}\u200d\u{1F469}\u200d\u{1F467} family", "\u{1F3F3}\uFE0F\u200d\u{1F308} pride", "\u0915\u094d\u200d\u0937 conjunct"]) {
+		assert.equal(sanitizeSessionName(name), name, `mangled: ${JSON.stringify(name)}`);
+	}
+});

--- a/src/sessions/session-store.ts
+++ b/src/sessions/session-store.ts
@@ -261,7 +261,63 @@ export interface SessionEntry {
   thinkingLevel?: string;
   /** Primitive #6 — see `SubagentSessionMetadata`. Unset on top-level sessions. */
   subagent?: SubagentSessionMetadata;
+  /**
+   * Operator-chosen display name. Absent means "unnamed" — callers fall back to
+   * the session key, which is what every surface did before names existed.
+   * Sanitised on write (see `sanitizeSessionName`); never trusted on read,
+   * since the store is a plain JSON file an operator can hand-edit.
+   */
+  name?: string;
   [key: string]: unknown;
+}
+
+/** Upper bound on a session name. Long enough for a sentence, short enough that
+ *  a list stays readable and a single entry can't bloat the store. */
+export const MAX_SESSION_NAME_LENGTH = 120;
+
+/**
+ * Normalise an operator-supplied session name.
+ *
+ * Returns `undefined` for anything that should CLEAR the name (empty, or
+ * whitespace/control characters only), so `/rename` with no argument is a
+ * natural "remove the name" rather than a separate command.
+ *
+ * Control characters are stripped rather than rejected: these names are printed
+ * into a TUI, and a stray \r or ANSI escape would corrupt the rendering of every
+ * row around it.
+ */
+export function sanitizeSessionName(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  // C0 + DEL + C1 (U+0080-U+009F) — C1 still carries escape semantics in some
+  // terminals — plus the bidi overrides, which can visually reverse a name so it
+  // reads as something else entirely in a list.
+  // eslint-disable-next-line no-control-regex
+  const stripped = raw.replace(
+    // C0 + DEL + C1, ZWSP, and the bidi marks/overrides/isolates (incl. U+061C).
+    //
+    // ZWJ (U+200D) and ZWNJ (U+200C) are deliberately NOT here. They are text,
+    // not formatting: stripping them tore "👨‍👩‍👧" into three separate people,
+    // broke the pride flag into two glyphs, and split Devanagari conjuncts.
+    // Emptiness is handled below by testing for VISIBLE content instead, which
+    // is the property we actually cared about.
+    /[\u0000-\u001f\u007f-\u009f\u061c\u200b\u200e\u200f\u202a-\u202e\u2066-\u2069]/g,
+    " ",
+  );
+  const collapsed = stripped.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return undefined;
+  // A name made only of joiners and spaces renders as nothing and cannot be
+  // distinguished from an unnamed thread, so treat it as a clear. Checking for
+  // visible content lets ZWJ/ZWNJ live inside a real name while still rejecting
+  // a name that is entirely invisible.
+  if (!/[^\s\u200c\u200d]/u.test(collapsed)) return undefined;
+  // Slice by CODE POINT, not UTF-16 unit: a raw slice can cut a surrogate pair
+  // and persist a lone surrogate that becomes U+FFFD on any UTF-8 round-trip.
+  // This also matches the agent tool's JSON-Schema `maxLength`, which JSON
+  // Schema defines in code points.
+  const points = [...collapsed];
+  return points.length > MAX_SESSION_NAME_LENGTH
+    ? points.slice(0, MAX_SESSION_NAME_LENGTH).join("")
+    : collapsed;
 }
 
 export interface SessionStoreFile {
@@ -478,7 +534,10 @@ function buildBrigadeMainSessionKeyLazy(agentId: string): string {
 export function deleteSessionEntry(agentId: string, sessionKey: string): boolean {
   return withSyncStoreLock(agentId, () => {
     const store = readSessionStore(agentId);
-    if (!(sessionKey in store.sessions)) return false;
+    // `in` walks the prototype chain: `"toString" in {}` is true, so a
+    // caller-supplied key like `toString` or `constructor` reported a
+    // successful delete for a session that never existed.
+    if (!Object.hasOwn(store.sessions, sessionKey)) return false;
     delete store.sessions[sessionKey];
     writeSessionStore(agentId, store);
     return true;
@@ -513,6 +572,35 @@ export function updateSessionEntry(
       ...rest,
       lastUsedAt: new Date().toISOString(),
     };
+    store.sessions[sessionKey] = next;
+    writeSessionStore(agentId, store);
+    return next;
+  });
+}
+
+/**
+ * Set or clear a session's display name.
+ *
+ * Deliberately NOT `updateSessionEntry`: that stamps `lastUsedAt`, and renaming
+ * is not *using* a session — it would jump the row to the top of every
+ * recency-sorted list and make the history reorder itself under the operator's
+ * cursor. Naming is metadata about a conversation, not activity in it.
+ *
+ * Returns the updated entry, or null when the session does not exist.
+ */
+export function renameSessionEntry(agentId: string, sessionKey: string, name: unknown): SessionEntry | null {
+  const clean = sanitizeSessionName(name);
+  return withSyncStoreLock(agentId, () => {
+    const store = readSessionStore(agentId);
+    // Own-property only. A bare index hits Object.prototype, so `constructor`
+    // was truthy and got spread into a brand-new entry that was then PERSISTED
+    // and listed in `/sessions` — the opposite of "never conjure one".
+    if (!Object.hasOwn(store.sessions, sessionKey)) return null;
+    const entry = store.sessions[sessionKey];
+    if (!entry) return null;
+    const next: SessionEntry = { ...entry };
+    if (clean === undefined) delete next.name;
+    else next.name = clean;
     store.sessions[sessionKey] = next;
     writeSessionStore(agentId, store);
     return next;

--- a/src/storage/convex/session-name-marshalling.test.ts
+++ b/src/storage/convex/session-name-marshalling.test.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from "node:assert";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { __sessionMarshalling } from "./session-store.js";
+import type { SessionEntry } from "../../sessions/session-store.js";
+
+// Hermetic: a real operator key file must not leak in — point the lookup nowhere.
+process.env.BRIGADE_ENCRYPTION_KEY_FILE = path.join(tmpdir(), "brigade-no-such-key-file");
+
+// Regression guard for a rename silently vanishing in convex mode.
+//
+// `name` has NO dedicated column on the sessions table, so it must ride the
+// sealed `extra` blob. Listing it in KNOWN_FIELDS excludes it from `extra`
+// without adding a column — the rename then looks like it worked (served from
+// the in-process cache) and is gone after the next gateway restart. This test
+// fails the moment someone "tidies up" by allowlisting it.
+const { entryToMutationArgs, rowToEntry } = __sessionMarshalling;
+
+describe("convex session marshalling — display name", () => {
+  const base = (overrides: Partial<SessionEntry> = {}): SessionEntry => ({
+    sessionId: "sid-1",
+    createdAt: new Date(1_700_000_000_000).toISOString(),
+    lastUsedAt: new Date(1_700_000_500_000).toISOString(),
+    ...overrides,
+  });
+
+  it("survives a column round-trip via the extra blob", () => {
+    const entry = base({ name: "Release prep" });
+    const args = entryToMutationArgs(entry) as Record<string, unknown>;
+    // Must NOT be promoted to a top-level column — none exists to receive it.
+    assert.equal(args.name, undefined, "name must not be emitted as a column");
+    assert.notEqual(args.extra, undefined, "name must be sealed into `extra`");
+    const restored = rowToEntry(args as never);
+    assert.equal(restored?.name, "Release prep");
+  });
+
+  it("an unnamed session round-trips without inventing a name", () => {
+    const args = entryToMutationArgs(base()) as Record<string, unknown>;
+    const restored = rowToEntry(args as never);
+    assert.equal(restored?.name, undefined);
+  });
+
+  it("keeps the name alongside the fields that DO have columns", () => {
+    const entry = base({ name: "Named", provider: "claude-cli", modelId: "claude-opus-5" });
+    const restored = rowToEntry(entryToMutationArgs(entry) as never);
+    assert.equal(restored?.name, "Named");
+    assert.equal(restored?.provider, "claude-cli");
+    assert.equal(restored?.modelId, "claude-opus-5");
+  });
+});

--- a/src/storage/convex/session-store.ts
+++ b/src/storage/convex/session-store.ts
@@ -44,6 +44,11 @@ const KNOWN_FIELDS = new Set([
 	"authProfile",
 	"thinkingLevel",
 	"subagent",
+	// NOTE: `name` is deliberately ABSENT. Listing a field here excludes it from
+	// the sealed `extra` blob, and there is no `name` column on the sessions
+	// table — allowlisting it would make a rename look like it worked (served
+	// from the in-process cache) and vanish on the next gateway restart. The
+	// `extra` path already persists and restores it correctly.
 ]);
 
 function isoToMs(value: unknown): number | undefined {


### PR DESCRIPTION
Sessions were identified only by their key, so a history list read as `t-0bf7c8e1` rather than what the conversation was about — and there was no way to remove one. The desktop app had rename in its own store, which never reached the CLI, so there were two disconnected notions of what a thread is called.

| | |
|---|---|
| `/rename [name]` | name the thread you are in; no argument clears it |
| `/delete <session-key>` | delete a thread **and its transcript** (repeat to confirm) |
| `sessions_rename` | the agent can title the conversation it is in |

Both slash commands are in autocomplete, `/help` and the banner; both RPCs are registered in `KNOWN_GUARDED_SESSIONS_METHODS`.

## Design decisions worth reviewing

**Renaming does not touch `lastUsedAt`.** `sessions.patch` would have — it calls `upsertSessionEntry`, which stamps recency *and* mints the entry when missing. Naming is metadata about a conversation, not activity in it; bumping recency would jump the row to the top of the history under the operator's cursor.

**`sessions_rename` takes no `sessionKey`.** The sessions bundle has no owner gate, so a key argument would let an untrusted channel peer rename other people's threads. Scoping to the caller's own session removes that class of abuse rather than policing it — and self-titling is the entire use case.

**`/delete` is operator-only.** No agent tool. Renaming is recoverable; deletion isn't.

**`name` is deliberately absent from the convex `KNOWN_FIELDS` allowlist.** It has no column, so listing it there excludes it from the sealed `extra` blob — a rename would look fine from cache and vanish on restart. A regression test fails if anyone tidies it back in.

## Bugs found and fixed during review

Seven review rounds. The ones worth naming:

- **Prototype-chain keys.** A bare index and `in` walk `Object.prototype`, so wire keys like `constructor` minted phantom entries that listed in `/sessions`, and `toString` reported a successful delete for a session that never existed. Fixed with `Object.hasOwn` plus a canonical-key requirement at the handler.
- **Wrong-agent deletion.** `resolveAgentIdFromSessionKey` collapses any unparseable key to the default agent, so deleting another agent's `legacy-main` would have destroyed main's identically-keyed thread.
- **`transcriptRemoved` was a lie in the default storage mode.** `LocalMessageStore` swallows its own `rm` errors, so a resolved promise is not evidence the bytes are gone. Now verified against the filesystem.
- **Convex transcript deletion.** A raw `fs.rmSync` no-ops in convex mode, where the transcript is rows — it would have reported a conversation permanently destroyed while retaining every word. Routed through `store.messages.deleteTranscript`.
- **ZWJ/ZWNJ corruption.** A hardening pass stripped them as invisibles, tearing `👨‍👩‍👧` into three people, splitting the pride flag, and breaking Devanagari conjuncts. They are text; emptiness is now decided by testing for visible content.

## Verification

Typecheck clean · `npm test` **1763/1763** · **33 new tests**

Note: the new test files sit ≥3 levels deep, and `run-tests.mjs` globs `src/**/*.test.ts` with `shell: true` — `/bin/sh` has no globstar, so it only matches two levels and **CI collects 1763 of ~6000 tests**. I ran the new ones explicitly every round. Worth a separate fix; running the full set surfaces ~40 pre-existing failures unrelated to this change.

## Known gaps, not addressed here

- Rename is a no-op for non-`main` agents — `sessionsAccessCheck` anchors the requester to the boot agent (`TODO(phase-2-multi-user)`)
- The session inbox is not purged on delete; sub-agent children of a deleted thread are orphaned
- `sessions.patch` can write `name` bypassing the sanitiser
- `sessions_list` returns `displayName` into other agents' context; it is markdown-escaped for the TUI only