### PR TITLE
fix(sessions): /delete accepts the short key form /sessions shows

### DIFF
--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -2833,7 +2833,15 @@ export async function wireConnectUi(
 		// `/sessions` is not executed on the first Enter.
 		if (trimmed === "/delete" || trimmed.startsWith("/delete ")) {
 			editor.setText("");
-			const key = trimmed === "/delete" ? "" : trimmed.slice("/delete ".length).trim();
+			// `/sessions` shows the short form (`t-c701aba6`) in its prominent column,
+			// and `/session` accepts it — so `/delete` must too. Without this the
+			// server's canonical-key guard rejected exactly the string the UI teaches,
+			// after the operator had already confirmed twice.
+			const deleteArg = trimmed === "/delete" ? "" : trimmed.slice("/delete ".length).trim();
+			const agentForDelete = boundAgentId ?? lastSnapshot?.agentId ?? DEFAULT_AGENT_ID;
+			const key = deleteArg && !deleteArg.startsWith("agent:")
+				? `agent:${agentForDelete}:${deleteArg}`
+				: deleteArg;
 			if (!key) {
 				insertBeforeEditor(
 					new Text(
@@ -3036,7 +3044,7 @@ export async function wireConnectUi(
 				: `live sessions for agent ${boundAgentId ?? lastSnapshot?.agentId ?? "main"}:`;
 			insertBeforeEditor(
 				new Markdown(
-					`${brand.dim(scopeLine)}\n${lines.join("\n")}\n\n${brand.dim("usage: /session <key> to bind · /rename <name> to name this thread · /mute <id|key> to unsubscribe")}`,
+					`${brand.dim(scopeLine)}\n${lines.join("\n")}\n\n${brand.dim("usage: /session <key> to bind · /rename <name> to name this thread · /delete <key> to remove one · /mute <id|key> to unsubscribe")}`,
 					1,
 					0,
 					markdownTheme,


### PR DESCRIPTION
Follow-up to #132, spotted in the running TUI.

## The bug

`/sessions` prints the short form in its prominent column:

```
main  t-c701aba6   agent:main:t-c701aba6
main  (home)       agent:main:main  ← bound
```

`/session t-c701aba6` accepts that — it canonicalises. `/delete t-c701aba6` did not, so the key went to the server verbatim and the new canonical-key guard rejected it:

```
✗ not a canonical agent:<id>:<rest> session key
```

…after the operator had already typed the command **twice** to get past the confirmation. The UI teaches one key format and the destructive command refuses it.

## The fix

Canonicalise a bare key to `agent:<agent>:<arg>`, exactly as `/session` does. The confirmation prompt now echoes the **expanded** key, so what is about to be deleted is shown in full rather than the abbreviation that was typed — a small safety gain over the old behaviour.

Also adds `/delete` to the `/sessions` usage hint, which listed `/session`, `/rename` and `/mute` but omitted the one destructive command in the set.

## Verification

Typecheck clean · `npm test` 1763/1763 · sessions-delete + session-rename suites 20/20