### PR TITLE
fix(tools): match allowed roots that are themselves symlinks

### DIFF
--- a/src/agents/tools/analyze-media-tool.ts
+++ b/src/agents/tools/analyze-media-tool.ts
@@ -663,7 +663,16 @@ function allowedLocalRoots(opts: { workspaceDir?: string; cwd?: string; ownerLoc
 	const add = (p?: string) => {
 		if (!p) return;
 		try {
-			roots.add(path.resolve(p));
+			const abs = path.resolve(p);
+			roots.add(abs);
+			// Both forms — see `allowedDocRoots` in doc-shared.ts. The target side is
+			// realpath'd, so a symlinked root (macOS `/var` → `/private/var`) matches
+			// nothing unless its realpath is a root too.
+			try {
+				roots.add(fs.realpathSync(abs));
+			} catch {
+				/* root doesn't exist (yet) — the resolved form still stands */
+			}
 		} catch {
 			/* ignore */
 		}

--- a/src/agents/tools/doc-shared.test.ts
+++ b/src/agents/tools/doc-shared.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Allowed-root scoping when a root is itself a SYMLINK.
+ *
+ * The guard realpaths the target (`nearestExistingAncestorReal` on a write,
+ * `fs.realpathSync` on a read) but used to keep the roots un-realpathed, so a
+ * symlinked root matched nothing. That is not a hypothetical: on macOS
+ * `os.tmpdir()` is `/var/folders/…` whose realpath is `/private/var/folders/…`,
+ * which made every doc/media tool refuse every file in temp — 41 test failures,
+ * invisible on Linux CI where `/tmp` is a real directory.
+ *
+ * This test builds the symlink explicitly so it fails on any platform.
+ */
+
+import { strict as assert } from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, it } from "node:test";
+
+import { allowedDocRoots, resolveOutputPath } from "./doc-shared.js";
+
+describe("allowed-root scoping — symlinked root", { skip: process.platform === "win32" }, () => {
+	it("accepts a write under a workspace reached through a symlink", () => {
+		const real = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "brigade-doc-real-"));
+		const link = path.join(fs.realpathSync(os.tmpdir()), `brigade-doc-link-${Date.now()}`);
+		fs.symlinkSync(real, link);
+		try {
+			const out = resolveOutputPath("out.docx", { workspaceDir: link, cwd: link });
+			assert.equal(out, path.join(link, "out.docx"));
+		} finally {
+			fs.rmSync(link, { force: true });
+			fs.rmSync(real, { recursive: true, force: true });
+		}
+	});
+
+	it("lists both the resolved and the realpath form of a root", () => {
+		const real = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "brigade-doc-real-"));
+		const link = path.join(fs.realpathSync(os.tmpdir()), `brigade-doc-link-${Date.now()}`);
+		fs.symlinkSync(real, link);
+		try {
+			const roots = allowedDocRoots({ workspaceDir: link });
+			assert.ok(roots.includes(link), "the path as given");
+			assert.ok(roots.includes(real), "and what it points at");
+		} finally {
+			fs.rmSync(link, { force: true });
+			fs.rmSync(real, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/agents/tools/doc-shared.ts
+++ b/src/agents/tools/doc-shared.ts
@@ -82,7 +82,18 @@ export function allowedDocRoots(opts: { workspaceDir?: string; cwd?: string }): 
 	const add = (p?: string) => {
 		if (!p) return;
 		try {
-			roots.add(path.resolve(p));
+			const abs = path.resolve(p);
+			roots.add(abs);
+			// Both forms, because the TARGET side is realpath'd and a root that is
+			// itself a symlink would then never match: on macOS `os.tmpdir()` is
+			// `/var/folders/…` while its realpath is `/private/var/folders/…`, so
+			// every file in temp read as "outside the allowed roots". Adding the
+			// realpath widens nothing — it names the same directory.
+			try {
+				roots.add(fs.realpathSync(abs));
+			} catch {
+				/* root doesn't exist (yet) — the resolved form still stands */
+			}
 		} catch {
 			/* ignore */
 		}

--- a/src/agents/tools/transcribe-audio-tool.ts
+++ b/src/agents/tools/transcribe-audio-tool.ts
@@ -609,7 +609,16 @@ function allowedLocalRoots(opts: { workspaceDir?: string; cwd?: string; ownerLoc
 	const add = (p?: string) => {
 		if (!p) return;
 		try {
-			roots.add(path.resolve(p));
+			const abs = path.resolve(p);
+			roots.add(abs);
+			// Both forms — see `allowedDocRoots` in doc-shared.ts. The target side is
+			// realpath'd, so a symlinked root (macOS `/var` → `/private/var`) matches
+			// nothing unless its realpath is a root too.
+			try {
+				roots.add(fs.realpathSync(abs));
+			} catch {
+				/* root doesn't exist (yet) — the resolved form still stands */
+			}
 		} catch {
 			/* ignore */
 		}


### PR DESCRIPTION
## Problem

Every doc and media tool refuses every file in the system temp directory on
macOS:

```
BrigadeToolInputError: refusing to read a source outside the allowed roots
(workspace / current dir / cache / temp). Move the file into the workspace first.
```

The file *is* in temp. Temp *is* an allowed root. The check still says no.

It affects `make_document`, `edit_document` (all six actions), `fill_form`,
`fill_template`, `analyze_media` and `transcribe_audio` — that is, everything
that scopes a path — and it fires on the most ordinary case there is: a file the
agent just wrote to `os.tmpdir()` and wants to read back.

## Root cause

The two sides of the comparison are not resolved the same way.

The **target** is realpath'd — `nearestExistingAncestorReal()` on a write
(`doc-shared.ts:171`), `fs.realpathSync()` on a read (`doc-shared.ts:203`).
That is deliberate: it stops a symlinked parent directory from redirecting a
write outside the roots.

The **roots** are collected with `path.resolve()` alone (`doc-shared.ts:85`).

So a root that is itself a symlink matches nothing under it. On macOS that is
the default state of the machine:

```
os.tmpdir()  =  /var/folders/…/T
realpath     =  /private/var/folders/…/T
```

`path.relative("/var/folders/…/T", "/private/var/folders/…/T/x.docx")` starts
with `..`, so `isInsideAnyRoot` returns false and a perfectly legitimate path is
refused.

It stayed hidden because on Linux `/tmp` is a real directory, so the two forms
coincide and CI is green.

## Change

Each root enters the set in both forms — as resolved, and as its realpath when
the directory exists:

```ts
const abs = path.resolve(p);
roots.add(abs);
try {
    roots.add(fs.realpathSync(abs));
} catch {
    /* root doesn't exist (yet) — the resolved form still stands */
}
```

**Nothing is widened.** The realpath of a directory names that same directory;
adding it only lets the comparison see a match that was already true. The
target side is untouched, so the symlink-redirection guard that motivated the
realpath in the first place still holds — a write through a symlinked parent is
still scoped by where the symlink actually points.

The same closure is duplicated in three files, and all three are patched:

- `src/agents/tools/doc-shared.ts` — `allowedDocRoots`
- `src/agents/tools/analyze-media-tool.ts` — `allowedLocalRoots`
- `src/agents/tools/transcribe-audio-tool.ts` — `allowedLocalRoots`

They are deliberately left as copies. Sharing them means reconciling three
different root lists (`analyze_media` and `transcribe_audio` take an
`ownerLocalAccess` widening that `doc-shared` has no concept of; the channel
subtrees differ), which is a larger change than this bug justifies and would put
a refactor of the path-scoping code inside a fix for it. Worth doing on its own
if a fourth caller ever appears.

## Tests

`src/agents/tools/doc-shared.test.ts` (new, 2 cases) builds the symlink itself
rather than leaning on the platform's tempdir, so it fails on Linux too — a
regression here would otherwise be invisible in CI, which is exactly how the bug
survived.

Verified in both directions: with the fix reverted the new file is 2 failed / 0
passed; with it, 2 passed.

## Verification

`npm run typecheck` clean. `npm test` green.

`npm test` alone is a weak signal here, because `scripts/run-tests.mjs` passes
`src/**/*.test.ts` through `spawnSync(..., { shell: true })` and `/bin/sh`
collapses `**` to a single `*` — 147 of 479 test files actually run. Running the
suite with the glob quoted, so Node does its own globbing:

| | before | after |
|---|---|---|
| fail | 45 | 12 |
| pass | 6014 | 6049 |

The 33 fixed are every docx / xlsx / pptx / PDF-path-guard / `analyze_media`
case that was failing on the allowed-roots message.

## Not in this PR

- **The test glob itself.** Quoting the pattern is a one-line change, but it
  turns 12 remaining failures into red CI, so it wants to land after they are
  fixed.
- **7 PDF failures**, all `TypeError: Cannot read properties of undefined
  (reading 'pos')` from `@pdf-lib/fontkit`'s `Struct.encode` during font
  subsetting. Unrelated root cause; they were previously masked by the
  allowed-roots error and only became visible once it was fixed.
- **`org tool — show action`** and one chart auto-format case. Separate causes,
  not yet triaged.