### PR TITLE
feat(sessions): per-session model pin, so one thread can run its own model

### DIFF
--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -14,6 +14,8 @@ import { readConfigOrInit } from "../../config/io.js";
 import { DEFAULT_AGENT_ID, resolveAllPaths } from "../../config/paths.js";
 import {
   defaultSessionKey,
+  pinSessionModel,
+  readSessionModelPin,
   readSessionStore,
   writeSessionStore,
 } from "../../sessions/session-store.js";
@@ -124,7 +126,11 @@ export async function runAgentTurn(opts: AgentOptions): Promise<void> {
 
   // Provider/model resolution order:
   //   1. CLI flag (`--provider` / `--model`) — explicit user intent for this run.
-  //   2. Persisted session override — set by a prior `/model X` command.
+  //   2. Persisted session PIN — set by a prior `/model X` command. Read from
+  //      `pinnedProvider`/`pinnedModelId`, never from `provider`/`modelId`:
+  //      the latter are stamped with the serving model on EVERY turn, so
+  //      reading them here froze each session to its first turn's model and
+  //      made a later change to the agent default a silent no-op.
   //   3. Per-agent legacy slot (`agents.<id>.defaultProvider/defaultModel`)
   //      — kept for back-compat with pre-wizard configs.
   //   4. Onboard-wizard defaults (`agents.defaults.{provider, model.primary}`)
@@ -139,15 +145,15 @@ export async function runAgentTurn(opts: AgentOptions): Promise<void> {
   const wizardDefaults = cfg.agents?.defaults as
     | { provider?: string; model?: { primary?: string } }
     | undefined;
-  const sessionEntry = readSessionStore(agentId).sessions[sessionKey];
+  const sessionPin = readSessionModelPin(agentId, sessionKey);
   const provider =
     opts.provider ??
-    sessionEntry?.provider ??
+    sessionPin?.provider ??
     agentCfg?.defaultProvider ??
     wizardDefaults?.provider;
   const modelId =
     opts.model ??
-    sessionEntry?.modelId ??
+    sessionPin?.modelId ??
     agentCfg?.defaultModel ??
     wizardDefaults?.model?.primary;
 
@@ -272,28 +278,22 @@ export async function runAgentTurn(opts: AgentOptions): Promise<void> {
   if (!result.reply.endsWith("\n")) process.stdout.write("\n");
 }
 
-// Persist the session's model override to sessions.json so the NEXT
-// `brigade agent` invocation against this session uses the new model
-// without the user having to repeat `/model X` or pass --model.
+// Persist the session's model PIN so the NEXT `brigade agent` invocation
+// against this session uses the new model without the user having to repeat
+// `/model X` or pass --model.
+//
+// Writes the dedicated pin fields, not `provider`/`modelId` — those are
+// overwritten on every turn with whatever model served it, so a pin stored
+// there would survive only until the next message.
 function persistSessionModel(args: {
   agentId: string;
   sessionKey: string;
   provider: string;
   modelId: string;
 }): void {
-  const store = readSessionStore(args.agentId);
-  const entry = store.sessions[args.sessionKey];
-  if (!entry) {
-    // No session yet (first turn) — the model override will land in the
-    // entry that resolveOrCreateSession creates on this turn. Nothing to
-    // persist here ahead of time. The active turn already uses the
-    // override via the runSingleTurn call.
-    return;
-  }
-  entry.provider = args.provider;
-  entry.modelId = args.modelId;
-  entry.lastUsedAt = new Date().toISOString();
-  writeSessionStore(args.agentId, store);
+  // Creates the entry when the session has not taken its first turn yet, so
+  // `/model` on a brand-new session key persists instead of silently no-opping.
+  pinSessionModel(args.agentId, args.sessionKey, args.provider, args.modelId);
 }
 
 // Forget the session entirely. Next `brigade agent` against the same

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -2638,7 +2638,9 @@ export async function wireConnectUi(
 					`${brand.dim("commands")}\n` +
 						`- ${chalk.bold("/exit")} or ${chalk.bold("/quit")} — disconnect & quit\n` +
 						`- ${chalk.bold("/help")} — this list\n` +
-						`- ${chalk.bold("/model <id>")} — switch to a configured model on the gateway\n` +
+						`- ${chalk.bold("/model <id>")} — switch this agent's model (every thread without a pin follows)\n` +
+						`- ${chalk.bold("/model <id> --thread")} — pin THIS thread to a model, leaving the agent alone\n` +
+						`- ${chalk.bold("/model --unpin")} — drop this thread's pin so it follows the agent again\n` +
 						`- ${chalk.bold("/provider [<name>]")} — switch model provider, or add a new one with an API key (no arg = list)\n` +
 						`- ${chalk.bold("/thinking <level>")} — set reasoning effort (off|minimal|low|medium|high|xhigh)\n` +
 						`- ${chalk.bold("/compact")} — summarize older turns to free up context\n` +
@@ -3886,7 +3888,60 @@ export async function wireConnectUi(
 				return;
 			}
 
-			const arg = trimmed === "/model" ? "" : trimmed.slice("/model ".length).trim();
+			const rawArg = trimmed === "/model" ? "" : trimmed.slice("/model ".length).trim();
+			// Scope flags. `/model <id>` stays AGENT-wide (every thread without a
+			// pin of its own follows it, existing and future alike); `--thread`
+			// pins just this thread; `--unpin` drops that pin so the thread
+			// follows its agent again.
+			const argTokens = rawArg.split(/\s+/).filter(Boolean);
+			const flags = argTokens.filter((t) => t.startsWith("--"));
+			const arg = argTokens.filter((t) => !t.startsWith("--")).join(" ");
+			const wantsThread = flags.includes("--thread") || flags.includes("--session");
+			const wantsUnpin = flags.includes("--unpin");
+			// An unrecognised flag must NOT fall through to the agent-wide path —
+			// a typo like `--thred` would silently move every thread instead of
+			// the one the operator meant.
+			const unknownFlag = flags.find(
+				(f) => f !== "--thread" && f !== "--session" && f !== "--unpin",
+			);
+			if (unknownFlag) {
+				insertBeforeEditor(
+					new Text(
+						`  ${brand.error(`✗ unknown option ${unknownFlag}`)} ${brand.dim("— usage: /model <id> [--thread] · /model --unpin")}`,
+						0,
+						0,
+					),
+				);
+				return;
+			}
+			if (wantsUnpin) {
+				try {
+					const res = await client.request("clear-session-model", withBinding());
+					insertBeforeEditor(
+						new Text(
+							res.cleared
+								? `  ${brand.amber("✓")} ${brand.dim("this thread follows the agent again —")} ${brand.white(`${lastSnapshot?.provider ?? "?"} · ${lastSnapshot?.modelId ?? "?"}`)}`
+								: `  ${brand.dim("this thread wasn't pinned — it already follows the agent.")}`,
+							0,
+							0,
+						),
+					);
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : String(err);
+					insertBeforeEditor(new Text(`  ${brand.error("✗")} ${brand.error(msg)}`, 0, 0));
+				}
+				return;
+			}
+			if (wantsThread && !arg) {
+				insertBeforeEditor(
+					new Text(
+						`  ${brand.error("✗ --thread needs a model id")} ${brand.dim("— usage: /model <id> --thread")}`,
+						0,
+						0,
+					),
+				);
+				return;
+			}
 			if (!arg) {
 				// Scope the list to the CURRENT provider and show ALL of its models,
 				// uncapped. `/model` is still a GLOBAL switcher — `/model <id>` switches
@@ -3920,7 +3975,7 @@ export async function wireConnectUi(
 					.join("\n");
 				insertBeforeEditor(
 					new Markdown(
-						`${brand.dim("models on your current provider:")}\n\n  ${head}\n${body}\n\n${brand.dim("usage: /model <id>  ·  switch provider with /provider")}`,
+						`${brand.dim("models on your current provider:")}\n\n  ${head}\n${body}\n\n${brand.dim("usage: /model <id>  ·  pin one thread: /model <id> --thread  ·  provider: /provider")}`,
 						1,
 						0,
 						markdownTheme,
@@ -3943,11 +3998,17 @@ export async function wireConnectUi(
 			try {
 				await client.request(
 					"set-model",
-					withBinding({ provider: target.provider, modelId: target.id }),
+					withBinding({
+						provider: target.provider,
+						modelId: target.id,
+						scope: wantsThread ? ("session" as const) : ("agent" as const),
+					}),
 				);
 				insertBeforeEditor(
 					new Text(
-						`  ${brand.amber("✓")} ${brand.dim("switched to")} ${brand.white(`${target.provider} · ${target.id}`)}`,
+						wantsThread
+							? `  ${brand.amber("✓")} ${brand.dim("this thread pinned to")} ${brand.white(`${target.provider} · ${target.id}`)} ${brand.dim("— other threads unaffected; /model --unpin to undo")}`
+							: `  ${brand.amber("✓")} ${brand.dim("switched to")} ${brand.white(`${target.provider} · ${target.id}`)}`,
 						0,
 						0,
 					),

--- a/src/core/server-methods/sessions-list-persisted.test.ts
+++ b/src/core/server-methods/sessions-list-persisted.test.ts
@@ -12,7 +12,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, test } from "node:test";
 
 import { handleSessionsList } from "./sessions.js";
-import { upsertSessionEntry } from "../../sessions/session-store.js";
+import { pinSessionModel, upsertSessionEntry } from "../../sessions/session-store.js";
 
 let tmpRoot: string;
 let prevState: string | undefined;
@@ -83,4 +83,37 @@ test("an unreadable store yields an empty list, never a thrown RPC", async () =>
 	const res = await handleSessionsList({ agentId: "ghost-agent" });
 	assert.deepEqual(res.sessions, []);
 	assert.equal(res.count, 0);
+});
+
+// A UI listing threads reads these rows. `model` is only what last SERVED the
+// session, so on its own it mislabels the two cases below.
+test("sessions.list distinguishes a pin from what last ran", async () => {
+	// Pinned, then messaged on a DIFFERENT model earlier: `model` lags the pin.
+	pinSessionModel("main", "agent:main:t-pinned", "openrouter", "qwen/qwen-2.5-72b-instruct");
+	upsertSessionEntry("main", "agent:main:t-pinned", { modelId: "claude-opus-5" });
+	// Unpinned: follows its agent, so it must NOT look pinned to anything.
+	upsertSessionEntry("main", "agent:main:t-plain", { modelId: "claude-opus-5" });
+
+	const res = await handleSessionsList({ agentId: "main" });
+	const pinned = res.sessions.find((s) => s.sessionKey === "agent:main:t-pinned");
+	const plain = res.sessions.find((s) => s.sessionKey === "agent:main:t-plain");
+
+	assert.equal(pinned?.pinnedProvider, "openrouter");
+	assert.equal(pinned?.pinnedModel, "qwen/qwen-2.5-72b-instruct");
+	assert.equal(pinned?.model, "claude-opus-5", "last-served is reported separately");
+	assert.equal(plain?.pinnedModel, undefined, "an unpinned thread follows its agent");
+	assert.equal(plain?.model, "claude-opus-5");
+});
+
+// The case that has no honest answer without the pin field: pin a thread and
+// never message it. `model` is absent entirely, so a UI reading only `model`
+// would show no model for a thread the operator just pinned.
+test("a thread pinned but never messaged still reports its pin", async () => {
+	pinSessionModel("main", "agent:main:t-fresh", "openrouter", "qwen/qwen-2.5-72b-instruct");
+
+	const res = await handleSessionsList({ agentId: "main" });
+	const row = res.sessions.find((s) => s.sessionKey === "agent:main:t-fresh");
+	assert.ok(row, "the pin created the entry, so the thread is listed");
+	assert.equal(row?.model, undefined, "nothing has served it yet");
+	assert.equal(row?.pinnedModel, "qwen/qwen-2.5-72b-instruct", "but the pin is visible");
 });

--- a/src/core/server-methods/sessions.ts
+++ b/src/core/server-methods/sessions.ts
@@ -38,6 +38,7 @@ import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
 import {
 	listSessionEntries,
+	readSessionModelPin,
 	readSessionStore,
 	deleteSessionEntry,
 	renameSessionEntry,
@@ -208,6 +209,11 @@ export async function handleSessionsList(
 				...(Number.isFinite(startedAt) ? { startedAt } : {}),
 				...(Number.isFinite(updatedAt) ? { updatedAt } : {}),
 				...(typeof entry.modelId === "string" ? { model: entry.modelId } : {}),
+				// The PIN, separate from `model` above (which is only what last
+				// served the session). A thread pinned but not yet messaged has a
+				// pin and a stale-or-absent `model`; surfacing only the latter
+				// would show a UI the wrong model for exactly that thread.
+				...(pinOf(agentId, sessionKey) ?? {}),
 				...(sanitizeSessionName(entry.name) ? { displayName: sanitizeSessionName(entry.name) } : {}),
 			});
 		}
@@ -218,6 +224,15 @@ export async function handleSessionsList(
 	let all = [...rows, ...persisted];
 	if (typeof params.limit === "number" && params.limit > 0) all = all.slice(0, params.limit);
 	return { sessions: all, count: all.length };
+}
+
+/** Pin fields for a list row, or undefined when the session follows its agent. */
+function pinOf(
+	agentId: string,
+	sessionKey: string,
+): { pinnedProvider: string; pinnedModel: string } | undefined {
+	const pin = readSessionModelPin(agentId, sessionKey);
+	return pin ? { pinnedProvider: pin.provider, pinnedModel: pin.modelId } : undefined;
 }
 
 function applyFilters(rows: LiveSessionRecord[], params: SessionsListParams): LiveSessionRecord[] {

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -252,8 +252,15 @@ import {
 	getLaneQueueSize,
 	sessionLane,
 } from "../process/lanes.js";
-import { defaultSessionKey, readSessionStore } from "../sessions/session-store.js";
+import {
+	clearSessionModelPin,
+	defaultSessionKey,
+	pinSessionModel,
+	readSessionModelPin,
+	readSessionStore,
+} from "../sessions/session-store.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { planStateFanout } from "./state-fanout.js";
 import { resolveSessionTranscriptPath } from "../config/paths.js";
 import {
 	flattenConversation,
@@ -1729,7 +1736,10 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		}
 	};
 
-	const buildSnapshot = (snapshotAgentId?: string): SessionStateSnapshot => {
+	const buildSnapshot = (
+		snapshotAgentId?: string,
+		snapshotSessionKey?: string,
+	): SessionStateSnapshot => {
 		// Wave K — per-binding snapshot. When the caller supplies a
 		// `snapshotAgentId`, the snapshot reflects THAT agent's runtime entry
 		// + workspace-derived persona name + per-agent live-session count, so
@@ -1743,25 +1753,42 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		// session-init + refreshed by boot-agent set-model). Non-boot
 		// snapshots derive on the fly from the agent's selected model — the
 		// derivation is pure + cheap (no I/O).
-		const supportsThinking = isBoot ? cachedSupportsThinking : !!rt.model?.reasoning;
-		const availableThinkingLevels = isBoot
-			? cachedThinkingLevels
-			: rt.model ? deriveThinkingLevels(rt.model) : [];
-		// Per-binding session targeting: the TUI bound to `targetAgentId`
-		// defaults to that agent's canonical session key when nothing else
-		// is bound. Falls back to the gateway's boot `sessionKey` for the
-		// boot agent to keep legacy unchanged.
-		const targetSessionKey = isBoot ? sessionKey : defaultSessionKey(targetAgentId);
+		// Per-binding session targeting happens BEFORE the capability derivation
+		// below, because a pinned session runs a different model from its agent
+		// and every capability shown in the header has to describe the model
+		// that will actually serve the next turn in THIS thread.
+		const targetSessionKey =
+			snapshotSessionKey?.trim() || (isBoot ? sessionKey : defaultSessionKey(targetAgentId));
+		// Same resolution the turn performs (see the `turnPin` block in the
+		// prompt path) — if these two ever disagree the header lies about which
+		// model answered.
+		const pin = readSessionModelPin(targetAgentId, targetSessionKey);
+		// A pinned model is validated against the registry when it is set, but
+		// the registry can be refreshed/reseeded since; an unresolvable pin
+		// still shows its ids and simply reports conservative capabilities
+		// rather than borrowing the agent model's, which would be a lie.
+		const pinnedModel = pin ? modelRegistry.find(pin.provider, pin.modelId) : undefined;
+		const effectiveModel = pin ? pinnedModel : rt.model;
+		const supportsThinking = pin
+			? !!pinnedModel?.reasoning
+			: isBoot
+				? cachedSupportsThinking
+				: !!rt.model?.reasoning;
+		const availableThinkingLevels = pin
+			? pinnedModel ? deriveThinkingLevels(pinnedModel) : []
+			: isBoot
+				? cachedThinkingLevels
+				: rt.model ? deriveThinkingLevels(rt.model) : [];
 		return {
-			provider: rt.provider,
-			modelId: rt.modelId,
-			modelName: rt.model?.name,
+			provider: pin?.provider ?? rt.provider,
+			modelId: pin?.modelId ?? rt.modelId,
+			modelName: effectiveModel?.name ?? pin?.modelId,
 			thinkingLevel: rt.thinkingLevel,
 			supportsThinking,
 			// Same derivation the turn itself uses (`resolveInboundImagePrompt` gates
 			// inline image blocks on exactly this), so the TUI's "this model can't see
 			// images" warning can never disagree with what the turn does with them.
-			supportsVision: modelSupportsImageInput(rt.model) === true,
+			supportsVision: modelSupportsImageInput(effectiveModel) === true,
 			availableThinkingLevels,
 			...(latestUpdate ? { updateAvailable: latestUpdate } : {}),
 			contextUsagePercent: lastContextUsagePercent,
@@ -1970,6 +1997,46 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		);
 
 	/** Send one event to all connected clients (or a filtered subset). */
+	/**
+	 * Per-socket send guards, shared by `broadcast` (one payload for everyone)
+	 * and `broadcastStateAllBindings` (a payload built per connection). Returns
+	 * null when the socket must be skipped, having already closed a slow
+	 * consumer; otherwise the connection's id, which may be undefined during
+	 * the open/assign race.
+	 */
+	const prepareClient = (ws: WebSocket): { connId: string | undefined } | null => {
+		if (ws.readyState !== ws.OPEN) return null;
+		// Slow-consumer backpressure. A client that keeps answering
+		// protocol-level PINGs (so the ping reaper never reaps it) but can't
+		// drain its receive side accumulates every broadcast in its send buffer
+		// without bound. Close it (1008 = policy violation) rather than grow
+		// gateway memory; the `close` handler drops it from `clients` + subs.
+		if (ws.bufferedAmount > MAX_WS_BUFFERED_BYTES) {
+			try {
+				ws.close(1008, "slow consumer");
+			} catch {
+				/* best-effort — socket may already be closing */
+			}
+			return null;
+		}
+		return { connId: clientConnIds.get(ws) };
+	};
+	/**
+	 * `ws.send` is wrapped because the `readyState === OPEN` check above narrows
+	 * but does not fully eliminate the window — a socket can transition between
+	 * the check and the send. Most not-OPEN sends surface as an async `error`
+	 * event rather than a synchronous throw, so an escaping throw is unlikely,
+	 * but the swallow keeps a hot broadcast path from ever crashing on one bad
+	 * socket — matching the try-wrapped `ws.ping()` in the reaper.
+	 */
+	const sendIfWritable = (ws: WebSocket, json: string): void => {
+		try {
+			ws.send(json);
+		} catch {
+			/* best-effort — drop send to a transitioning socket */
+		}
+	};
+
 	const broadcast = <K extends EventName>(event: K, payload: EventPayload[K]): void => {
 		// Untagged payloads broadcast to everyone (state, error, basic log).
 		// Tagged payloads (pi, log with agent/session, approval-request,
@@ -2022,71 +2089,63 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				: { type: "event", event, payload };
 		const json = JSON.stringify(frame);
 		for (const ws of clients) {
-			if (ws.readyState !== ws.OPEN) continue;
-			// Slow-consumer backpressure. A client that keeps answering
-			// protocol-level PINGs (so the ping reaper never reaps it) but
-			// can't drain its receive side accumulates every broadcast in its
-			// send buffer without bound — `broadcast` fires on every Pi event
-			// mid-turn. When the buffered bytes exceed the cap, close the
-			// socket (1008 = policy violation) and drop the client instead of
-			// growing gateway memory. The `close` handler removes it from
-			// `clients` + the subscription maps.
-			if (ws.bufferedAmount > MAX_WS_BUFFERED_BYTES) {
-				try {
-					ws.close(1008, "slow consumer");
-				} catch {
-					/* best-effort — socket may already be closing */
-				}
-				continue;
-			}
-			const connId = clientConnIds.get(ws);
+			const ready = prepareClient(ws);
+			if (!ready) continue;
 			// No connId yet (race between socket open + onConnection assign):
 			// best-effort send (matches old behaviour).
-			//
-			// `ws.send` is wrapped because the `readyState === OPEN` check
-			// above narrows but does not fully eliminate the window — a socket
-			// can transition state between the check and the send. Most
-			// not-OPEN sends surface as an async `'error'` event (handled by
-			// `ws.on("error")`) rather than a synchronous throw, so an escaping
-			// throw is unlikely, but the swallow keeps a hot broadcast path
-			// (Pi events, tick, cron) from ever crashing on one bad socket —
-			// matching the try-wrapped `ws.ping()` in the reaper below.
-			if (!connId) {
-				try {
-					ws.send(json);
-				} catch {
-					/* best-effort — drop send to a transitioning socket */
-				}
-				continue;
-			}
-			if (connWantsFrame(connId, frameAgentId, frameSessionId)) {
-				try {
-					ws.send(json);
-				} catch {
-					/* best-effort — drop send to a transitioning socket */
-				}
+			if (!ready.connId || connWantsFrame(ready.connId, frameAgentId, frameSessionId)) {
+				sendIfWritable(ws, json);
 			}
 		}
 	};
 
 	/**
-	 * Wave K — fan out a state snapshot to every binding. Sends the boot-agent
-	 * snapshot (untagged → reaches legacy un-subscribed clients) PLUS one
-	 * tagged snapshot per distinct non-boot agentId any connected client is
-	 * subscribed to. The per-conn filter delivers each tagged frame only to
-	 * that agent's subscribers — so a TUI bound to `agent:ops` sees `ops`'s
-	 * header while an un-bound TUI keeps seeing the boot header.
+	 * Fan out a state snapshot to every binding.
+	 *
+	 * Built PER CONNECTION rather than once for everyone, because the model in
+	 * the snapshot now depends on the SESSION a connection is bound to, not
+	 * just its agent: a pinned thread runs a different model from its agent, so
+	 * a single shared payload cannot describe both. Two TUIs on the same agent
+	 * but different threads legitimately see different headers.
+	 *
+	 * Recipients are chosen explicitly here, so these frames bypass the tag
+	 * filter `broadcast()` applies. Fan-out per subscribed agent is preserved
+	 * exactly as before; the session is layered on top only where it is
+	 * unambiguous.
 	 */
 	const broadcastStateAllBindings = (): void => {
-		const seen = new Set<string>();
-		for (const subs of clientAgentSubs.values()) {
-			for (const id of subs) {
-				if (id && id !== agentId) seen.add(id);
+		// One connection per open socket, but many share a binding — build each
+		// distinct (agent, session) payload once.
+		const frames = new Map<string, string>();
+		const frameFor = (a: string | undefined, sk: string | undefined): string => {
+			const cacheKey = `${a ?? ""}\u0000${sk ?? ""}`;
+			let json = frames.get(cacheKey);
+			if (json === undefined) {
+				json = JSON.stringify({
+					type: "event",
+					event: "state",
+					payload: buildSnapshot(a, sk),
+				} satisfies Frame);
+				frames.set(cacheKey, json);
 			}
-		}
-		broadcast("state", buildSnapshot());
-		for (const id of seen) {
-			broadcast("state", buildSnapshot(id));
+			return json;
+		};
+		for (const ws of clients) {
+			const ready = prepareClient(ws);
+			if (!ready) continue;
+			const { connId } = ready;
+			// Recipient planning lives in `state-fanout.ts` so it is covered by a
+			// focused unit test rather than a live WS server — same split as
+			// `connWantsFrame` / `shouldDeliverFrame`.
+			const targets = planStateFanout({
+				agentSubs: connId ? clientAgentSubs.get(connId) : undefined,
+				sessionSubs: connId ? clientSessionSubs.get(connId) : undefined,
+				bootAgentId: agentId,
+				ownerOf: (sk) => parseAgentSessionKey(sk)?.agentId,
+			});
+			for (const t of targets) {
+				sendIfWritable(ws, frameFor(t.agentId, t.sessionKey));
+			}
 		}
 	};
 
@@ -2885,8 +2944,20 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				// so a turn for `agent:ops` no longer sees mutations meant for
 				// `agent:main`.
 				const turnRuntime = getAgentRuntime(targetAgentId);
-				const turnProvider = turnRuntime.provider;
-				const turnModelId = turnRuntime.modelId;
+				// Per-session model pin, when this session has one. A pin is the
+				// ONLY thing that makes a session diverge from its agent: sessions
+				// without one read `turnRuntime` live, so an agent-wide `/model`
+				// still moves every unpinned session, existing or brand new.
+				//
+				// Deliberately NOT `entry.provider`/`entry.modelId` — every turn
+				// stamps those with whatever served it, so reading them here would
+				// freeze each session to its first turn's model and make an
+				// agent-wide switch a silent no-op. See `readSessionModelPin`.
+				const turnPin = turn.sessionKey
+					? readSessionModelPin(targetAgentId, turn.sessionKey)
+					: null;
+				const turnProvider = turnPin?.provider ?? turnRuntime.provider;
+				const turnModelId = turnPin?.modelId ?? turnRuntime.modelId;
 				const turnThinkingLevel = turnRuntime.thinkingLevel;
 
 				// C2: forward the per-agent `workspace` override from cfg so the
@@ -3145,6 +3216,41 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 						authStorage: targetAuth,
 					})) as Model<string> | undefined);
 				if (!target) throw new Error(`model ${p.provider}/${p.modelId} not found`);
+				// Session scope — pin THIS session and stop. The agent's runtime
+				// entry and its persisted config are deliberately left alone:
+				// giving one thread a different model must not move the agent or
+				// any of its other threads. Validation above already ran, so a
+				// pin can only ever name a model that actually resolves.
+				if (p.scope === "session") {
+					const rawPinKey = typeof p.sessionKey === "string" ? p.sessionKey.trim() : "";
+					if (!rawPinKey) {
+						throw new Error('set-model: scope "session" requires a sessionKey');
+					}
+					// The pin is READ back at turn time under the turn's own
+					// agentId, so writing it under a different agent's store would
+					// file it where no turn will ever look for it. Reject the
+					// mismatch instead of silently cross-filing.
+					const parsedPinKey = parseAgentSessionKey(rawPinKey);
+					if (parsedPinKey && parsedPinKey.agentId !== targetAgentId) {
+						throw new Error(
+							`set-model: session ${rawPinKey} does not belong to agent ${targetAgentId}`,
+						);
+					}
+					const pinVerdict = sessionsAccessCheck({
+						action: "send",
+						targetSessionKey: rawPinKey,
+					});
+					if (!pinVerdict.allowed) {
+						const err = new Error(pinVerdict.reason ?? "set-model forbidden");
+						(err as Error & { code?: string }).code = "forbidden";
+						throw err;
+					}
+					if (!pinSessionModel(targetAgentId, rawPinKey, p.provider, p.modelId)) {
+						throw new Error(`set-model: cannot pin session ${rawPinKey}`);
+					}
+					broadcastStateAllBindings();
+					return undefined as ResponseFor[M];
+				}
 				// Mutate ONLY this agent's runtime entry — never spill model
 				// changes for one agent onto another's next turn.
 				perAgentRuntime.set(targetAgentId, {
@@ -3218,6 +3324,34 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				}
 				broadcastStateAllBindings();
 				return undefined as ResponseFor[M];
+			}
+			case "clear-session-model": {
+				const p = params as RequestParams["clear-session-model"];
+				const targetAgentId = p.agentId?.trim() || agentId;
+				const rawKey = typeof p.sessionKey === "string" ? p.sessionKey.trim() : "";
+				const pinKey = rawKey || defaultSessionKey(targetAgentId);
+				const parsedPinKey = parseAgentSessionKey(pinKey);
+				if (parsedPinKey && parsedPinKey.agentId !== targetAgentId) {
+					throw new Error(
+						`clear-session-model: session ${pinKey} does not belong to agent ${targetAgentId}`,
+					);
+				}
+				const clearVerdict = sessionsAccessCheck({
+					action: "send",
+					targetSessionKey: pinKey,
+				});
+				if (!clearVerdict.allowed) {
+					const err = new Error(clearVerdict.reason ?? "clear-session-model forbidden");
+					(err as Error & { code?: string }).code = "forbidden";
+					throw err;
+				}
+				// Report whether a pin was actually dropped, so the TUI can say
+				// "this thread wasn't pinned" instead of implying it changed
+				// something. Read before the clear — after it, both look alike.
+				const hadPin = readSessionModelPin(targetAgentId, pinKey) !== null;
+				clearSessionModelPin(targetAgentId, pinKey);
+				if (hadPin) broadcastStateAllBindings();
+				return { cleared: hadPin } as ResponseFor[M];
 			}
 			case "switch-model-mid-turn": {
 				const p = params as RequestParams["switch-model-mid-turn"];
@@ -3699,7 +3833,7 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 					pendingApprovals,
 					recentSystemEvents: recentSystemEvents.get(targetSessionKey) ?? [],
 					epoch: gatewayEpoch,
-					snapshot: buildSnapshot(targetAgentId),
+					snapshot: buildSnapshot(targetAgentId, targetSessionKey),
 				} as ResponseFor[M];
 			}
 			case "memory-graph": {
@@ -4003,7 +4137,10 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 						const snapFrame: Frame = {
 							type: "event",
 							event: "state",
-							payload: buildSnapshot(p.agentId.trim()),
+							payload: buildSnapshot(
+								p.agentId.trim(),
+								typeof p.sessionId === "string" ? p.sessionId.trim() : undefined,
+							),
 						};
 						ws.send(JSON.stringify(snapFrame));
 					}

--- a/src/core/state-fanout.test.ts
+++ b/src/core/state-fanout.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { planStateFanout } from "./state-fanout.js";
+
+// Mirrors `parseAgentSessionKey`'s agent extraction for canonical keys.
+const ownerOf = (sk: string): string | undefined => {
+	const m = /^agent:([^:]+):.+$/.exec(sk);
+	return m ? m[1] : undefined;
+};
+
+const plan = (
+	agentSubs: string[] | undefined,
+	sessionSubs: string[] | undefined,
+	bootAgentId = "main",
+) =>
+	planStateFanout({
+		agentSubs: agentSubs ? new Set(agentSubs) : undefined,
+		sessionSubs: sessionSubs ? new Set(sessionSubs) : undefined,
+		bootAgentId,
+		ownerOf,
+	});
+
+// The regression that would break every client: a connection must always be
+// planned at least one frame, or state updates stop arriving entirely.
+test("every connection is always planned at least one frame", () => {
+	const cases: Array<[string[] | undefined, string[] | undefined]> = [
+		[undefined, undefined],
+		[[], []],
+		[["main"], undefined],
+		[undefined, ["agent:main:t-1"]],
+		[["main", "ops"], ["agent:ops:t-9"]],
+		[["main"], ["agent:main:t-1", "agent:main:t-2"]],
+	];
+	for (const [a, s] of cases) {
+		assert.ok(plan(a, s).length >= 1, `no frame planned for ${JSON.stringify([a, s])}`);
+	}
+});
+
+test("un-subscribed client still gets the boot-agent snapshot", () => {
+	assert.deepEqual(plan(undefined, undefined), [{ agentId: undefined, sessionKey: undefined }]);
+	assert.deepEqual(plan([], []), [{ agentId: undefined, sessionKey: undefined }]);
+});
+
+test("the bound thread rides along on its own agent's snapshot", () => {
+	assert.deepEqual(plan(["main"], ["agent:main:t-1"]), [
+		{ agentId: "main", sessionKey: "agent:main:t-1" },
+	]);
+});
+
+// Carrying agent A's thread into agent B's snapshot would read B's store for
+// A's key and report a pin that does not apply there.
+test("a thread never rides on another agent's snapshot", () => {
+	assert.deepEqual(plan(["ops"], ["agent:main:t-1"]), [
+		{ agentId: "ops", sessionKey: undefined },
+	]);
+	assert.deepEqual(plan(["main", "ops"], ["agent:ops:t-9"]), [
+		{ agentId: "main", sessionKey: undefined },
+		{ agentId: "ops", sessionKey: "agent:ops:t-9" },
+	]);
+});
+
+test("agent fan-out is preserved: one frame per subscribed agent", () => {
+	const out = plan(["main", "ops", "coder"], undefined);
+	assert.equal(out.length, 3);
+	assert.deepEqual(
+		out.map((t) => t.agentId),
+		["main", "ops", "coder"],
+	);
+	assert.ok(out.every((t) => t.sessionKey === undefined));
+});
+
+// Zero or many session subs cannot identify "the thread being viewed".
+test("an ambiguous session binding falls back to agent-level", () => {
+	assert.deepEqual(plan(["main"], ["agent:main:t-1", "agent:main:t-2"]), [
+		{ agentId: "main", sessionKey: undefined },
+	]);
+	assert.deepEqual(plan(["main"], []), [{ agentId: "main", sessionKey: undefined }]);
+});
+
+test("a session-only subscription rides the boot agent when it owns the key", () => {
+	assert.deepEqual(plan(undefined, ["agent:main:t-1"]), [
+		{ agentId: undefined, sessionKey: "agent:main:t-1" },
+	]);
+	// ...but not when it belongs to a different agent.
+	assert.deepEqual(plan(undefined, ["agent:ops:t-1"]), [
+		{ agentId: undefined, sessionKey: undefined },
+	]);
+});
+
+test("a non-canonical session key is never carried", () => {
+	assert.deepEqual(plan(["main"], ["constructor"]), [
+		{ agentId: "main", sessionKey: undefined },
+	]);
+	assert.deepEqual(plan(["main"], ["not-a-key"]), [{ agentId: "main", sessionKey: undefined }]);
+});

--- a/src/core/state-fanout.ts
+++ b/src/core/state-fanout.ts
@@ -1,0 +1,67 @@
+// Pure per-connection state-snapshot fan-out planner for the gateway.
+//
+// A `state` snapshot used to be built once and broadcast to everyone, because
+// everything in it was per-AGENT. Per-session model pins broke that assumption:
+// a pinned thread runs a different model from its agent, so two TUIs bound to
+// the same agent but different threads legitimately need different snapshots.
+//
+// This module decides WHICH snapshots one connection should receive, given the
+// subscriptions it holds. It is extracted from `startServer` for the same
+// reason `shouldDeliverFrame` is — so the behaviour is exercised by a focused
+// unit test instead of a live WS server.
+//
+// Agent fan-out is preserved exactly as it was before pins existed: one
+// snapshot per subscribed agent, and the boot-agent snapshot for a client that
+// never subscribed. The session is layered on top only where it is unambiguous.
+
+/** One snapshot to build and send: the agent it describes, and the thread. */
+export interface StateFanoutTarget {
+	/** undefined = the gateway's boot agent (legacy un-subscribed client). */
+	agentId: string | undefined;
+	/** undefined = that agent's default session (no unambiguous thread). */
+	sessionKey: string | undefined;
+}
+
+export interface StateFanoutInput {
+	/** Agents this connection subscribed to. */
+	agentSubs: ReadonlySet<string> | undefined;
+	/** Sessions this connection subscribed to. */
+	sessionSubs: ReadonlySet<string> | undefined;
+	/** The gateway's boot agent id — the owner for the un-subscribed case. */
+	bootAgentId: string;
+	/**
+	 * Which agent a session key belongs to, or undefined when the key isn't
+	 * canonical. Injected so this stays pure (the caller passes
+	 * `parseAgentSessionKey`).
+	 */
+	ownerOf: (sessionKey: string) => string | undefined;
+}
+
+/**
+ * Plan the state frames for one connection.
+ *
+ * The session binding is only applied to a snapshot whose agent OWNS that
+ * session. Carrying agent A's thread into agent B's snapshot would read B's
+ * store for A's key and report a pin that doesn't apply there.
+ */
+export function planStateFanout(input: StateFanoutInput): StateFanoutTarget[] {
+	const { agentSubs, sessionSubs, bootAgentId, ownerOf } = input;
+	// The TUI holds exactly ONE session binding at a time — it unsubscribes the
+	// previous thread before subscribing the next — so a single entry identifies
+	// the thread this connection is looking at. Any other count is ambiguous
+	// (zero = never bound, more than one = a multiplexing client), and we fall
+	// back to agent-level snapshots rather than guessing which thread is meant.
+	const boundSession = sessionSubs && sessionSubs.size === 1 ? [...sessionSubs][0] : undefined;
+	const sessionIfOwnedBy = (ownerAgentId: string): string | undefined => {
+		if (!boundSession) return undefined;
+		return ownerOf(boundSession) === ownerAgentId ? boundSession : undefined;
+	};
+
+	if (!agentSubs || agentSubs.size === 0) {
+		// Legacy / un-subscribed client: the boot-agent snapshot, exactly as
+		// before. It can still carry a thread if the client subscribed to one
+		// without naming an agent.
+		return [{ agentId: undefined, sessionKey: sessionIfOwnedBy(bootAgentId) }];
+	}
+	return [...agentSubs].map((id) => ({ agentId: id, sessionKey: sessionIfOwnedBy(id) }));
+}

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -116,6 +116,8 @@ export type RequestMethod =
 	| "steer"
 	/** Switch to a different model. Reply: void. */
 	| "set-model"
+	/** Drop a session's model pin so it follows its agent again. */
+	| "clear-session-model"
 	/** Mid-turn live model switch — abort + swap + re-prompt. Reply: void. */
 	| "switch-model-mid-turn"
 	/** Set thinking level. Pi clamps to model capabilities. Reply: void. */
@@ -305,6 +307,7 @@ export const REQUEST_METHODS = [
 	"abort",
 	"steer",
 	"set-model",
+	"clear-session-model",
 	"switch-model-mid-turn",
 	"set-thinking",
 	"compact",
@@ -517,6 +520,29 @@ export interface RequestParams {
 		modelId: string;
 		/** Agent id whose runtime entry is mutated; defaults to caller's bound agent. */
 		agentId?: string;
+		/**
+		 * Session to pin. Only read when `scope` is "session"; ignored for
+		 * agent scope, where the change deliberately spans every session.
+		 */
+		sessionKey?: string;
+		/**
+		 * "agent" (the default, and the pre-existing behaviour) — move the
+		 * agent's model. Every session WITHOUT its own pin follows, whether it
+		 * already exists or is created later.
+		 *
+		 * "session" — pin `sessionKey` alone and leave the agent untouched, so
+		 * one thread can run a different model without affecting the others.
+		 *
+		 * Optional for wire-compat: a client older than this field sends no
+		 * scope and keeps getting agent-wide behaviour.
+		 */
+		scope?: "agent" | "session";
+	};
+	"clear-session-model": {
+		/** Session whose pin is dropped; defaults to the caller's bound session. */
+		sessionKey?: string;
+		/** Agent owning that session; defaults to the caller's bound agent. */
+		agentId?: string;
 	};
 	"switch-model-mid-turn": {
 		provider: string;
@@ -667,6 +693,9 @@ export interface ResponseFor {
 	abort: void;
 	steer: void;
 	"set-model": void;
+	/** `cleared: false` means the session existed but had no pin — a no-op the
+	 *  TUI reports differently from an actual unpin. */
+	"clear-session-model": { cleared: boolean };
 	"switch-model-mid-turn": void;
 	"set-thinking": void;
 	compact: void;

--- a/src/protocol/methods.ts
+++ b/src/protocol/methods.ts
@@ -85,7 +85,23 @@ export interface SessionListRow {
 	kind?: string;
 	channel?: string;
 	subject?: string;
+	/**
+	 * The model that last SERVED this session — a record of what ran, not a
+	 * choice. Absent on a session that has never taken a turn. A UI labelling
+	 * a thread's model wants `pinnedModel` (an explicit pin) or the resolved
+	 * `modelId` from `SessionStateSnapshot` (pin ?? agent ?? defaults); this
+	 * field goes stale the moment the agent's model moves under an unpinned
+	 * session, and lags a pin that hasn't been used yet.
+	 */
 	model?: string;
+	/**
+	 * Set only when the operator PINNED this session to a model (`/model <id>
+	 * --thread`). Absent means the session follows its agent, so an agent-wide
+	 * `/model` moves it. Together with `model` above, a UI can distinguish
+	 * "pinned to X" from "last ran on Y".
+	 */
+	pinnedProvider?: string;
+	pinnedModel?: string;
 	state?: string;
 	startedAt?: number;
 	endedAt?: number;

--- a/src/sessions/session-model-pin.test.ts
+++ b/src/sessions/session-model-pin.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+	MAX_MODEL_PIN_LENGTH,
+	clearSessionModelPin,
+	pinSessionModel,
+	readSessionModelPin,
+	readSessionStore,
+	resolveOrCreateSession,
+	upsertSessionEntry,
+} from "./session-store.js";
+
+function withTempState(fn: () => void): void {
+	const dir = mkdtempSync(path.join(tmpdir(), "brigade-model-pin-"));
+	const prev = process.env.BRIGADE_STATE_DIR;
+	process.env.BRIGADE_STATE_DIR = dir;
+	try {
+		fn();
+	} finally {
+		if (prev === undefined) delete process.env.BRIGADE_STATE_DIR;
+		else process.env.BRIGADE_STATE_DIR = prev;
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+const KEY = "agent:main:t-pin";
+
+test("pin round-trips and clears", () => {
+	withTempState(() => {
+		assert.equal(readSessionModelPin("main", KEY), null);
+		assert.ok(pinSessionModel("main", KEY, "openrouter", "qwen/qwen-2.5-72b-instruct"));
+		assert.deepEqual(readSessionModelPin("main", KEY), {
+			provider: "openrouter",
+			modelId: "qwen/qwen-2.5-72b-instruct",
+		});
+		clearSessionModelPin("main", KEY);
+		assert.equal(readSessionModelPin("main", KEY), null);
+	});
+});
+
+// THE migration guarantee. Every session that has ever run already carries a
+// `provider`/`modelId` stamp from its last turn. If those were read as a pin,
+// every historical thread would be frozen to its first turn's model and an
+// agent-wide `/model` would silently fail to move any of them.
+test("a legacy entry with provider/modelId but no pin reads as UNPINNED", () => {
+	withTempState(() => {
+		upsertSessionEntry("main", KEY, {
+			provider: "claude-cli",
+			modelId: "claude-opus-5",
+		});
+		const entry = readSessionStore("main").sessions[KEY];
+		assert.equal(entry?.provider, "claude-cli", "stamp is present");
+		assert.equal(readSessionModelPin("main", KEY), null, "but it is NOT a pin");
+	});
+});
+
+// The bug that made per-session model look missing: every turn stamps the
+// entry with whatever model served it. That must not disturb the pin.
+test("a turn's stamp neither creates nor destroys a pin", () => {
+	withTempState(() => {
+		pinSessionModel("main", KEY, "openrouter", "qwen/qwen-2.5-72b-instruct");
+		// Simulate a turn: exactly what runSingleTurn passes as overrides.
+		resolveOrCreateSession({
+			agentId: "main",
+			sessionKey: KEY,
+			overrides: { provider: "claude-cli", modelId: "claude-opus-5" },
+		});
+		const entry = readSessionStore("main").sessions[KEY];
+		assert.equal(entry?.provider, "claude-cli", "stamp records what actually ran");
+		assert.deepEqual(
+			readSessionModelPin("main", KEY),
+			{ provider: "openrouter", modelId: "qwen/qwen-2.5-72b-instruct" },
+			"pin survives a turn that used a different model",
+		);
+
+		// And on an UNPINNED session the same stamp must not conjure a pin.
+		const other = "agent:main:t-unpinned";
+		resolveOrCreateSession({
+			agentId: "main",
+			sessionKey: other,
+			overrides: { provider: "claude-cli", modelId: "claude-opus-5" },
+		});
+		assert.equal(readSessionModelPin("main", other), null);
+	});
+});
+
+test("half a pin is not a pin", () => {
+	withTempState(() => {
+		// Only reachable by hand-editing the store; must degrade to "follow the
+		// agent" rather than guess the missing half.
+		upsertSessionEntry("main", KEY, { pinnedProvider: "openrouter" });
+		assert.equal(readSessionModelPin("main", KEY), null);
+	});
+});
+
+test("pin rejects unusable ids and never writes half a pin", () => {
+	withTempState(() => {
+		const controlChar = "a\u0000b";
+		const tooLong = "x".repeat(MAX_MODEL_PIN_LENGTH + 1);
+		for (const bad of ["", "   ", controlChar, tooLong]) {
+			assert.equal(pinSessionModel("main", KEY, "openrouter", bad), null);
+			assert.equal(pinSessionModel("main", KEY, bad, "some-model"), null);
+		}
+		assert.equal(pinSessionModel("main", KEY, 42, "some-model"), null);
+		assert.equal(readSessionModelPin("main", KEY), null);
+		assert.equal(readSessionStore("main").sessions[KEY], undefined, "no entry conjured");
+	});
+});
+
+test("prototype keys neither read nor create", () => {
+	withTempState(() => {
+		assert.equal(readSessionModelPin("main", "constructor"), null);
+		assert.equal(readSessionModelPin("main", "__proto__"), null);
+		// A non-canonical key may not CREATE an entry.
+		assert.equal(pinSessionModel("main", "constructor", "openrouter", "m"), null);
+		assert.equal(pinSessionModel("main", "not-a-session-key", "openrouter", "m"), null);
+		assert.equal(clearSessionModelPin("main", "constructor"), null);
+	});
+});
+
+test("pin creates the entry for a thread that has not taken a turn yet", () => {
+	withTempState(() => {
+		// The TUI mints a thread key the moment you open a new thread, so
+		// pinning before the first message has to persist.
+		const fresh = "agent:main:t-brandnew";
+		assert.equal(readSessionStore("main").sessions[fresh], undefined);
+		assert.ok(pinSessionModel("main", fresh, "openrouter", "qwen/qwen-2.5-72b-instruct"));
+		assert.deepEqual(readSessionModelPin("main", fresh), {
+			provider: "openrouter",
+			modelId: "qwen/qwen-2.5-72b-instruct",
+		});
+	});
+});
+
+test("clearing is idempotent and scoped to one session", () => {
+	withTempState(() => {
+		const a = "agent:main:t-a";
+		const b = "agent:main:t-b";
+		pinSessionModel("main", a, "openrouter", "qwen-a");
+		pinSessionModel("main", b, "openrouter", "qwen-b");
+		clearSessionModelPin("main", a);
+		clearSessionModelPin("main", a);
+		assert.equal(readSessionModelPin("main", a), null);
+		assert.deepEqual(readSessionModelPin("main", b), {
+			provider: "openrouter",
+			modelId: "qwen-b",
+		});
+		assert.equal(clearSessionModelPin("main", "agent:main:t-missing"), null);
+	});
+});

--- a/src/sessions/session-store.ts
+++ b/src/sessions/session-store.ts
@@ -17,6 +17,7 @@ import {
   writeThroughSessionCache,
 } from "../storage/session-cache.js";
 import { tryGetRuntimeContext } from "../storage/runtime-context.js";
+import { parseAgentSessionKey } from "./session-key-utils.js";
 
 /**
  * Wave L P2#11 — cross-process advisory file lock for `sessions.json`.
@@ -253,12 +254,30 @@ export interface SessionEntry {
   sessionId: string;
   createdAt: string;
   lastUsedAt: string;
-  // Optional per-session overrides — provider/model/auth profile/think level.
-  // Kept loose; Pi consumes whatever it understands and ignores the rest.
+  // What actually served this session's LAST turn. Every turn stamps these
+  // (see `runSingleTurn`'s `resolveOrCreateSession` overrides), so they are a
+  // record of what ran — NOT an operator choice. Do not read them to decide
+  // which model a turn should use; read `pinnedProvider`/`pinnedModelId`.
   provider?: string;
   modelId?: string;
   authProfile?: string;
   thinkingLevel?: string;
+  /**
+   * Explicit per-session model pin — the ONLY thing that makes a session
+   * diverge from its agent's current model.
+   *
+   * Deliberately a SEPARATE pair from `provider`/`modelId` above. Those are
+   * stamped on every turn, so every session that has ever run already carries
+   * one; reading them as a pin would retroactively freeze every historical
+   * thread to whatever model happened to serve its first turn, and an
+   * agent-wide `/model` would then silently fail to move any of them.
+   * Absence means "follow the agent", which is what we want for every
+   * pre-existing entry and every new session.
+   *
+   * Both fields are set and cleared together — a half-pin is never persisted.
+   */
+  pinnedProvider?: string;
+  pinnedModelId?: string;
   /** Primitive #6 — see `SubagentSessionMetadata`. Unset on top-level sessions. */
   subagent?: SubagentSessionMetadata;
   /**
@@ -643,6 +662,121 @@ export function upsertSessionEntry(
     // Convex mode never writes the JSONL here (inMemory + factory) — skip.
     if (tryGetRuntimeContext()?.mode !== "convex") ensureDir(resolveSessionsDir(agentId));
     return entry;
+  });
+}
+
+/* ─────────────────────── per-session model pin ─────────────────────── */
+
+/**
+ * A session's explicit model pin. Both halves are always present — the store
+ * never persists half a pin, so callers never have to reason about a provider
+ * without a model.
+ */
+export interface SessionModelPin {
+  provider: string;
+  modelId: string;
+}
+
+/** Upper bound on a pinned provider/model id. Well clear of the longest real
+ *  model id, while keeping a hand-edited or RPC-supplied value from bloating
+ *  the store. */
+export const MAX_MODEL_PIN_LENGTH = 200;
+
+/**
+ * Normalise one half of a pin. Anything unusable returns undefined, which
+ * callers read as "no pin" rather than an error: the store is a plain JSON
+ * file an operator can hand-edit, so a malformed value must degrade to
+ * "follow the agent" and never throw mid-turn.
+ */
+function sanitizeModelPinField(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  // Rejected, not stripped. Unlike a display name, an id containing a control
+  // character isn't a label we can tidy up — it's an id that will never match
+  // a registry entry, and it would corrupt every surface that prints it.
+  if (/[\u0000-\u001f\u007f]/.test(raw)) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_MODEL_PIN_LENGTH) return undefined;
+  return trimmed;
+}
+
+/**
+ * Read a session's model pin, or null when it has none — the common case, and
+ * the one that makes an agent-wide `/model` move the session.
+ *
+ * Own-property only: a bare index hits `Object.prototype`, so a key like
+ * `constructor` would resolve to a function and get probed for a pin.
+ */
+export function readSessionModelPin(agentId: string, sessionKey: string): SessionModelPin | null {
+  const store = readSessionStore(agentId);
+  if (!Object.hasOwn(store.sessions, sessionKey)) return null;
+  const entry = store.sessions[sessionKey];
+  if (!entry) return null;
+  const provider = sanitizeModelPinField(entry.pinnedProvider);
+  const modelId = sanitizeModelPinField(entry.pinnedModelId);
+  // Half a pin is not a pin. Pins are always written as a pair, so this only
+  // fires on a hand-edited store — follow the agent rather than guess.
+  if (!provider || !modelId) return null;
+  return { provider, modelId };
+}
+
+/**
+ * Pin a session to a specific provider/model.
+ *
+ * Creates the entry when the session hasn't taken its first turn yet — the TUI
+ * mints a thread key the moment you open a new thread, so pinning a fresh
+ * thread has to persist rather than silently no-op. Only a canonical
+ * `agent:<id>:<rest>` key may CREATE; a non-canonical key can still pin an
+ * entry that already exists, but never conjures one.
+ */
+export function pinSessionModel(
+  agentId: string,
+  sessionKey: string,
+  provider: unknown,
+  modelId: unknown,
+): SessionEntry | null {
+  const cleanProvider = sanitizeModelPinField(provider);
+  const cleanModelId = sanitizeModelPinField(modelId);
+  if (!cleanProvider || !cleanModelId) return null;
+  return withSyncStoreLock(agentId, () => {
+    const store = readSessionStore(agentId);
+    const existing = Object.hasOwn(store.sessions, sessionKey)
+      ? store.sessions[sessionKey]
+      : undefined;
+    if (!existing && !parseAgentSessionKey(sessionKey)) return null;
+    const now = new Date().toISOString();
+    const next: SessionEntry = existing
+      ? { ...existing, pinnedProvider: cleanProvider, pinnedModelId: cleanModelId }
+      : {
+          sessionId: randomUUID(),
+          createdAt: now,
+          lastUsedAt: now,
+          pinnedProvider: cleanProvider,
+          pinnedModelId: cleanModelId,
+        };
+    store.sessions[sessionKey] = next;
+    writeSessionStore(agentId, store);
+    if (tryGetRuntimeContext()?.mode !== "convex") ensureDir(resolveSessionsDir(agentId));
+    return next;
+  });
+}
+
+/**
+ * Drop a session's pin so it follows its agent again. Returns null when there
+ * is no such session; returns the entry when there is, pinned or not, so
+ * clearing twice is idempotent.
+ */
+export function clearSessionModelPin(agentId: string, sessionKey: string): SessionEntry | null {
+  return withSyncStoreLock(agentId, () => {
+    const store = readSessionStore(agentId);
+    if (!Object.hasOwn(store.sessions, sessionKey)) return null;
+    const entry = store.sessions[sessionKey];
+    if (!entry) return null;
+    const next: SessionEntry = { ...entry };
+    delete next.pinnedProvider;
+    delete next.pinnedModelId;
+    store.sessions[sessionKey] = next;
+    writeSessionStore(agentId, store);
+    return next;
   });
 }
 


### PR DESCRIPTION
## What

`/model` stays **agent-wide** — every session without a pin of its own follows it, existing threads and new ones alike. A session diverges only when explicitly pinned.

```
/model claude-sonnet-5            → moves the agent (and every unpinned thread)
/model claude-sonnet-5 --thread   → pins THIS thread only
/model --unpin                    → this thread follows the agent again
```

## Why it didn't already work

`SessionEntry.provider/modelId` have existed for a long time, but nothing read them: the gateway resolved every turn from `getAgentRuntime(agentId)` alone, so chat ignored per-session model entirely. Only `brigade agent` consulted the entry.

Those two fields also could **not** become the pin. Every turn stamps them with whatever model served it (`runSingleTurn` → `resolveOrCreateSession` overrides), so reading them as an operator choice would retroactively freeze every existing thread to its first turn's model, and an agent-wide `/model` would become a silent no-op on all of them.

So the pin is its own pair of fields. Absence means "follow the agent" — correct for every legacy entry, with **no migration and no data rewrite**.

## Changes

- **`session-store`** — `pinnedProvider`/`pinnedModelId` plus `readSessionModelPin` / `pinSessionModel` / `clearSessionModelPin`. Written as a pair (half a pin is not a pin), own-property lookups only, and a non-canonical key may pin an entry that already exists but never conjures one. Deliberately **not** added to convex's `KNOWN_FIELDS`, so both fields round-trip through the sealed `extra` blob instead of needing a column — the inverse of the `name` trap.
- **gateway** — turn resolution and `buildSnapshot` both consult the pin through the same helper, so the header cannot disagree with the model that answers. `set-model` gains `scope: "session"`; new `clear-session-model` reports whether a pin was actually dropped. Both guarded, and a session key belonging to another agent is rejected rather than cross-filed.
- **state broadcast** — now built **per connection**. The model in a snapshot depends on the bound thread, so one shared payload can no longer describe two TUIs on the same agent. Recipient planning is extracted to `state-fanout.ts` for a focused unit test, mirroring how `connWantsFrame` delegates to `shouldDeliverFrame`. Agent fan-out is preserved exactly; the session is layered on only where unambiguous.
- **`brigade agent`** — read the stamp as a pin, which froze CLI sessions the same way. Now reads the pin.

## Verification

Driven against a real gateway on an isolated port and state dir:

| step | pinned thread | plain thread |
|---|---|---|
| baseline | opus-5 | opus-5 |
| `/model sonnet-5 --thread` | **sonnet-5** | opus-5 |
| then agent-wide `/model fable-5` | **sonnet-5** (held) | **fable-5** (followed) |
| `/model --unpin` | fable-5 | fable-5 |

Row 3 is the whole point: an agent-wide switch moves unpinned threads and leaves pinned ones alone.

Also confirmed: the pin survives a full gateway restart, a real turn resolves *through* it, and unpinning twice is idempotent (`cleared=false` the second time).

Both critical tests were mutation-checked — making `readSessionModelPin` fall back to the incidental stamp makes them fail.

`tsc` and `biome` clean; 551 tests pass across `sessions/`, `core/` and `cli/commands/`.

## Not in scope

A broad sweep shows 43 failures in `analyze_media` path guards and the document tools. **Exactly 43 fail on clean `main` too** — pre-existing, and invisible to CI because `scripts/run-tests.mjs:31` globs `src/**/*.test.ts` through `/bin/sh`, which has no globstar and matches only two directory levels.