### PR TITLE
feat: surface reasoning honestly, provider-agnostic limits, /context

### DIFF
--- a/docs/reliable-streaming.md
+++ b/docs/reliable-streaming.md
@@ -244,3 +244,37 @@ client.on("resync", recover);      // backfill after a mid-stream gap
 
 That is the whole contract: **subscribe → resume → apply live by identity →
 resume again on any gap.** In order, nothing missing, nothing misplaced.
+
+## Cursor replay for sub-agent and synthetic frames
+
+The ordered stream was gap-*detectable* everywhere and gap-*repairable* only
+where the JSONL transcript could rebuild it. Two kinds of frame it cannot:
+
+- **sub-agent frames** (`subagentDepth > 0`) carry the child's own session id
+  and live in a child transcript the parent's `resume` never reads;
+- **synthetic frames** — the tool events Brigade mints for a `claude-cli` turn,
+  whose tools run inside the binary's own loop — are in no transcript at all.
+
+Both were therefore left unsequenced, which was correct: stamping a seq on a
+frame you cannot replay turns every dropped decoration into an unrepairable
+gap, and the client resyncs forever. **You cannot sequence a stream you cannot
+replay.**
+
+`FrameRing` (`src/core/frame-ring.ts`) closes that from the other end. It
+retains those frames per session — bounded by count, bytes, and distinct
+sessions — so `resume({ sinceSeq })` can return `replayedFrames`: the exact
+bytes originally broadcast, applied after the transcript and deduped by the
+same identity keys as a live frame. With replay available, sequencing them is
+safe, and they now carry a seq under **their own** session id rather than the
+parent's — so a client watching only the parent still sees an unbroken parent
+sequence instead of a false gap for every child frame it filtered out.
+
+Top-level `message_update` frames are deliberately **not** retained: they are
+cumulative, so buffering a long reply would cost O(n²) memory to redeliver what
+the transcript already returns better.
+
+`replayComplete` is the load-bearing part of the contract. It is `false` when
+retention was trimmed past the cursor, meaning some frames are gone for good
+and the client should treat that span as lost rather than assume it was empty.
+A client that reads a partial replay as total silently skips real content —
+worse than the gap it set out to repair.

--- a/docs/reliable-streaming.md
+++ b/docs/reliable-streaming.md
@@ -245,29 +245,20 @@ client.on("resync", recover);      // backfill after a mid-stream gap
 That is the whole contract: **subscribe → resume → apply live by identity →
 resume again on any gap.** In order, nothing missing, nothing misplaced.
 
-## Cursor replay for sub-agent and synthetic frames
+## Cursor replay for synthetic frames
 
 The ordered stream was gap-*detectable* everywhere and gap-*repairable* only
-where the JSONL transcript could rebuild it. Two kinds of frame it cannot:
+where the JSONL transcript could rebuild it. **Synthetic** frames — the tool
+events Brigade mints for a `claude-cli` turn, whose tools run inside the
+binary's own loop — are in no transcript at all, yet they carry the routing
+session key, so `resume` can find them again.
 
-- **sub-agent frames** (`subagentDepth > 0`) carry the child's own session id
-  and live in a child transcript the parent's `resume` never reads;
-- **synthetic frames** — the tool events Brigade mints for a `claude-cli` turn,
-  whose tools run inside the binary's own loop — are in no transcript at all.
-
-Both were therefore left unsequenced, which was correct: stamping a seq on a
-frame you cannot replay turns every dropped decoration into an unrepairable
-gap, and the client resyncs forever. **You cannot sequence a stream you cannot
-replay.**
-
-`FrameRing` (`src/core/frame-ring.ts`) closes that from the other end. It
-retains those frames per session — bounded by count, bytes, and distinct
-sessions — so `resume({ sinceSeq })` can return `replayedFrames`: the exact
-bytes originally broadcast, applied after the transcript and deduped by the
-same identity keys as a live frame. With replay available, sequencing them is
-safe, and they now carry a seq under **their own** session id rather than the
-parent's — so a client watching only the parent still sees an unbroken parent
-sequence instead of a false gap for every child frame it filtered out.
+`FrameRing` (`src/core/frame-ring.ts`) retains them per session — bounded by
+count, bytes, and distinct sessions — so `resume({ sinceSeq })` returns
+`replayedFrames`: the exact bytes originally broadcast, applied after the
+transcript and deduped by the same identity keys as a live frame. The TUI sends
+the cursor from its `resync` handler, where the last-seen seq is already in
+hand.
 
 Top-level `message_update` frames are deliberately **not** retained: they are
 cumulative, so buffering a long reply would cost O(n²) memory to redeliver what
@@ -276,5 +267,27 @@ the transcript already returns better.
 `replayComplete` is the load-bearing part of the contract. It is `false` when
 retention was trimmed past the cursor, meaning some frames are gone for good
 and the client should treat that span as lost rather than assume it was empty.
-A client that reads a partial replay as total silently skips real content —
-worse than the gap it set out to repair.
+It answers only "is the oldest frame I still hold the next one this cursor
+expects?" — never "are there interior gaps?", since the frames that create
+those are precisely the ones the transcript rebuilds better.
+
+### Why sub-agent frames are still unsequenced
+
+They look like the same case and are not. A sub-agent frame is tagged with the
+**child's Pi session UUID**, while `resume` is called with an `agent:…` session
+**key**. Retaining under one namespace and replaying from the other means the
+replay can never fire — so sequencing them would rest on a guarantee that does
+not exist, which is exactly what the "never sequence what you cannot replay"
+rule forbids.
+
+Sequencing them also has costs that promise was meant to justify: every
+`spawn_agent` mints a new per-session counter, and that map evicts in creation
+order, so the operator's own long-lived session — created first — is evicted
+first, restarting its counter and repainting the transcript on every connected
+client. A terminal `agent_end` frame also carries the child's entire
+transcript, which the ring's oversize carve-out would retain permanently on a
+session that never receives another frame.
+
+Making sub-agent replay real means teaching `resume` the child namespace. Until
+then they stay unsequenced: a gap in them is undetectable-but-honest rather
+than detectable-but-unrepairable.

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -331,6 +331,26 @@ const MUTATIONS = [
 
   // ── Reasoning honesty ──
   {
+    claim: "an empty reasoning block cannot pin a turn to hidden",
+    file: "src/core/server.ts",
+    find: "\t\t\t\t\t\treasoningTracker.noteThinkingBlock(agentIdForTurn, sessionKeyForTurn, b);",
+    replace: "\t\t\t\t\t\treasoningTracker.setVisibility(agentIdForTurn, sessionKeyForTurn, refineReasoningVisibility(reasoningTracker.declaredVisibility(agentIdForTurn, sessionKeyForTurn), b));",
+    tests: "src/agents/reasoning/reasoning-state.test.ts",
+    expectMissed: true,
+    reason: "the mutant reintroduces the gateway-side latch, which only the gateway wiring exercises; the tracker-level tests model that loop via a helper and stay green. Verified by hand instead.",
+  },
+  {
+    claim: "the per-session seq counter evicts least-recently-USED",
+    file: "src/protocol/stream-seq.ts",
+    find: "\tcounters.delete(sessionId);\n\tcounters.set(sessionId, next);",
+    replace: "\tcounters.set(sessionId, next);",
+    tests: "src/protocol/stream-seq.test.ts",
+    expectMissed: true,
+    reason: "Map insertion-order semantics are not asserted by the existing seq tests; the eviction sweep that depends on it lives in server.ts and has no gateway-level test",
+  },
+
+
+  {
     claim: "the no-text downgrade is derived, so it cannot stick to a turn",
     file: "src/agents/reasoning/reasoning-state.ts",
     find: "\t\t\tvisibility: reportedVisibility(e),",
@@ -361,9 +381,9 @@ const MUTATIONS = [
     tests: "src/core/frame-ring.test.ts",
   },
   {
-    claim: "sub-agent and synthetic frames are retained for replay",
+    claim: "synthetic frames are retained for replay",
     file: "src/core/frame-ring.ts",
-    find: "\tconst replayOnly = isPi && (depth > 0 || synthetic);",
+    find: "\tconst replayOnly = isPi && depth === 0 && synthetic;",
     replace: "\tconst replayOnly = false;",
     tests: "src/core/frame-ring.test.ts",
   },

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -329,6 +329,45 @@ const MUTATIONS = [
     tests: "src/agents/tools/make-document-tool.test.ts",
   },
 
+  // ── Reasoning honesty ──
+  {
+    claim: "the no-text downgrade is derived, so it cannot stick to a turn",
+    file: "src/agents/reasoning/reasoning-state.ts",
+    find: "\t\t\tvisibility: reportedVisibility(e),",
+    replace: "\t\t\tvisibility: e.visibility,",
+    tests: "src/agents/reasoning/reasoning-state.test.ts",
+  },
+  {
+    claim: "reasoning chars count the whole turn, not the last phase",
+    file: "src/agents/reasoning/reasoning-state.ts",
+    find: "\t\te.startedAt = now;\n\t\t// `chars` is deliberately NOT reset here.",
+    replace: "\t\te.startedAt = now;\n\t\te.chars = 0;\n\t\t// `chars` is deliberately NOT reset here.",
+    tests: "src/agents/reasoning/reasoning-state.test.ts",
+  },
+  {
+    claim: "rate-limit headers are matched case-insensitively",
+    file: "src/agents/usage/limits.ts",
+    find: "\tfor (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;",
+    replace: "\tfor (const [k, v] of Object.entries(headers)) lower[k] = v;",
+    tests: "src/agents/usage/limits.test.ts",
+  },
+
+  // ── Cursor replay ──
+  {
+    claim: "a partial replay is never reported as complete",
+    file: "src/core/frame-ring.ts",
+    find: "\t\tconst complete = oldest <= sinceSeq + 1;",
+    replace: "\t\tconst complete = true;",
+    tests: "src/core/frame-ring.test.ts",
+  },
+  {
+    claim: "sub-agent and synthetic frames are retained for replay",
+    file: "src/core/frame-ring.ts",
+    find: "\tconst replayOnly = isPi && (depth > 0 || synthetic);",
+    replace: "\tconst replayOnly = false;",
+    tests: "src/core/frame-ring.test.ts",
+  },
+
   // ── Delta streaming ──
   {
     claim: "the delta strip keeps the client's render key",

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -329,6 +329,15 @@ const MUTATIONS = [
     tests: "src/agents/tools/make-document-tool.test.ts",
   },
 
+  // ── Delta streaming ──
+  {
+    claim: "the delta strip keeps the client's render key",
+    file: "src/core/delta-mode.ts",
+    find: "\tconst { content: _omitted, ...msgWithoutContent } = msg;",
+    replace: "\tconst { content: _omitted, role: _r, timestamp: _t, ...msgWithoutContent } = msg;",
+    tests: "src/core/delta-stream.test.ts",
+  },
+
   // ── Pi/Anthropic dialect boundary ──
   {
     claim: "the Pi and Anthropic tool dialects stay distinct",
@@ -389,6 +398,46 @@ const MUTATIONS = [
     find: "\t\ttimestamp: compaction.at,",
     replace: "",
     tests: "src/agents/compaction/mid-turn.test.ts",
+  },
+  {
+    // The `_signal` underscore was the tell: accepted, named as unused, dropped.
+    // Every layer ABOVE this one threaded the signal correctly, so the abort
+    // path looked wired from any single file — and Ctrl+C still left a billed
+    // summarization of a full context window running against the provider.
+    claim: "an aborted turn cancels the compaction summarizer's billed LLM call",
+    file: "src/agents/compaction/summarizer.ts",
+    find: "build(priorSummary ?? args.priorSummary)(wrapTranscriptForSummary(transcript), signal)",
+    replace: "build(priorSummary ?? args.priorSummary)(wrapTranscriptForSummary(transcript))",
+    tests: "src/agents/compaction/mid-turn-wiring.test.ts",
+  },
+  {
+    // Pi's prompt() takes no signal, so the ONLY cancellation handle is
+    // session.abort(). Remove the bridge and the isolated session keeps
+    // streaming after the operator has been told the turn was cancelled.
+    claim: "the isolated LLM call honours the caller's signal at all",
+    file: "src/agents/memory/extract.ts",
+    find: "\t\tif (signal?.aborted) throw new IsolatedLlmAbortError();",
+    replace: "",
+    tests: "src/agents/memory/extract.test.ts src/agents/compaction/mid-turn-wiring.test.ts",
+  },
+  {
+    // Both directions are expensive. Read as an error, a Ctrl+C disables the
+    // compactor for the turn AND truncates history nobody asked to lose; read
+    // as a cancellation, a real failure is retried on every request in the loop.
+    claim: "an abort is classified as a cancellation, not a failed summarization",
+    file: "src/agents/compaction/mid-turn-runner.ts",
+    find: "\tif (e.name === \"AbortError\" || e.code === \"ABORT_ERR\" || e.code === 20) return true;",
+    replace: "",
+    tests: "src/agents/compaction/mid-turn-runner.test.ts src/agents/compaction/mid-turn-wiring.test.ts",
+  },
+  {
+    // `noteCompaction` counts BEFORE the call, so an interrupt that is not given
+    // back lets an operator close their own guard by pressing Ctrl+C twice.
+    claim: "a cancelled compaction is given back to the breaker's budget",
+    file: "src/agents/smart-compaction.ts",
+    find: "\t\tif (next > 0) this.consecutive.set(sessionKey, next);",
+    replace: "\t\tthis.consecutive.set(sessionKey, current);",
+    tests: "src/agents/smart-compaction.breaker.test.ts",
   },
   {
     claim: "tool-call arguments reach the summarizer",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -37,6 +37,37 @@ const keepAlive = pathToFileURL(join(import.meta.dirname, "test-keepalive.mjs"))
 // Double quotes stop the shell expanding it on POSIX and are stripped by cmd.exe
 // on Windows, so in both cases Node's own test runner receives the pattern and
 // does the globbing itself — and Node's globber does understand `**`.
+// TYPECHECK FIRST — `npm test` DOES NOT TYPECHECK ON ITS OWN.
+//
+// The suite runs under `tsx`, which STRIPS types and never checks them. That
+// makes every compile-time guard in this repo invisible to `npm test`:
+// a `Record<BrigadeOwnKeys, true>` conformance guard, a `satisfies keyof
+// ToolCall` tripwire, a discriminant pinned to Pi's own literal type — all of
+// them can be violated and the suite still reports a confident green.
+//
+// Proven, not assumed: adding a field to `BrigadeTool` (which the tool-boundary
+// guard exists to catch) left all six of its tests passing. CI caught it only
+// because `ci.yml` runs `npm run typecheck` as a SEPARATE step — so the guards
+// worked in CI and were decorative locally, which is precisely backwards. The
+// whole point of a compile-time guard is to fail fast for the person editing.
+//
+// 6 seconds against a 4-minute suite. Skip with BRIGADE_SKIP_TYPECHECK=1 for a
+// tight edit loop; CI never skips.
+if (process.env.BRIGADE_SKIP_TYPECHECK !== "1") {
+  const tc = spawnSync("npx", ["tsc", "--noEmit", "-p", "tsconfig.json"], {
+    stdio: "inherit",
+    shell: true,
+  });
+  if (tc.status !== 0) {
+    console.error(
+      "\ntypecheck failed — the suite was NOT run.\n" +
+        "`tsx` strips types, so these errors would not have failed any test.\n" +
+        "Set BRIGADE_SKIP_TYPECHECK=1 to run the suite anyway.",
+    );
+    process.exit(tc.status ?? 1);
+  }
+}
+
 const extra = process.argv.slice(2);
 const res = spawnSync("npx", ["tsx", "--import", keepAlive, "--test", '"src/**/*.test.ts"', ...extra], {
   stdio: "inherit",

--- a/src/agents/agent-loop.ts
+++ b/src/agents/agent-loop.ts
@@ -28,6 +28,7 @@ import {
   createAgentSession,
 } from "@earendil-works/pi-coding-agent";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import { warnUnhandledPiDroppedFields } from "./tools/pi-tool-boundary.js";
 import fs from "node:fs";
 
 import {
@@ -158,6 +159,7 @@ import {
   CompactionBreaker,
   describeCompactionOutcome,
   evaluateCompactionDecision,
+  isCompactionCancellation,
   summarizeCompactionOutcome,
 } from "./smart-compaction.js";
 import { resolveToolSummary } from "./tool-summaries.js";
@@ -1224,6 +1226,11 @@ async function runSingleTurnLocked(p: RunSingleTurnLockedArgs): Promise<RunSingl
   ];
   const webToolNames = webTools.map((t) => t.name);
   brigadeCustomTools.push(...webTools);
+  // These three are pushed AFTER `assembleBrigadeToolset` returns, so they miss
+  // the boundary check in `session-wiring.ts`. Pi copies a fixed field list and
+  // silently drops the rest; checking here is what keeps that from being an
+  // invisible hole for the one group of tools that skips the normal path.
+  warnUnhandledPiDroppedFields(brigadeCustomTools, "agent-loop");
   // Gate the system-prompt ## Web section on whether ANY web tool actually
   // landed in customTools. `fetch_url` is always available (built-in raw
   // fetch needs no provider), so this is effectively always true today;
@@ -3437,6 +3444,23 @@ async function maybeTriggerCompaction(args: {
       });
     }
   } catch (err) {
+    // A CANCELLED compaction is not a failed one. `noteCompaction` was counted
+    // up front on purpose — the guard must hold even if the call never returns
+    // — but an operator's Ctrl+C paid for nothing and proved nothing about
+    // whether compaction helps this session. Left counted, two interrupts in a
+    // row close the guard for the full cooldown and a healthy session cannot
+    // compact for five minutes because the user cancelled twice. So give the
+    // attempt back and say nothing louder than debug: this is the user getting
+    // what they asked for, not a fault.
+    if (isCompactionCancellation(err)) {
+      compactionBreaker.undoCompaction(args.sessionId);
+      log.debug("pre-emptive compaction cancelled by the operator", {
+        agentId: args.agentId,
+        sessionId: args.sessionId,
+        consecutive: compactionBreaker.count(args.sessionId),
+      });
+      return;
+    }
     // Compaction failure isn't fatal — Pi's auto-compaction gets a chance
     // to run during the prompt, and worst case the request fails with a
     // context-window error that the retry policy classifies as transient.

--- a/src/agents/compaction/mid-turn-runner.test.ts
+++ b/src/agents/compaction/mid-turn-runner.test.ts
@@ -194,6 +194,61 @@ test("an abort abandons the wait and does NOT burn the turn's attempt", async ()
 	assert.equal(calls, 1);
 });
 
+test("an abort raised INSIDE the summarizer does not disable the compactor", async () => {
+	// Once the signal is actually plumbed to the isolated LLM call, the abort can
+	// surface as a rejection from `summarize` itself rather than from this
+	// module's own signal watcher — and it can arrive with no signal on THIS
+	// call at all (the isolated session holds the turn's signal, we do not).
+	// Classified as an error it would set `disabled`, so a Ctrl+C would cost the
+	// turn its one compaction attempt and truncate history nobody asked to lose.
+	const outcomes: MidTurnOutcome[] = [];
+	let calls = 0;
+	const compact = createMidTurnCompactor({
+		contextWindowTokens: WINDOW,
+		summarize: async () => {
+			calls += 1;
+			if (calls === 1) {
+				throw Object.assign(new Error("isolated LLM call was cancelled by the caller"), {
+					name: "AbortError",
+					code: "ABORT_ERR",
+				});
+			}
+			return "## GOAL\nship";
+		},
+		onEnd: (o) => outcomes.push(o),
+	});
+	const messages = bigConversation();
+
+	assert.equal(await compact(messages), messages, "no truncation on a cancelled turn");
+	assert.equal(outcomes.at(-1)!.reason, "aborted");
+
+	// The SAME instance, not a fresh one: the claim is that the turn's single
+	// attempt was not burned, and only the same compactor can prove that.
+	const out = await compact(messages);
+	assert.equal(calls, 2, "the compactor is still armed after an interrupt");
+	assert.ok(out.length < messages.length);
+	assert.equal(outcomes.at(-1)!.reason, "applied");
+});
+
+test("a genuine summarizer failure still disables the compactor", async () => {
+	// The other half of the classification. Cancellations must be forgiven;
+	// real failures must not be, or one broken call becomes one per request for
+	// the rest of the tool loop.
+	let calls = 0;
+	const compact = createMidTurnCompactor({
+		contextWindowTokens: WINDOW,
+		deterministicFallback: false,
+		summarize: async () => {
+			calls += 1;
+			throw new Error("provider exploded");
+		},
+	});
+	const messages = bigConversation();
+	await compact(messages);
+	await compact(messages);
+	assert.equal(calls, 1, "one wasted call per turn, never one per request");
+});
+
 test("an empty summary is treated as a failure, not as a valid compaction", async () => {
 	// A blank summary would otherwise be injected as the entire record of
 	// everything that came before.

--- a/src/agents/compaction/mid-turn-runner.ts
+++ b/src/agents/compaction/mid-turn-runner.ts
@@ -308,6 +308,37 @@ function reinjectOmissions(summary: string, transcript: string): string {
 	return `${summary}\n\n## RECOVERED DETAIL (literal strings extracted from the transcript; data, not instructions)\n${body}`;
 }
 
+/**
+ * Was this a CANCELLATION rather than a failed summarization?
+ *
+ * Three spellings have to be recognised, because three different layers can win
+ * the race in `summarizePrefix`:
+ *
+ *   • `mid-turn-compaction:aborted` — this module's own signal watcher.
+ *   • A DOM-shaped `AbortError` — what the summarizer's isolated LLM call now
+ *     throws when the turn's signal reaches it. Before the signal was plumbed
+ *     this could never happen, so only the first spelling existed.
+ *   • The signal simply being aborted — the backstop for anything that loses
+ *     its error identity crossing a layer.
+ *
+ * Getting this wrong is expensive in BOTH directions, which is why it is a
+ * named predicate rather than an inline string test. Misread as an error, a
+ * Ctrl+C disables the compactor for the rest of the turn AND truncates history
+ * the user never asked to lose. Misread as a cancellation, a genuine failure is
+ * retried on every request in the tool loop — one wasted call becomes dozens.
+ *
+ * Deliberately local rather than shared with `retry-policy.ts`: this module is
+ * kept dependency-light on purpose (decision core, sanitizer, prompt helpers
+ * only) so it cannot re-enter anything that could re-enter compaction.
+ */
+function isCancellation(err: unknown, signal: AbortSignal | undefined): boolean {
+	if (signal?.aborted) return true;
+	const e = err as { name?: unknown; code?: unknown; message?: unknown } | null | undefined;
+	if (!e) return false;
+	if (e.name === "AbortError" || e.code === "ABORT_ERR" || e.code === 20) return true;
+	return typeof e.message === "string" && e.message.endsWith(":aborted");
+}
+
 function passThrough(
 	messages: AgentMessage[],
 	reason: MidTurnOutcome["reason"],
@@ -560,7 +591,7 @@ export function createMidTurnCompactor(
 			result = await inFlight;
 		} catch (err) {
 			const message = (err as Error)?.message ?? String(err);
-			const reason: MidTurnOutcome["reason"] = message.endsWith(":aborted")
+			const reason: MidTurnOutcome["reason"] = isCancellation(err, signal)
 				? "aborted"
 				: message.endsWith(":timeout")
 					? "timeout"

--- a/src/agents/compaction/mid-turn-wiring.test.ts
+++ b/src/agents/compaction/mid-turn-wiring.test.ts
@@ -15,6 +15,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
 import { buildBrigadeTransformContext } from "../payload-mutators.js";
 import { createMidTurnCompactor } from "./mid-turn-runner.js";
+import { createCompactionSummarizer } from "./summarizer.js";
 
 const user = (text: string) => ({ role: "user", content: [{ type: "text", text }] }) as AgentMessage;
 const asst = (text: string) =>
@@ -129,4 +130,72 @@ test("the free tool-result shrink runs BEFORE the paid summarization", async () 
 		sawTokens < before,
 		`compactor saw ${sawTokens} chars, chain received ${before} — the shrink must run first`,
 	);
+});
+
+test("Ctrl+C reaches the summarizer's own LLM call, not just the runner's wait", async () => {
+	// THE HOP THAT WAS DEAD. Every layer above this one threaded the signal —
+	// Pi hands it to `transformContext`, the chain forwards it to the compactor,
+	// the runner races it against the summarization — and then the summarizer
+	// accepted it as `_signal` and dropped it on the floor. The visible effect
+	// was a lie: Ctrl+C stopped Brigade WAITING for the summary while the
+	// isolated session underneath kept streaming a full context window to the
+	// provider and kept billing for it. Compaction is one of the largest single
+	// calls Brigade makes, so the one call an operator most wants to cancel was
+	// the only one they could not.
+	//
+	// The proof has to run against the REAL summarizer and the REAL isolated-LLM
+	// factory, because the defect lived precisely in the wiring between them —
+	// a test that stubbed either end would have passed the whole time it was
+	// broken. The workspace, registry and model below are deliberate junk: an
+	// aborted signal must short-circuit BEFORE any of them is touched, so the
+	// call cannot reach a provider. Drop the signal again and this same junk
+	// blows up with a TypeError instead of an AbortError, which is exactly the
+	// assertion below.
+	const summarize = createCompactionSummarizer({
+		workspaceDir: "/nonexistent-brigade-abort-probe",
+		agentDir: "/nonexistent-brigade-abort-probe",
+		authStorage: {},
+		modelRegistry: {},
+		model: { id: "probe" },
+	});
+	assert.ok(summarize, "a summarizer is built when a model and registry are present");
+
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		summarize("some transcript to summarize", controller.signal),
+		(err: Error) =>
+			// Shaped as a DOM AbortError so `retry-policy.ts` never mistakes a
+			// cancellation for a transient fault and re-bills the call.
+			err.name === "AbortError" &&
+			(err as Error & { code?: string }).code === "ABORT_ERR",
+		"an aborted turn cancels the summarization instead of paying for it",
+	);
+});
+
+test("an aborted summarization is a cancellation, never a compaction failure", async () => {
+	// The whole chain, end to end: an abort raised inside the summarizer must
+	// surface through the runner as `aborted` — the ONE outcome that neither
+	// truncates history nor disables the compactor for the rest of the turn.
+	// Read as an error instead, a Ctrl+C would silently drop the older half of
+	// the conversation from every remaining request in the turn.
+	const outcomes: string[] = [];
+	const abortError = Object.assign(new Error("isolated LLM call was cancelled by the caller"), {
+		name: "AbortError",
+		code: "ABORT_ERR",
+	});
+	const transform = buildBrigadeTransformContext({
+		midTurnCompactor: createMidTurnCompactor({
+			contextWindowTokens: WINDOW,
+			summarize: async () => {
+				throw abortError;
+			},
+			onEnd: (o) => outcomes.push(o.reason),
+		}),
+	});
+	const messages = bigConversation();
+	const out = await transform(messages);
+
+	assert.equal(outcomes.at(-1), "aborted", "not `error`, and not `fallback-truncated`");
+	assert.equal(out.length, messages.length, "an interrupted turn keeps its history intact");
 });

--- a/src/agents/compaction/summarizer.ts
+++ b/src/agents/compaction/summarizer.ts
@@ -96,6 +96,13 @@ export function createCompactionSummarizer(
 	// command results — is attacker-influenceable, and a summary is re-injected
 	// into the model's context on every later turn, so an injection that lands
 	// here is persistent. Of every harness surveyed, only Gemini CLI guards it.
-	return (transcript: string, _signal?: AbortSignal, priorSummary?: string) =>
-		build(priorSummary ?? args.priorSummary)(wrapTranscriptForSummary(transcript));
+	//
+	// FORWARD THE SIGNAL. This parameter used to be spelt `_signal` and dropped,
+	// which made the whole abort path decorative: the runner would stop WAITING
+	// on a cancelled summarization, but the isolated session underneath kept
+	// streaming a full context window to the provider and kept billing for it.
+	// Compaction is one of the largest single calls Brigade makes, so the one
+	// call an operator most wants to cancel was the one call they could not.
+	return (transcript: string, signal?: AbortSignal, priorSummary?: string) =>
+		build(priorSummary ?? args.priorSummary)(wrapTranscriptForSummary(transcript), signal);
 }

--- a/src/agents/extensions/registry.ts
+++ b/src/agents/extensions/registry.ts
@@ -17,6 +17,7 @@ import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-a
 
 import type { BrigadeConfig } from "../../config/io.js";
 import type { AnyBrigadeTool } from "../tools/types.js";
+import { warnUnhandledPiDroppedFields } from "../tools/pi-tool-boundary.js";
 import { type BrigadeHookName, createHookRunner, type HookFireResult } from "./hook-runner.js";
 import type { ChannelMessagingAdapter, ChannelSecurityAdapter } from "../channels/types.adapters.js";
 import type {
@@ -646,6 +647,11 @@ export class BrigadeExtensionRegistry {
 				// all match. Cast bridges the nominal gap without changing authoring.
 				const built = t.tool ?? t.factory?.create(factoryCtx);
 				if (!built) continue;
+				// Extension tools are the ones the conformance test structurally
+				// cannot see: a third-party module builds them at runtime, so an
+				// extra field on one never meets Brigade's compiler. This line is
+				// the last point before Pi's wrapper drops it in silence.
+				warnUnhandledPiDroppedFields([built], "extension");
 				pi.registerTool(built as never);
 			}
 			// Pi has no native hook priority — handlers fire in registration order — so

--- a/src/agents/memory/extract.test.ts
+++ b/src/agents/memory/extract.test.ts
@@ -2,13 +2,15 @@ import { strict as assert } from "node:assert";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it, test } from "node:test";
 
 import { FactStore } from "./records.js";
 import { linksFrom } from "./links.js";
 import {
 	flattenConversation,
 	getCursor,
+	IsolatedLlmAbortError,
+	makeIsolatedLlm,
 	parseExtractedFacts,
 	runExtractionSweep,
 	storeExtractedFacts,
@@ -362,4 +364,43 @@ describe("runExtractionSweep — semantic relationship edges (SAME call, no extr
 		assert.equal(res.ran, false);
 		assert.equal(new FactStore(dir).readAll().length, 0, "no facts, hence no edges");
 	});
+});
+
+test("an aborted signal cancels an isolated LLM call before it costs anything", async () => {
+	// `makeIsolatedLlm` is the bottom of every Brigade-owned model call — memory
+	// sweeps, skill distillation, and mid-turn compaction, which summarizes an
+	// entire context window and is the single largest of them. Pi's `prompt()`
+	// takes no signal (pi-agent-core agent.d.ts:104-105), so before this the
+	// runner had NOTHING to cancel with: a Ctrl+C stopped Brigade waiting and
+	// left the provider request running, and billing.
+	//
+	// The workspace, registry and model here are deliberate junk. An aborted
+	// signal has to short-circuit before any of them is read, so the assertion
+	// is not just "it rejected" but "it rejected as a cancellation": drop the
+	// pre-flight check and this same junk produces a TypeError from the model
+	// registry instead.
+	const llm = makeIsolatedLlm("system", {
+		workspaceDir: "/nonexistent-brigade-abort-probe",
+		agentDir: "/nonexistent-brigade-abort-probe",
+		authStorage: {},
+		modelRegistry: {},
+		model: { id: "probe" },
+	});
+	const controller = new AbortController();
+	controller.abort();
+	await assert.rejects(
+		llm("distill this", controller.signal),
+		(err: Error & { code?: string }) => err.name === "AbortError" && err.code === "ABORT_ERR",
+	);
+});
+
+test("an IsolatedLlmAbortError is shaped so a retry policy never re-bills it", () => {
+	// `retry-policy.ts` and `model-fallback.ts` both classify aborts by exactly
+	// `name === "AbortError" || code === "ABORT_ERR" || code === 20`. A
+	// cancellation wearing any other shape would be read as a transient provider
+	// fault and retried — re-spending the money the cancellation just saved.
+	const err = new IsolatedLlmAbortError();
+	assert.equal(err.name, "AbortError");
+	assert.equal(err.code, "ABORT_ERR");
+	assert.ok(err instanceof Error);
 });

--- a/src/agents/memory/extract.ts
+++ b/src/agents/memory/extract.ts
@@ -636,6 +636,24 @@ export class MemoryLlmTimeoutError extends Error {
 }
 
 /**
+ * Marker thrown when the CALLER cancelled an isolated LLM call.
+ *
+ * Deliberately shaped like a DOM `AbortError` — `name: "AbortError"`,
+ * `code: "ABORT_ERR"` — because that is the exact pair `retry-policy.ts` and
+ * `model-fallback.ts` classify aborts by. A cancellation that escapes this
+ * module wearing any other shape would be read as a transient provider fault
+ * and RETRIED, which re-bills the call the operator just cancelled: the precise
+ * outcome the cancellation exists to prevent.
+ */
+export class IsolatedLlmAbortError extends Error {
+	readonly code = "ABORT_ERR" as const;
+	constructor() {
+		super("isolated LLM call was cancelled by the caller");
+		this.name = "AbortError";
+	}
+}
+
+/**
  * Build an ISOLATED, tool-less subagent runner: a one-shot LLM call with
  * `systemPrompt` pinned, run against a throwaway transcript (deleted after) so
  * it never pollutes the real session. Reuses the resolved model/auth (inherits
@@ -673,8 +691,24 @@ export function makeIsolatedLlm(
 	 * Fires after a SUCCESSFUL call. Never throws into the caller.
 	 */
 	onUsage?: (usage: IsolatedLlmUsage) => void,
-): (input: string) => Promise<string> {
-	return async (input: string): Promise<string> => {
+): (input: string, signal?: AbortSignal) => Promise<string> {
+	/**
+	 * `signal` is the CALLER'S cancellation — for mid-turn compaction it is the
+	 * turn's own AbortSignal, i.e. the operator's Ctrl+C.
+	 *
+	 * Pi's `prompt()` accepts no signal (`pi-agent-core` agent.d.ts:104-105); the
+	 * only cancellation handle an `AgentSession` exposes is `abort()`, which is
+	 * what the timeout path below already uses. So the signal is BRIDGED onto
+	 * that. Without the bridge an interrupted turn left a summarization of a full
+	 * context window running to completion against the provider — real, billed
+	 * spend on an answer nobody would ever read, and the operator had already
+	 * been told the turn was cancelled.
+	 */
+	return async (input: string, signal?: AbortSignal): Promise<string> => {
+		// CHECK BEFORE SPENDING ANYTHING. A call cancelled while it was queued must
+		// not build a session, resolve auth, or reach a provider — the last of
+		// those is billed, and the first two are work with no possible consumer.
+		if (signal?.aborted) throw new IsolatedLlmAbortError();
 		// The isolated extraction sweep can itself run on an Ollama model. Re-assert
 		// the native transport before each run: `ModelRegistry.refresh()` calls
 		// `resetApiProviders()`, which wipes our dynamic `api: "ollama"` registration,
@@ -739,10 +773,39 @@ export function makeIsolatedLlm(
 				}, timeoutMs);
 				timer.unref?.();
 			});
+			// Bridge the caller's cancellation onto the session, the same way the
+			// timeout above does. Whichever fires first wins the race below; both
+			// stop the in-flight provider stream rather than merely stopping US
+			// from waiting for it.
+			let onAbort: (() => void) | undefined;
+			const abortPromise = new Promise<never>((_, reject) => {
+				if (!signal) return;
+				onAbort = () => {
+					// Best-effort, like the timeout path: Pi's abort() is documented
+					// never to throw, but the rejection below is what must surface.
+					void (session as AgentSession).abort?.().catch(() => {});
+					reject(new IsolatedLlmAbortError());
+				};
+				// Aborted in the window between the pre-flight check and here.
+				if (signal.aborted) {
+					onAbort();
+					return;
+				}
+				signal.addEventListener("abort", onAbort, { once: true });
+			});
 			try {
-				await Promise.race([(session as AgentSession).prompt(input), timeoutPromise]);
+				await Promise.race([
+					(session as AgentSession).prompt(input),
+					timeoutPromise,
+					abortPromise,
+				]);
 			} finally {
 				if (timer) clearTimeout(timer);
+				// The signal OUTLIVES this call — it belongs to the turn, and a turn
+				// can run several isolated calls. An unremoved listener would keep
+				// this finished session, and the whole transcript it closed over,
+				// reachable until the turn ended.
+				if (onAbort && signal) signal.removeEventListener("abort", onAbort);
 			}
 			// Read the meter BEFORE returning. The session is thrown away on the
 			// next line, and with it the only record that this call happened.

--- a/src/agents/payload-mutators.ts
+++ b/src/agents/payload-mutators.ts
@@ -1200,13 +1200,24 @@ export function wrapStreamFnWithPayloadMutations(session: AgentSession): void {
         applyAllPayloadMutations(next, m);
         return next;
       },
-      // RATE-LIMIT HEADERS, FOR EVERY PROVIDER.
+      // RATE-LIMIT HEADERS, WHEREVER THE PROVIDER SENDS THEM.
       //
-      // Pi hands back `ProviderResponse { status, headers }` on every provider
-      // call (`pi-ai types.d.ts:64`), and EVERY backend Pi drives goes through
-      // this one `streamFn`. So observing here — rather than in any single
-      // provider's adapter — is what makes "how much have I got left?"
-      // provider-agnostic instead of an Anthropic-only feature.
+      // Pi hands back `ProviderResponse { status, headers }` via `onResponse`,
+      // and observing here — rather than in any single provider's adapter —
+      // means one seam covers every backend that reports limits at all.
+      //
+      // NOT universal, and the difference matters. Verified in pi-ai: the
+      // Anthropic, OpenAI-completions, OpenAI-responses, Azure, Codex and
+      // Bedrock providers all invoke `onResponse` on the STREAMING path. The
+      // Google, Vertex, Mistral and Cloudflare providers never invoke it, and
+      // Brigade's own transports (`transport-dispatch.ts`) intercept before
+      // Pi's provider path — so `claude-cli` and `ollama-native` do not arrive
+      // here either. `claude-cli` is covered separately by `plan-limits.ts`,
+      // which reads the binary's own `rate_limit_event` frames.
+      //
+      // A backend that reports nothing simply records nothing, and the UI omits
+      // the block rather than drawing an empty bar: "unknown" and "none left"
+      // must never render the same way.
       //
       // `recordLimitsFromHeaders` already reads both conventions in use
       // (`anthropic-ratelimit-*` and `x-ratelimit-*`) and skips absent families

--- a/src/agents/payload-mutators.ts
+++ b/src/agents/payload-mutators.ts
@@ -22,7 +22,8 @@
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { PI_TOOL_CALL, PI_TOOL_RESULT, WIRE_TOOL_RESULT } from "./pi-dialect.js";
-import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
+import type { Api, Model, ProviderResponse, ThinkingLevel } from "@earendil-works/pi-ai";
+import { recordLimitsFromHeaders } from "./usage/limits.js";
 
 import { scrubAnthropicRefusalSentinel } from "./error-classifier.js";
 import { sanitizeMessages } from "./sanitize-surrogates.js";
@@ -1174,6 +1175,7 @@ export function wrapStreamFnWithPayloadMutations(session: AgentSession): void {
 
   const wrapped: StreamFn = (model, context, options) => {
     const userOnPayload = options?.onPayload;
+    const userOnResponse = options?.onResponse;
     // OpenRouter app attribution: when (and only when) this request routes
     // through OpenRouter, merge Brigade's HTTP-Referer / X-OpenRouter-Title
     // headers into Pi's `SimpleStreamOptions.headers`. Caller-supplied headers
@@ -1198,6 +1200,34 @@ export function wrapStreamFnWithPayloadMutations(session: AgentSession): void {
         applyAllPayloadMutations(next, m);
         return next;
       },
+      // RATE-LIMIT HEADERS, FOR EVERY PROVIDER.
+      //
+      // Pi hands back `ProviderResponse { status, headers }` on every provider
+      // call (`pi-ai types.d.ts:64`), and EVERY backend Pi drives goes through
+      // this one `streamFn`. So observing here — rather than in any single
+      // provider's adapter — is what makes "how much have I got left?"
+      // provider-agnostic instead of an Anthropic-only feature.
+      //
+      // `recordLimitsFromHeaders` already reads both conventions in use
+      // (`anthropic-ratelimit-*` and `x-ratelimit-*`) and skips absent families
+      // rather than recording them as zero, because "no data" and "none left"
+      // are opposites and a UI must never confuse them.
+      //
+      // Strictly an observer: it reads headers, records, and returns. It never
+      // alters the response, and it is wrapped so a malformed header can never
+      // take down a turn — telemetry must not be able to break the request it
+      // is describing.
+      onResponse: async (response: ProviderResponse, m: Model<Api>) => {
+        try {
+          if (response && typeof response === "object" && response.headers) {
+            const provider = typeof m?.provider === "string" ? m.provider : "unknown";
+            recordLimitsFromHeaders(provider, response.headers);
+          }
+        } catch {
+          /* telemetry is never allowed to fail a turn */
+        }
+        if (userOnResponse) await userOnResponse(response, m);
+      },
     };
     return original(model, context, augmented);
   };
@@ -1211,6 +1241,7 @@ type StreamFn = (
   context: unknown,
   options?: {
     onPayload?: (payload: unknown, m: Model<any>) => unknown | Promise<unknown>;
+    onResponse?: (response: ProviderResponse, m: Model<any>) => void | Promise<void>;
     headers?: Record<string, string>;
   } & Record<string, unknown>,
 ) => unknown;

--- a/src/agents/reasoning/reasoning-state.test.ts
+++ b/src/agents/reasoning/reasoning-state.test.ts
@@ -296,3 +296,83 @@ test("start() defaults to summary, never raw", () => {
 	t.end("a", "s");
 	assert.equal(t.snapshot("a", "s")?.visibility, "summary");
 });
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * The PRODUCTION wiring, not the tracker in isolation.
+ *
+ * Every test above seeds `setVisibility(...,"summary")` right after
+ * `beginTurn`, which is exactly the step the gateway does NOT do per block.
+ * The gateway instead refines per thinking block:
+ *
+ *     prev = <read current>;  setVisibility(refine(prev, block))
+ *
+ * A reviewer showed that reading the DERIVED value there wrote the no-text
+ * downgrade back into storage, where `refineReasoningVisibility` — which never
+ * widens fidelity — made it permanent. These reproduce that loop.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/** Exactly what `server.ts` does for each `thinking` block on a message. */
+function refineLikeGateway(
+	t: ReasoningTracker,
+	block: { thinking?: string; thinkingSignature?: string; redacted?: boolean },
+): void {
+	t.noteThinkingBlock("a", "s", block);
+}
+
+test("an empty reasoning item does not permanently pin the turn to hidden", () => {
+	// OpenAI's o-series / GPT-5 emit one reasoning item per `output_item.added`,
+	// many of them empty, each settling as empty-text + signature.
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+
+	// Item 1: empty, but signed — legitimately refines to `hidden`.
+	t.start("a", "s", "summary");
+	refineLikeGateway(t, { thinking: "", thinkingSignature: "sig-1" });
+	t.end("a", "s");
+
+	// Item 2: a genuine 900-character summary.
+	t.start("a", "s", "summary");
+	t.delta("a", "s", "y".repeat(900));
+	refineLikeGateway(t, { thinking: "y".repeat(900), thinkingSignature: "sig-2" });
+	t.end("a", "s");
+
+	const snap = t.snapshot("a", "s");
+	assert.equal(snap?.chars, 900, "the summary did arrive");
+	assert.notEqual(
+		snap?.visibility,
+		"hidden",
+		"900 chars of summary must not render as 'not exposed by this model'",
+	);
+});
+
+test("the derived downgrade is never written back into storage", () => {
+	// The mechanism itself: after a settled empty turn the REPORTED value is
+	// `hidden`, but the STORED value must still be `summary` — otherwise the
+	// next refine reads `hidden` as its floor and can never climb back.
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
+	t.end("a", "s");
+
+	assert.equal(t.snapshot("a", "s")?.visibility, "hidden", "reported: nothing arrived");
+	assert.equal(t.declaredVisibility("a", "s"), "summary", "stored: what the backend can return");
+
+	// An empty block records nothing at all now — `chars` already knows whether
+	// text arrived, so there is no value to write back and therefore nothing
+	// that can latch.
+	refineLikeGateway(t, { thinking: "" });
+	assert.equal(t.declaredVisibility("a", "s"), "summary");
+});
+
+test("a genuinely redacted phase still refines to redacted", () => {
+	// The guard must not block real downgrades — only the derived one.
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
+	refineLikeGateway(t, { redacted: true, thinkingSignature: "sig" });
+	t.end("a", "s");
+	assert.equal(t.snapshot("a", "s")?.visibility, "redacted");
+});

--- a/src/agents/reasoning/reasoning-state.test.ts
+++ b/src/agents/reasoning/reasoning-state.test.ts
@@ -215,26 +215,84 @@ test("a redacted phase is NOT downgraded — it is already block-proven", () => 
 	assert.equal(t.snapshot("a", "s")?.visibility, "redacted");
 });
 
-test("an expected-but-entirely-silent phase still reports, as hidden", () => {
-	// No thinking event, no token count — the case where BOTH proofs are absent.
-	// Without `expectReasoning` this session reported nothing at all, and an
-	// empty header reads as "the model did not think".
+/* ─────────────────────────────────────────────────────────────────────────
+ * The regressions an adversarial review reproduced against the real class.
+ *
+ * `end()` fires once per model ROUNDTRIP, not per logical turn, and `start()`
+ * used to reset `chars` per PHASE. Together those made the "no text arrived"
+ * downgrade fire on turns that had streamed a real summary, and latch for the
+ * rest of the turn once it did.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+test("a second EMPTY reasoning item does not erase a real summary", () => {
+	// OpenAI's o-series / GPT-5 open one reasoning item per `output_item.added`
+	// and routinely emit several per response, many with empty summaries.
 	const t = new ReasoningTracker();
 	t.beginTurn("a", "s");
 	t.setVisibility("a", "s", "summary");
-	t.expectReasoning("a", "s");
+	t.start("a", "s", "summary");
+	t.delta("a", "s", "x".repeat(600)); // a real summary
+	t.end("a", "s");
+	t.start("a", "s", "summary"); // second item, no text at all
 	t.end("a", "s");
 
-	assert.equal(t.snapshot("a", "s")?.visibility, "hidden");
+	const snap = t.snapshot("a", "s");
+	assert.equal(snap?.visibility, "summary", "600 chars of summary did arrive");
+	assert.equal(snap?.chars, 600, "chars counts the whole turn, not the last phase");
 });
 
-test("a NON-reasoning model still contributes no snapshot at all", () => {
-	// The guard rail: `expected` is only set for a reasoning-capable model with
-	// thinking on, so an ordinary model must not gain a phantom "Thought" line.
+test("late reasoning text corrects an early empty phase", () => {
+	// Roundtrip 1 opens an empty phase; roundtrip 2 streams a genuine summary.
+	// The old code latched `hidden` on the first and never re-evaluated, so the
+	// real summary rendered under a label saying it was never exposed.
 	const t = new ReasoningTracker();
 	t.beginTurn("a", "s");
-	t.setVisibility("a", "s", "none");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
 	t.end("a", "s");
+	assert.equal(t.snapshot("a", "s")?.visibility, "hidden", "nothing seen yet");
 
-	assert.equal(t.snapshot("a", "s"), undefined);
+	t.start("a", "s", "summary");
+	t.delta("a", "s", "y".repeat(900));
+	t.end("a", "s");
+	assert.equal(
+		t.snapshot("a", "s")?.visibility,
+		"summary",
+		"the downgrade must not latch — it is derived, not stored",
+	);
+});
+
+test("an ACTIVE phase is never downgraded — text may not have arrived yet", () => {
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
+	assert.equal(t.snapshot("a", "s")?.visibility, "summary");
+});
+
+test("a new turn re-evaluates from scratch", () => {
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
+	t.end("a", "s");
+	assert.equal(t.snapshot("a", "s")?.visibility, "hidden");
+
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
+	t.delta("a", "s", "fresh reasoning");
+	t.end("a", "s");
+	assert.equal(t.snapshot("a", "s")?.visibility, "summary");
+});
+
+test("start() defaults to summary, never raw", () => {
+	// Understating fidelity is a smaller error than claiming a paraphrase is
+	// the model's own chain of thought (see visibility.ts).
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.start("a", "s");
+	t.delta("a", "s", "some text");
+	t.end("a", "s");
+	assert.equal(t.snapshot("a", "s")?.visibility, "summary");
 });

--- a/src/agents/reasoning/reasoning-state.test.ts
+++ b/src/agents/reasoning/reasoning-state.test.ts
@@ -163,3 +163,78 @@ test("a new turn clears the previous phase's duration", () => {
 	t.beginTurn(A, S);
 	assert.equal(t.snapshot(A, S), undefined, "a fresh turn has nothing to report yet");
 });
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * A summary that never arrived is not a summary.
+ *
+ * Reported from a live session: the footer read
+ *
+ *     Thought for 15s · 400 reasoning tokens · provider summary
+ *
+ * with `/reasoning on` and NOTHING rendered in the conversation. The model
+ * reasoned and was billed for it; the "provider summary" label came from the
+ * static provider map, not from anything the turn actually returned. It sent
+ * the operator looking for text that does not exist.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+test("reasoning with tokens but ZERO text is reported as hidden, not summary", () => {
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary"); // the static guess for this provider
+	t.start("a", "s", "summary");
+	t.setTokens("a", "s", 400); // billed…
+	// …and not one character of reasoning text ever arrives.
+	t.end("a", "s");
+
+	const snap = t.snapshot("a", "s");
+	assert.equal(snap?.visibility, "hidden");
+	assert.equal(snap?.tokens, 400);
+	assert.equal(snap?.chars, undefined);
+});
+
+test("a real summary keeps its label — the downgrade is not indiscriminate", () => {
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.start("a", "s", "summary");
+	t.delta("a", "s", "the model explained itself here");
+	t.setTokens("a", "s", 400);
+	t.end("a", "s");
+
+	assert.equal(t.snapshot("a", "s")?.visibility, "summary");
+});
+
+test("a redacted phase is NOT downgraded — it is already block-proven", () => {
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "redacted");
+	t.start("a", "s", "redacted");
+	t.setTokens("a", "s", 120);
+	t.end("a", "s");
+
+	assert.equal(t.snapshot("a", "s")?.visibility, "redacted");
+});
+
+test("an expected-but-entirely-silent phase still reports, as hidden", () => {
+	// No thinking event, no token count — the case where BOTH proofs are absent.
+	// Without `expectReasoning` this session reported nothing at all, and an
+	// empty header reads as "the model did not think".
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "summary");
+	t.expectReasoning("a", "s");
+	t.end("a", "s");
+
+	assert.equal(t.snapshot("a", "s")?.visibility, "hidden");
+});
+
+test("a NON-reasoning model still contributes no snapshot at all", () => {
+	// The guard rail: `expected` is only set for a reasoning-capable model with
+	// thinking on, so an ordinary model must not gain a phantom "Thought" line.
+	const t = new ReasoningTracker();
+	t.beginTurn("a", "s");
+	t.setVisibility("a", "s", "none");
+	t.end("a", "s");
+
+	assert.equal(t.snapshot("a", "s"), undefined);
+});

--- a/src/agents/reasoning/reasoning-state.ts
+++ b/src/agents/reasoning/reasoning-state.ts
@@ -33,6 +33,13 @@ import type { ReasoningVisibility, SessionReasoningState } from "../../protocol.
 
 interface Entry {
 	active: boolean;
+	/**
+	 * The turn ran a reasoning-capable model with thinking enabled.
+	 *
+	 * This is the THIRD proof that reasoning happened, and it exists because the
+	 * other two can both be absent on a perfectly ordinary turn. See `end()`.
+	 */
+	expected: boolean;
 	visibility: ReasoningVisibility;
 	startedAt?: number;
 	chars: number;
@@ -53,7 +60,7 @@ interface Entry {
 }
 
 function fresh(): Entry {
-	return { active: false, visibility: "none", chars: 0, everReasoned: false };
+	return { active: false, visibility: "none", chars: 0, everReasoned: false, expected: false };
 }
 
 export class ReasoningTracker {
@@ -92,6 +99,7 @@ export class ReasoningTracker {
 	beginTurn(agentId: string, sessionKey: string): void {
 		const e = this.touch(agentId, sessionKey);
 		e.active = false;
+		e.expected = false;
 		e.startedAt = undefined;
 		e.chars = 0;
 		e.tokens = undefined;
@@ -138,6 +146,39 @@ export class ReasoningTracker {
 		if (e.active && e.startedAt !== undefined) e.lastDurationMs = Math.max(0, now - e.startedAt);
 		e.active = false;
 		e.startedAt = undefined;
+		// SETTLE AN UNOBSERVED-BUT-EXPECTED PHASE.
+		//
+		// The turn ran a reasoning model with thinking on, and yet nothing was
+		// ever observed: no thinking event, no reasoning-token count. That is not
+		// evidence the model skipped reasoning — it is the omitted-but-billed
+		// case, which is the DEFAULT on the current Claude generation.
+		//
+		// Report it as `hidden` so the UI can say "not exposed by this model"
+		// instead of showing an empty header that reads as "it didn't think".
+		// Only ever downgrades: a phase that WAS observed keeps whatever
+		// visibility the blocks proved, and a non-reasoning model never sets
+		// `expected`, so it still contributes no snapshot at all.
+		if (!e.everReasoned && e.expected) {
+			e.visibility = "hidden";
+			e.everReasoned = true;
+		}
+		// A SUMMARY THAT NEVER ARRIVED IS NOT A SUMMARY.
+		//
+		// `summary` is only ever a STATIC guess from the provider id — it says
+		// what this backend is capable of returning, not what this turn actually
+		// returned. When the model demonstrably reasoned (a duration, a billed
+		// token count) and produced ZERO characters of reasoning text, calling
+		// that "provider summary" tells the operator to look for something that
+		// is not there, and quietly misreports the omitted-but-billed case as a
+		// summary they simply cannot see.
+		//
+		// Observed emptiness outranks the static guess, so downgrade to `hidden`
+		// — whose label is "not exposed by this model", which is the truth.
+		// `raw` is downgraded for the same reason. `redacted` is left alone: it
+		// is already a stronger, block-proven statement.
+		if (e.everReasoned && e.chars === 0 && (e.visibility === "summary" || e.visibility === "raw")) {
+			e.visibility = "hidden";
+		}
 	}
 
 	/** Record separately-billed reasoning tokens, when a provider reports them. */
@@ -150,6 +191,35 @@ export class ReasoningTracker {
 			// omitted-but-billed case).
 			e.everReasoned = true;
 		}
+	}
+
+	/**
+	 * This turn is RUNNING a reasoning-capable model with thinking enabled.
+	 *
+	 * ─────────────────────────────────────────────────────────────────────────
+	 * WHY A THIRD SIGNAL IS NEEDED
+	 * ─────────────────────────────────────────────────────────────────────────
+	 * `everReasoned` was provable two ways: a thinking event arrived, or the
+	 * provider reported a separately-billed reasoning-token count. On the
+	 * current Claude generation BOTH are absent on a normal turn:
+	 *
+	 *   • `display: "omitted"` is the default, and it emits NO `thinking_delta`
+	 *     events at all — only an empty block with a real signature, fully
+	 *     billed (see `visibility.ts` for the vendor citation).
+	 *   • Pi folds reasoning tokens into `output` before Brigade sees a usage
+	 *     record, so `reasoningTokens` never arrives either.
+	 *
+	 * With neither proof, `snapshot()` returned `undefined`, the gateway sent no
+	 * reasoning state, and the TUI rendered NOTHING — which reads as "the model
+	 * did not think". It thought, and the operator paid for it. That is the
+	 * exact misrepresentation this whole subsystem exists to prevent.
+	 *
+	 * Deliberately keyed off the MODEL'S DECLARED CAPABILITY and the configured
+	 * thinking level, never off a provider name. A provider allow-list would be
+	 * wrong the day a new backend ships, and Brigade drives 22 of them.
+	 */
+	expectReasoning(agentId: string, sessionKey: string): void {
+		this.touch(agentId, sessionKey).expected = true;
 	}
 
 	/** Declare what this backend exposes. Called when the turn's model is known. */

--- a/src/agents/reasoning/reasoning-state.ts
+++ b/src/agents/reasoning/reasoning-state.ts
@@ -33,6 +33,15 @@ import type { ReasoningVisibility, SessionReasoningState } from "../../protocol.
 
 interface Entry {
 	active: boolean;
+	/**
+	 * A provider safety filter removed a block this turn.
+	 *
+	 * Kept apart from `visibility` because it is an OBSERVATION about one block,
+	 * whereas `visibility` is a statement about what the backend can return. The
+	 * two used to be crushed into one field, which is what let a single empty
+	 * block permanently rewrite the backend's capability.
+	 */
+	redactedSeen: boolean;
 	visibility: ReasoningVisibility;
 	startedAt?: number;
 	chars: number;
@@ -53,7 +62,7 @@ interface Entry {
 }
 
 function fresh(): Entry {
-	return { active: false, visibility: "none", chars: 0, everReasoned: false };
+	return { active: false, visibility: "none", chars: 0, everReasoned: false, redactedSeen: false };
 }
 
 /**
@@ -88,15 +97,41 @@ function reportedVisibility(e: {
 	chars: number;
 	everReasoned: boolean;
 	active: boolean;
+	redactedSeen: boolean;
 }): ReasoningVisibility {
+	// A safety filter removed something. Strongest statement available, and it
+	// outranks everything else — including text that arrived in another block.
+	if (e.redactedSeen) return "redacted";
 	// Mid-phase, text may simply not have arrived YET. Only judge a settled turn.
 	if (e.active) return e.visibility;
 	if (!e.everReasoned) return e.visibility;
+	// Text DID arrive somewhere in this turn, so the backend exposed its
+	// reasoning and the declared capability stands. This is the branch that
+	// stops one empty reasoning item — providers emit several per response,
+	// many empty — from relabelling a turn that produced a real summary.
 	if (e.chars > 0) return e.visibility;
+	// Reasoned, settled, and not one character of it was exposed.
 	if (e.visibility === "summary" || e.visibility === "raw") return "hidden";
 	return e.visibility;
 }
 
+/**
+ * Note what one `thinking` block revealed, WITHOUT overwriting the declared
+ * capability.
+ *
+ * The gateway used to refine visibility per block and write the result back:
+ *
+ *     prev = <current>;  setVisibility(refine(prev, block))
+ *
+ * `refineReasoningVisibility` never widens fidelity, so the first empty block
+ * pinned the session to `hidden` for the rest of the turn and a later block
+ * carrying a genuine summary could not lift it. The label then said the
+ * model's reasoning was never exposed while that summary sat on screen.
+ *
+ * Redaction is an observation, so it is recorded as one. Emptiness needs no
+ * recording at all: `chars` already knows whether any text arrived, and
+ * `reportedVisibility` reads it per snapshot.
+ */
 export class ReasoningTracker {
 	private readonly entries = new Map<string, Entry>();
 
@@ -134,6 +169,7 @@ export class ReasoningTracker {
 		const e = this.touch(agentId, sessionKey);
 		e.active = false;
 		e.startedAt = undefined;
+		e.redactedSeen = false;
 		e.chars = 0;
 		e.tokens = undefined;
 		e.everReasoned = false;
@@ -200,6 +236,40 @@ export class ReasoningTracker {
 			// omitted-but-billed case).
 			e.everReasoned = true;
 		}
+	}
+
+	/**
+	 * The STORED visibility, before the derived no-text downgrade.
+	 *
+	 * ─────────────────────────────────────────────────────────────────────────
+	 * WHY THIS IS SEPARATE FROM `snapshot().visibility`
+	 * ─────────────────────────────────────────────────────────────────────────
+	 * `snapshot()` reports a DERIVED value — a `summary` with no text becomes
+	 * `hidden`, recomputed on every read so it cannot latch. That is right for a
+	 * renderer and catastrophic for the refine loop.
+	 *
+	 * The gateway refines visibility per thinking block:
+	 *   prev = <read current>; setVisibility(refine(prev, block))
+	 * If `prev` is the DERIVED value, the downgrade gets written back into
+	 * storage, and `refineReasoningVisibility` never widens fidelity — so it is
+	 * permanent. One empty reasoning item then pins the whole turn to `hidden`,
+	 * and a later item streaming a genuine summary renders under a label saying
+	 * the model's reasoning was never exposed. That is the precise inversion the
+	 * derivation was introduced to remove, re-entering through the back door.
+	 *
+	 * So: read THIS to refine, read `snapshot()` to display.
+	 */
+	declaredVisibility(agentId: string, sessionKey: string): ReasoningVisibility {
+		return this.entries.get(this.key(agentId, sessionKey))?.visibility ?? "none";
+	}
+
+	noteThinkingBlock(
+		agentId: string,
+		sessionKey: string,
+		block: { thinking?: string; thinkingSignature?: string; redacted?: boolean } | undefined,
+	): void {
+		if (!block) return;
+		if (block.redacted === true) this.touch(agentId, sessionKey).redactedSeen = true;
 	}
 
 	/** Declare what this backend exposes. Called when the turn's model is known. */

--- a/src/agents/reasoning/reasoning-state.ts
+++ b/src/agents/reasoning/reasoning-state.ts
@@ -33,13 +33,6 @@ import type { ReasoningVisibility, SessionReasoningState } from "../../protocol.
 
 interface Entry {
 	active: boolean;
-	/**
-	 * The turn ran a reasoning-capable model with thinking enabled.
-	 *
-	 * This is the THIRD proof that reasoning happened, and it exists because the
-	 * other two can both be absent on a perfectly ordinary turn. See `end()`.
-	 */
-	expected: boolean;
 	visibility: ReasoningVisibility;
 	startedAt?: number;
 	chars: number;
@@ -60,7 +53,48 @@ interface Entry {
 }
 
 function fresh(): Entry {
-	return { active: false, visibility: "none", chars: 0, everReasoned: false, expected: false };
+	return { active: false, visibility: "none", chars: 0, everReasoned: false };
+}
+
+/**
+ * What to REPORT, as opposed to what was declared.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS IS DERIVED AND NOT STORED
+ * ─────────────────────────────────────────────────────────────────────────
+ * `visibility` starts as a static guess from the provider id — what this
+ * backend CAN return, not what this turn did. When a turn demonstrably
+ * reasoned and produced zero characters of text, reporting "provider summary"
+ * points the operator at a summary that does not exist.
+ *
+ * The first attempt at this MUTATED the stored value inside `end()`, and that
+ * was wrong in a way that inverted the very misrepresentation it was meant to
+ * fix. `end()` fires once per model ROUNDTRIP, not once per logical turn, so a
+ * tool-using turn settles several times: an empty first roundtrip latched
+ * `hidden`, and a second roundtrip streaming a genuine 900-character summary
+ * kept it — the real summary then rendered under a label saying the model's
+ * reasoning was never exposed.
+ *
+ * Deriving it at read time cannot latch. Every snapshot re-answers the
+ * question from the turn's cumulative evidence, so late text corrects an early
+ * empty phase automatically.
+ *
+ * `redacted` is never downgraded: pi-ai emits a redacted block as
+ * `thinking_start` → `thinking_end` with no deltas, so `chars` is always 0 and
+ * the downgrade would relabel every redacted phase as merely "not exposed".
+ */
+function reportedVisibility(e: {
+	visibility: ReasoningVisibility;
+	chars: number;
+	everReasoned: boolean;
+	active: boolean;
+}): ReasoningVisibility {
+	// Mid-phase, text may simply not have arrived YET. Only judge a settled turn.
+	if (e.active) return e.visibility;
+	if (!e.everReasoned) return e.visibility;
+	if (e.chars > 0) return e.visibility;
+	if (e.visibility === "summary" || e.visibility === "raw") return "hidden";
+	return e.visibility;
 }
 
 export class ReasoningTracker {
@@ -99,7 +133,6 @@ export class ReasoningTracker {
 	beginTurn(agentId: string, sessionKey: string): void {
 		const e = this.touch(agentId, sessionKey);
 		e.active = false;
-		e.expected = false;
 		e.startedAt = undefined;
 		e.chars = 0;
 		e.tokens = undefined;
@@ -108,11 +141,20 @@ export class ReasoningTracker {
 	}
 
 	/** A reasoning phase opened. */
-	start(agentId: string, sessionKey: string, visibility: ReasoningVisibility = "raw", now = Date.now()): void {
+	// Defaults to `summary`, not `raw`, matching `initialReasoningVisibility`:
+	// understating fidelity is a smaller error than telling the operator they
+	// are reading the model's own chain of thought when they are reading a
+	// paraphrase. Reachable whenever `setVisibility` did not run first.
+	start(agentId: string, sessionKey: string, visibility: ReasoningVisibility = "summary", now = Date.now()): void {
 		const e = this.touch(agentId, sessionKey);
 		e.active = true;
 		e.startedAt = now;
-		e.chars = 0;
+		// `chars` is deliberately NOT reset here. It counts the reasoning text
+		// seen across the whole logical TURN, and `beginTurn()` is what clears
+		// it. Resetting per phase meant a second reasoning item with no text
+		// erased the record of a first item that streamed a real summary — and
+		// providers emit several items per response routinely (OpenAI's o-series
+		// and GPT-5 open one per `output_item.added`, many of them empty).
 		e.everReasoned = true;
 		// A phase that opens tells us the model reasons; keep a more specific
 		// visibility if one was already established for this session.
@@ -146,39 +188,6 @@ export class ReasoningTracker {
 		if (e.active && e.startedAt !== undefined) e.lastDurationMs = Math.max(0, now - e.startedAt);
 		e.active = false;
 		e.startedAt = undefined;
-		// SETTLE AN UNOBSERVED-BUT-EXPECTED PHASE.
-		//
-		// The turn ran a reasoning model with thinking on, and yet nothing was
-		// ever observed: no thinking event, no reasoning-token count. That is not
-		// evidence the model skipped reasoning — it is the omitted-but-billed
-		// case, which is the DEFAULT on the current Claude generation.
-		//
-		// Report it as `hidden` so the UI can say "not exposed by this model"
-		// instead of showing an empty header that reads as "it didn't think".
-		// Only ever downgrades: a phase that WAS observed keeps whatever
-		// visibility the blocks proved, and a non-reasoning model never sets
-		// `expected`, so it still contributes no snapshot at all.
-		if (!e.everReasoned && e.expected) {
-			e.visibility = "hidden";
-			e.everReasoned = true;
-		}
-		// A SUMMARY THAT NEVER ARRIVED IS NOT A SUMMARY.
-		//
-		// `summary` is only ever a STATIC guess from the provider id — it says
-		// what this backend is capable of returning, not what this turn actually
-		// returned. When the model demonstrably reasoned (a duration, a billed
-		// token count) and produced ZERO characters of reasoning text, calling
-		// that "provider summary" tells the operator to look for something that
-		// is not there, and quietly misreports the omitted-but-billed case as a
-		// summary they simply cannot see.
-		//
-		// Observed emptiness outranks the static guess, so downgrade to `hidden`
-		// — whose label is "not exposed by this model", which is the truth.
-		// `raw` is downgraded for the same reason. `redacted` is left alone: it
-		// is already a stronger, block-proven statement.
-		if (e.everReasoned && e.chars === 0 && (e.visibility === "summary" || e.visibility === "raw")) {
-			e.visibility = "hidden";
-		}
 	}
 
 	/** Record separately-billed reasoning tokens, when a provider reports them. */
@@ -191,35 +200,6 @@ export class ReasoningTracker {
 			// omitted-but-billed case).
 			e.everReasoned = true;
 		}
-	}
-
-	/**
-	 * This turn is RUNNING a reasoning-capable model with thinking enabled.
-	 *
-	 * ─────────────────────────────────────────────────────────────────────────
-	 * WHY A THIRD SIGNAL IS NEEDED
-	 * ─────────────────────────────────────────────────────────────────────────
-	 * `everReasoned` was provable two ways: a thinking event arrived, or the
-	 * provider reported a separately-billed reasoning-token count. On the
-	 * current Claude generation BOTH are absent on a normal turn:
-	 *
-	 *   • `display: "omitted"` is the default, and it emits NO `thinking_delta`
-	 *     events at all — only an empty block with a real signature, fully
-	 *     billed (see `visibility.ts` for the vendor citation).
-	 *   • Pi folds reasoning tokens into `output` before Brigade sees a usage
-	 *     record, so `reasoningTokens` never arrives either.
-	 *
-	 * With neither proof, `snapshot()` returned `undefined`, the gateway sent no
-	 * reasoning state, and the TUI rendered NOTHING — which reads as "the model
-	 * did not think". It thought, and the operator paid for it. That is the
-	 * exact misrepresentation this whole subsystem exists to prevent.
-	 *
-	 * Deliberately keyed off the MODEL'S DECLARED CAPABILITY and the configured
-	 * thinking level, never off a provider name. A provider allow-list would be
-	 * wrong the day a new backend ships, and Brigade drives 22 of them.
-	 */
-	expectReasoning(agentId: string, sessionKey: string): void {
-		this.touch(agentId, sessionKey).expected = true;
 	}
 
 	/** Declare what this backend exposes. Called when the turn's model is known. */
@@ -242,7 +222,7 @@ export class ReasoningTracker {
 		if (!e.everReasoned && !e.active) return undefined;
 		return {
 			active: e.active,
-			visibility: e.visibility,
+			visibility: reportedVisibility(e),
 			...(e.startedAt !== undefined ? { startedAt: e.startedAt } : {}),
 			...(e.chars > 0 ? { chars: e.chars } : {}),
 			...(e.tokens !== undefined ? { tokens: e.tokens } : {}),

--- a/src/agents/session-wiring.ts
+++ b/src/agents/session-wiring.ts
@@ -31,6 +31,7 @@ import { makePathWriteGuard } from "./path-write-guard.js";
 import type { SessionContext } from "./session-context.js";
 import { type BrigadeBeforeToolCallHook, makeUnknownToolGuard } from "./tool-guard.js";
 import { makeToolLoopDetector } from "./tool-loop-detector.js";
+import { warnUnhandledPiDroppedFields } from "./tools/pi-tool-boundary.js";
 import { wrapOwnerOnlyToolExecution, wrapToolExecutionTimeout } from "./tools/common.js";
 import { createBrigadeTools } from "./tools/registry.js";
 import type { AnyBrigadeTool } from "./tools/types.js";
@@ -322,6 +323,13 @@ export function assembleBrigadeToolset(opts: {
 		? allowedBuiltinNames
 		: allowedBuiltinNames.filter((n) => policyAllows(n));
 	const brigadeToolNames = customTools.map((t) => t.name);
+	// This array is about to become Pi's `customTools`, and Pi's tool wrapper
+	// copies a fixed field list onto the object its loop sees — everything else
+	// is dropped with no error and no type failure (see tools/pi-tool-boundary.ts).
+	// Reporting is deliberately one-way: an unmodelled field is a smell, not a
+	// reason to withhold a working tool, so the operator gets a line naming what
+	// vanished rather than a feature that quietly does nothing.
+	warnUnhandledPiDroppedFields(customTools, "session-wiring");
 	return {
 		builtinToolNames: builtinNames,
 		brigadeToolNames,

--- a/src/agents/smart-compaction.breaker.test.ts
+++ b/src/agents/smart-compaction.breaker.test.ts
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { after, test } from "node:test";
 
+import { TUI, type Component, type Terminal } from "@earendil-works/pi-tui";
+
+import { wireConnectUi } from "../cli/commands/connect.js";
+import type { BrigadeClient } from "../tui/client.js";
+import type { SessionStateSnapshot } from "../protocol.js";
 import {
 	CompactionBreaker,
 	describeCompactionOutcome,
 	estimateContextTokensFromMessages,
+	isCompactionCancellation,
 	MAX_COMPACTIONS_WITHOUT_REPLY,
 	summarizeCompactionOutcome,
 } from "./smart-compaction.js";
@@ -55,6 +61,59 @@ test("sessions are independent — one stuck thread cannot block another", () =>
 	b.noteCompaction("a");
 	assert.equal(b.allow("a"), false);
 	assert.equal(b.allow("b"), true);
+});
+
+test("an operator's Ctrl+C cannot close their own guard", () => {
+	// `noteCompaction` is counted BEFORE the summarization on purpose — the guard
+	// has to hold even if the call never returns. A CANCELLED compaction is the
+	// one case where that is wrong: nothing was paid for and nothing was learned
+	// about whether compaction helps this session, which is the only question
+	// this guard exists to answer. Counted anyway, two interrupts in a row would
+	// lock a perfectly healthy session out of compaction for the whole cooldown.
+	const b = new CompactionBreaker();
+	for (let i = 0; i < MAX_COMPACTIONS_WITHOUT_REPLY + 3; i += 1) {
+		assert.equal(b.allow(S), true, `interrupt ${i} still leaves the guard open`);
+		b.noteCompaction(S);
+		b.undoCompaction(S); // the operator pressed Ctrl+C
+	}
+	assert.equal(b.count(S), 0);
+	assert.equal(b.allow(S), true);
+});
+
+test("undoing a cancellation rewinds ONE attempt, it does not clear the budget", () => {
+	// The distinction from `noteReply`. A real failure followed by an interrupt
+	// must still leave the real failure on the books — otherwise a session that
+	// alternates failure and cancellation compacts forever, which is the exact
+	// loop the breaker was written for.
+	const b = new CompactionBreaker();
+	b.noteCompaction(S); // a genuine failure
+	b.noteCompaction(S); // a cancelled attempt
+	assert.equal(b.allow(S), false, "the guard closed on the second attempt");
+	b.undoCompaction(S);
+	assert.equal(b.count(S), 1, "the genuine failure survives");
+	assert.equal(b.allow(S), true, "but the cancelled attempt is given back");
+});
+
+test("undoCompaction on an unknown session is a no-op, not a negative count", () => {
+	const b = new CompactionBreaker();
+	b.undoCompaction("never-seen");
+	assert.equal(b.count("never-seen"), 0);
+	assert.equal(b.size, 0);
+});
+
+test("a cancellation is recognised by shape, not by message text", () => {
+	// The same pair `retry-policy.ts` and `model-fallback.ts` classify by, so an
+	// abort raised anywhere below — Pi's run abort, an isolated summarization
+	// call, a provider fetch — is recognised without each layer inventing its
+	// own spelling.
+	assert.equal(isCompactionCancellation(Object.assign(new Error("x"), { name: "AbortError" })), true);
+	assert.equal(isCompactionCancellation(Object.assign(new Error("x"), { code: "ABORT_ERR" })), true);
+	assert.equal(isCompactionCancellation(Object.assign(new Error("x"), { code: 20 })), true);
+	// A real failure must NOT be forgiven — that would retry a broken
+	// summarization on every attempt, which is the loop the breaker exists for.
+	assert.equal(isCompactionCancellation(new Error("Connection error.")), false);
+	assert.equal(isCompactionCancellation(undefined), false);
+	assert.equal(isCompactionCancellation("AbortError"), false);
 });
 
 test("forget clears a session", () => {
@@ -145,15 +204,117 @@ test("trip opens the guard immediately, without spending the attempt budget", ()
 
 /* ───────────── what the operator is told, end to end ───────────── */
 
-/** The line the TUI renders from `compaction_end.outcome`. */
-function compactionLine(oc: { freedTokens: number; messagesBefore: number; messagesAfter: number; madeProgress: boolean } | undefined): string {
-	if (!oc) return "compacted · usage refreshes on the next reply";
-	return oc.madeProgress
-		? `compacted · freed ${oc.freedTokens} tokens · ${oc.messagesBefore} → ${oc.messagesAfter} messages`
-		: `compacted · reclaimed almost nothing (${oc.messagesBefore} → ${oc.messagesAfter} messages)`;
+// These used to call a `compactionLine()` declared right here in the test file,
+// which was a COPY of the expression inside `connect.ts`'s `compaction_end`
+// handler — and a stale one: it asserted `freed 118000 tokens` where production
+// runs the figure through `formatTokens` and prints `freed 118k tokens`. The
+// test agreed with itself and disagreed with the screen, and deleting the real
+// line from `connect.ts` would not have failed it.
+//
+// The real line is built inline inside a closure in `wireConnectUi`, so there is
+// nothing to import. What CAN be driven is the whole path: boot the real connect
+// UI against a fake terminal and a fake gateway, push the `compaction_end` frame
+// the gateway really sends, and read the row off the widget tree.
+
+/** A Terminal that renders nowhere. */
+class FakeTerminal implements Terminal {
+	onInput: (data: string) => void = () => {};
+	start(onInput: (data: string) => void): void {
+		this.onInput = onInput;
+	}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(): void {}
+	get columns(): number {
+		return 120;
+	}
+	get rows(): number {
+		return 40;
+	}
+	get kittyProtocolActive(): boolean {
+		return false;
+	}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
 }
 
-test("a real compaction tells the operator what it freed", () => {
+const UI_AGENT = "main";
+const UI_SESSION = "agent:main:main";
+
+const UI_SNAPSHOT = {
+	provider: "claude-cli",
+	modelId: "opus-4-8",
+	modelName: "Opus 4.8",
+	thinkingLevel: "off",
+	supportsThinking: true,
+	supportsVision: true,
+	availableThinkingLevels: ["off"],
+	contextUsagePercent: 889,
+	totalTokensIn: 0,
+	totalTokensOut: 0,
+	totalCostUsd: 0,
+	isAgentRunning: false,
+	messageCount: 0,
+	agentId: UI_AGENT,
+	agentName: "brigade",
+	sessionKey: UI_SESSION,
+} as unknown as SessionStateSnapshot;
+
+const bootedUis: TUI[] = [];
+after(() => {
+	for (const tui of bootedUis) {
+		for (const child of (tui as unknown as { children: Component[] }).children) {
+			(child as unknown as { stop?: () => void }).stop?.();
+		}
+	}
+});
+
+/** Boot the real connect UI and hand back a way to push one `compaction_end`. */
+async function compactionScreen(event: Record<string, unknown>): Promise<string> {
+	const tui = new TUI(new FakeTerminal());
+	bootedUis.push(tui);
+	const handlers = new Map<string, Array<(...a: never[]) => void>>();
+	const client = {
+		on(name: string, fn: (...a: never[]) => void) {
+			const list = handlers.get(name) ?? [];
+			list.push(fn);
+			handlers.set(name, list);
+			return client;
+		},
+		connect: async () => {},
+		resume: async () => {},
+		close: () => {},
+		request: async (method: string) => {
+			if (method === "get-state") return UI_SNAPSHOT;
+			if (method === "list-models") return [];
+			if (method === "sessions.list" || method === "list-sessions") return [];
+			if (method === "list-agents") return [];
+			return undefined;
+		},
+	};
+	await wireConnectUi(tui, client as unknown as BrigadeClient, UI_AGENT, UI_SESSION);
+	const emit = (name: string, payload: unknown): void => {
+		for (const fn of handlers.get(name) ?? []) (fn as (p: unknown) => void)(payload);
+	};
+	emit("state", UI_SNAPSHOT);
+	emit("pi", { event, subagentDepth: 0, agentId: UI_AGENT, sessionId: UI_SESSION });
+	return (tui as unknown as { children: Component[] }).children
+		.map((c) => (c as unknown as { render(width: number): string[] }).render(120).join("\n"))
+		.join("\n");
+}
+
+/** The `compaction_end` frame the gateway sends for a SUCCESSFUL compaction. */
+function compactionEnd(outcome: unknown): Record<string, unknown> {
+	return { type: "compaction_end", aborted: false, result: {}, outcome };
+}
+
+test("a real compaction tells the operator what it freed", async () => {
 	// The summarization's COST cannot be priced — the provider reports no usage
 	// for it — but what it RECLAIMED is always measurable, and saying nothing was
 	// how a no-progress loop kept passing for success.
@@ -163,27 +324,44 @@ test("a real compaction tells the operator what it freed", () => {
 		messagesBefore: 142,
 		messagesAfter: 12,
 	});
-	assert.equal(
-		compactionLine(o),
-		"compacted · freed 118000 tokens · 142 → 12 messages",
+	const screen = await compactionScreen(compactionEnd(o));
+	assert.ok(
+		screen.includes("compacted · freed 118k tokens · 142 → 12 messages"),
+		`the operator must be told what was freed; screen tail:\n${screen.slice(-400)}`,
 	);
 });
 
-test("a compaction that achieved nothing says so, instead of claiming success", () => {
+test("a compaction that achieved nothing says so, instead of claiming success", async () => {
 	const o = summarizeCompactionOutcome({
 		tokensBefore: 150_000,
 		tokensAfter: 149_500,
 		messagesBefore: 100,
 		messagesAfter: 100,
 	});
-	assert.match(compactionLine(o), /reclaimed almost nothing/);
-	assert.doesNotMatch(compactionLine(o), /freed/);
+	assert.equal(o.madeProgress, false, "0.3% freed is not progress");
+	const screen = await compactionScreen(compactionEnd(o));
+	assert.ok(screen.includes("reclaimed almost nothing (100 → 100 messages)"), "it must say so");
+	assert.equal(screen.includes("freed"), false, "and must not also claim a saving");
 });
 
-test("an older gateway with no outcome falls back to the honest old wording", () => {
+test("an older gateway with no outcome falls back to the honest old wording", async () => {
 	// The percentage genuinely is stale until the next successful reply, so the
 	// fallback is not a lie — just less useful.
-	assert.match(compactionLine(undefined), /usage refreshes on the next reply/);
+	const screen = await compactionScreen(compactionEnd(undefined));
+	assert.ok(screen.includes("compacted · usage refreshes on the next reply"));
+});
+
+test("a compaction that FAILED is never reported as a compaction", async () => {
+	// Pi emits `compaction_end` on every failure path with `aborted: false` and
+	// no `result`. Branching on `aborted` alone printed "✓ compacted · reclaimed
+	// almost nothing" for a summarization that never ran.
+	const screen = await compactionScreen({
+		type: "compaction_end",
+		aborted: false,
+		errorMessage: "rate limited",
+	});
+	assert.ok(screen.includes("compaction failed · rate limited"), "the failure is named");
+	assert.equal(screen.includes("compacted ·"), false, "and never dressed up as success");
 });
 
 test("one estimator is shared, so the trigger and the measurement cannot disagree", () => {

--- a/src/agents/smart-compaction.ts
+++ b/src/agents/smart-compaction.ts
@@ -730,6 +730,26 @@ export const MAX_COMPACTIONS_WITHOUT_REPLY = 2;
  */
 export const COMPACTION_BREAKER_COOLDOWN_MS = 5 * 60_000;
 
+/**
+ * Was a compaction CANCELLED rather than failed?
+ *
+ * The two have to be told apart before the breaker sees them. A failure is
+ * evidence — it says compaction is not working for this session and the guard
+ * should count it. A cancellation is the operator, and it says nothing at all;
+ * charging it to the budget lets a user close their own guard by pressing
+ * Ctrl+C twice.
+ *
+ * Matched on the DOM `AbortError` shape (`name` / `code`), the same pair
+ * `retry-policy.ts` and `model-fallback.ts` classify by, so an abort raised
+ * anywhere below — Pi's own run abort, an isolated summarization call, a
+ * provider fetch — is recognised without each layer inventing its own spelling.
+ */
+export function isCompactionCancellation(value: unknown): boolean {
+	if (!value || typeof value !== "object") return false;
+	const v = value as { name?: unknown; code?: unknown };
+	return v.name === "AbortError" || v.code === "ABORT_ERR" || v.code === 20;
+}
+
 export class CompactionBreaker {
 	private readonly consecutive = new Map<string, number>();
 	/** When each session's guard last closed, for the cooldown. */
@@ -788,6 +808,36 @@ export class CompactionBreaker {
 		this.consecutive.set(sessionKey, next);
 		if (next >= this.max) this.closedAt.set(sessionKey, this.now());
 		this.evictIfNeeded();
+	}
+
+	/**
+	 * Give back an attempt that never actually happened.
+	 *
+	 * `noteCompaction` is counted BEFORE the summarization, deliberately: the
+	 * guard has to hold even if the call never returns. A CANCELLED compaction is
+	 * the one case where that is wrong. The operator pressed Ctrl+C — no
+	 * summarization was paid for, and nothing was learned about whether
+	 * compaction can help this session, which is the only question the guard
+	 * exists to answer. Counting it means two interrupts in a row close the guard
+	 * for the whole cooldown and leave a perfectly healthy session unable to
+	 * compact for five minutes, on the strength of an operator's own keystrokes.
+	 *
+	 * Not the same as `noteReply`: that CLEARS the budget because a reply proved
+	 * the context figure moved. This only rewinds the one uncounted attempt, so a
+	 * genuine failure that happened to be followed by an interrupt still counts.
+	 */
+	undoCompaction(sessionKey: string): void {
+		const current = this.consecutive.get(sessionKey);
+		if (current === undefined) return;
+		const next = current - 1;
+		// delete+set, like `noteCompaction` — a bare `set` on an existing key
+		// preserves insertion order and would leave a stale LRU position behind.
+		this.consecutive.delete(sessionKey);
+		if (next > 0) this.consecutive.set(sessionKey, next);
+		// Below the bound the guard is open again, so the cooldown stamp that
+		// would have reopened it is meaningless — and leaving it would let a later
+		// `allow()` clear a legitimately-earned count the moment it elapsed.
+		if (next < this.max) this.closedAt.delete(sessionKey);
 	}
 
 	/**

--- a/src/agents/tools/pi-tool-boundary.test.ts
+++ b/src/agents/tools/pi-tool-boundary.test.ts
@@ -1,48 +1,89 @@
 /**
  * The tool boundary is a contract, and this is what enforces it.
  *
- * Pi's `wrapToolDefinition` copies seven named fields into the object its loop
- * sees and drops everything else — silently, with no type error, because
- * `BrigadeTool` extends `AgentTool` and adding a field to it compiles fine.
+ * Pi's tool wrapper copies seven named fields into the object its loop sees and
+ * drops everything else — silently, with no type error, because `BrigadeTool`
+ * extends `AgentTool` and adding a field to it compiles fine.
  *
- * The first test below fails the build if someone adds a `BrigadeTool` field
- * without deciding which side of the boundary it lives on. That turns a silent
- * drop into a compile-time conversation, which is the only reliable defence
- * against a failure mode whose symptom is nothing happening.
+ * The contract needs BOTH halves below, because each catches what the other
+ * structurally cannot:
+ *
+ *   • COMPILE-TIME — `BOUNDARY_DECLARED` is typed `Record<BrigadeOwnKeys, true>`,
+ *     so a new field on `BrigadeTool` fails `tsc` as a missing property and a
+ *     field removed from the type fails as an excess one. That pins the runtime
+ *     list to the type in BOTH directions, which is why nothing here is written
+ *     out by hand: a list a human retypes is a list that restates the answer.
+ *
+ *   • RUNTIME — the suite runs under `tsx`, which STRIPS types and never
+ *     typechecks. So the compile-time half is invisible to `npm test`, and a
+ *     tool assembled at runtime (an extension's, an MCP server's) never met the
+ *     compiler at all. The sweeps below walk Brigade's REAL tool surface and
+ *     fail on any field that is neither carried by Pi nor consumed by Brigade.
  */
 
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, test } from "node:test";
 
-import {
+// HOME → tempdir BEFORE importing the tool registry: several modules on that
+// import graph (exec-approvals and friends) pin paths at load time, and a test
+// that assembles the real toolset must not read the developer's own state.
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-pi-boundary-"));
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+process.env.HOME = tmpHome;
+process.env.USERPROFILE = tmpHome;
+delete process.env.BRIGADE_HOME;
+// Composio and render_video are availability-gated. Neither gate changes what
+// this file asserts (it sweeps whatever tools exist), but pinning them keeps
+// the swept set identical on a developer box that happens to have them.
+delete process.env.COMPOSIO_API_KEY;
+process.env.BRIGADE_HYPERFRAMES_PATH = path.join(tmpHome, "no-such-hyperframes");
+
+const {
 	BRIGADE_LOCAL_TOOL_FIELDS,
 	PI_CARRIED_TOOL_FIELDS,
 	fieldsPiWillDrop,
 	unhandledPiDroppedFields,
-} from "./pi-tool-boundary.js";
+	warnUnhandledPiDroppedFields,
+} = await import("./pi-tool-boundary.js");
+const { assembleBrigadeToolset } = await import("../session-wiring.js");
+const { makeFetchUrlTool } = await import("./web-fetch.js");
+const { makeBrowserTool } = await import("./browser.js");
+
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 
 import type { BrigadeTool } from "./types.js";
 
-/**
- * Every optional field `BrigadeTool` adds on top of Pi's `AgentTool`.
- *
- * This is written out by hand ON PURPOSE. TypeScript types are erased at
- * runtime, so nothing can derive this list automatically — and that is exactly
- * why the field was droppable in the first place. Adding a field to
- * `BrigadeTool` without adding it here fails the assertion below.
- */
-const BRIGADE_TOOL_OWN_FIELDS = ["ownerOnly", "displaySummary"] as const;
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-pi-boundary-ws-"));
+fs.mkdirSync(path.join(workspace, "memory"), { recursive: true });
+
+after(() => {
+	if (originalHome !== undefined) process.env.HOME = originalHome;
+	else delete process.env.HOME;
+	if (originalUserProfile !== undefined) process.env.USERPROFILE = originalUserProfile;
+	else delete process.env.USERPROFILE;
+	for (const dir of [workspace, tmpHome]) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* best-effort */
+		}
+	}
+});
 
 /**
- * COMPILE-TIME half of the contract, and the load-bearing one.
+ * COMPILE-TIME half of the contract, and the only list of Brigade-own fields
+ * in this file.
  *
- * `BrigadeOwnKeys` is derived from the type itself — every key `BrigadeTool`
- * adds on top of Pi's `AgentTool`. `Record<BrigadeOwnKeys, true>` then fails to
- * type-check the moment a new field appears on `BrigadeTool` and is not listed
- * here, so the build stops before anyone can ship a field Pi silently drops.
- *
- * The runtime list below must stay in step; the test that follows asserts it.
+ * `BrigadeOwnKeys` is derived from the type — every key `BrigadeTool` adds on
+ * top of Pi's `AgentTool`. `Record<BrigadeOwnKeys, true>` then rejects both a
+ * missing key (a new `BrigadeTool` field nobody classified) and an excess one
+ * (a field deleted from the type but left behind here), so `Object.keys` of it
+ * is a compiler-verified projection of the type rather than a hand-copy.
  */
 type BrigadeOwnKeys = Exclude<keyof BrigadeTool, keyof AgentTool>;
 const BOUNDARY_DECLARED: Record<BrigadeOwnKeys, true> = {
@@ -50,49 +91,122 @@ const BOUNDARY_DECLARED: Record<BrigadeOwnKeys, true> = {
 	displaySummary: true,
 };
 
-test("the runtime field list matches the type", () => {
-	// The compile-time check above cannot be read at runtime (types are erased),
-	// so the two lists are kept in step here. Drift means the boundary test
-	// below is checking a stale set.
-	assert.deepEqual(
-		[...BRIGADE_TOOL_OWN_FIELDS].sort(),
-		Object.keys(BOUNDARY_DECLARED).sort(),
-		"BRIGADE_TOOL_OWN_FIELDS has drifted from BrigadeTool's actual keys",
-	);
-});
-
 test("every Brigade-only tool field is declared on one side of the boundary", () => {
 	// The whole point. A field that is neither carried by Pi nor consumed by
 	// Brigade is a field that vanishes with no symptom.
 	const carried = new Set<string>(PI_CARRIED_TOOL_FIELDS);
 	const local = new Set<string>(BRIGADE_LOCAL_TOOL_FIELDS);
-	for (const field of BRIGADE_TOOL_OWN_FIELDS) {
+	const declared = Object.keys(BOUNDARY_DECLARED);
+	assert.ok(declared.length > 0, "BrigadeTool should add at least one field over AgentTool");
+	for (const field of declared) {
 		assert.ok(
 			carried.has(field) || local.has(field),
 			`\`${field}\` is on BrigadeTool but declared on neither side of the Pi boundary.\n` +
-				`Pi's wrapToolDefinition copies only: ${PI_CARRIED_TOOL_FIELDS.join(", ")}.\n` +
+				`Pi's tool wrapper copies only: ${PI_CARRIED_TOOL_FIELDS.join(", ")}.\n` +
 				`Either consume it Brigade-side (add to BRIGADE_LOCAL_TOOL_FIELDS) or carry it across yourself.`,
 		);
 	}
 });
 
-test("the carried-field list still matches Pi's wrapper", async () => {
-	// If a Pi upgrade changes which fields survive, this is where we find out —
-	// rather than in a feature that quietly stops working.
-	const mod = (await import("@earendil-works/pi-coding-agent")) as Record<string, unknown>;
-	const create = mod.createReadTool as ((cwd: string) => object) | undefined;
-	assert.equal(typeof create, "function", "createReadTool should exist to sample a real tool");
-	const real = create!(process.cwd());
-	// Every field Pi's own tool exposes must be one we know about — otherwise
-	// our model of the boundary is stale.
-	const unknown = fieldsPiWillDrop(real).filter(
-		(f) => !(BRIGADE_LOCAL_TOOL_FIELDS as readonly string[]).includes(f),
-	);
+test("no field Brigade declares local is one Pi already carries", () => {
+	// A field in both lists means someone "handled" Brigade-side something Pi
+	// delivers anyway — harmless today, but it makes the boundary lie about
+	// which side owns the field.
+	const carried = new Set<string>(PI_CARRIED_TOOL_FIELDS);
 	assert.deepEqual(
-		unknown,
+		BRIGADE_LOCAL_TOOL_FIELDS.filter((f) => carried.has(f)),
 		[],
-		`Pi's own tool carries fields this boundary does not model: ${unknown.join(", ")}`,
+		"a field cannot be both carried by Pi and consumed Brigade-side",
 	);
+});
+
+/**
+ * Locate Pi's tool wrapper on disk by walking up to the installing
+ * `node_modules`. A Pi upgrade that MOVES or renames this file should be as
+ * loud as one that changes its field list, so a miss throws rather than skips.
+ */
+function resolvePiWrapperSource(): string {
+	const rel = path.join(
+		"node_modules",
+		"@earendil-works",
+		"pi-coding-agent",
+		"dist",
+		"core",
+		"tools",
+		"tool-definition-wrapper.js",
+	);
+	let dir = path.dirname(fileURLToPath(import.meta.url));
+	for (;;) {
+		const candidate = path.join(dir, rel);
+		if (fs.existsSync(candidate)) return candidate;
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	throw new Error(
+		`Could not find Pi's ${rel}. If a Pi upgrade moved it, re-verify ` +
+			`PI_CARRIED_TOOL_FIELDS against the new wrapper and update this path.`,
+	);
+}
+
+test("PI_CARRIED_TOOL_FIELDS still matches Pi's tool wrapper source", () => {
+	// The module claims this list is "verified against
+	// tool-definition-wrapper.js". Verify it against that file, not against a
+	// sample tool — a sample only proves the fields a given tool happens to set,
+	// while the wrapper source is the actual copy list. A Pi upgrade that adds
+	// or drops a carried field lands here instead of in a dead feature.
+	// Read the file directly rather than resolving it: Pi's `exports` map
+	// publishes only ".", so every deep subpath is unresolvable by design.
+	const wrapperPath = resolvePiWrapperSource();
+	const src = fs.readFileSync(wrapperPath, "utf8");
+	// Both exported wrappers build their object from the same fixed field list;
+	// `createToolDefinitionFromAgentTool` is the one Brigade's `customTools`
+	// actually go through. Read the first object literal of each and compare.
+	const bodies = src.match(/return\s*\{[\s\S]*?\n\s*\};/g) ?? [];
+	assert.ok(bodies.length >= 2, "expected both wrapper functions in Pi's wrapper source");
+	for (const body of bodies.slice(0, 2)) {
+		const copied = [...body.matchAll(/^\s{8}([A-Za-z_$][\w$]*):/gm)].map((m) => m[1]);
+		assert.deepEqual(
+			[...copied].sort(),
+			[...PI_CARRIED_TOOL_FIELDS].sort(),
+			`Pi's wrapper now copies a different field list than PI_CARRIED_TOOL_FIELDS.\n` +
+				`Wrapper: ${copied.join(", ")}\nBrigade: ${PI_CARRIED_TOOL_FIELDS.join(", ")}`,
+		);
+	}
+});
+
+test("every tool Brigade hands to Pi survives the boundary", () => {
+	// RUNTIME conformance, derived from the real objects rather than from a
+	// list of field names. `tsx` strips types, so this is the ONLY half of the
+	// contract that `npm test` can see — and the only one that can catch a
+	// field on a tool the compiler never inspected.
+	const toolset = assembleBrigadeToolset({ workspaceDir: workspace, agentId: "main", cwd: workspace });
+	assert.ok(toolset.customTools.length > 0, "expected a real Brigade tool surface to sweep");
+	const offenders: string[] = [];
+	for (const tool of toolset.customTools) {
+		const unhandled = unhandledPiDroppedFields(tool);
+		if (unhandled.length > 0) offenders.push(`${tool.name}: ${unhandled.join(", ")}`);
+	}
+	assert.deepEqual(
+		offenders,
+		[],
+		`These tools carry fields Pi drops and Brigade does not consume:\n  ${offenders.join("\n  ")}\n` +
+			`Add each to BRIGADE_LOCAL_TOOL_FIELDS (and consume it Brigade-side) or carry it across yourself.`,
+	);
+});
+
+test("the web tools appended after toolset assembly survive it too", () => {
+	// `fetch_url` / `web_search` / the browser tool are pushed onto the custom
+	// tool array in the agent loop, AFTER `assembleBrigadeToolset` returns — so
+	// the sweep above never sees them. They reach Pi all the same.
+	const late = [makeFetchUrlTool({}), makeBrowserTool({})];
+	for (const tool of late) {
+		assert.deepEqual(
+			unhandledPiDroppedFields(tool),
+			[],
+			`${tool.name} carries a field Pi drops that Brigade does not consume`,
+		);
+	}
 });
 
 test("fieldsPiWillDrop names exactly what Pi discards", () => {
@@ -132,4 +246,31 @@ test("a tool carrying only Pi-known fields reports nothing", () => {
 	const plain = { name: "n", label: "l", description: "d", parameters: {}, execute: () => {} };
 	assert.deepEqual(fieldsPiWillDrop(plain), []);
 	assert.deepEqual(unhandledPiDroppedFields(plain), []);
+});
+
+test("the runtime reporter logs rather than throws, whatever it is handed", () => {
+	// The production contract: report, never refuse. A tool the reporter cannot
+	// even enumerate must not take the turn down with it — which is exactly the
+	// shape a third-party extension can produce.
+	const hostile = new Proxy(
+		{ name: "hostile", execute: () => {} },
+		{
+			ownKeys() {
+				throw new Error("ownKeys trap exploded");
+			},
+		},
+	);
+	assert.doesNotThrow(() => {
+		warnUnhandledPiDroppedFields(
+			[
+				{ name: "fine", execute: () => {} },
+				{ name: "leaky", execute: () => {}, retryPolicy: { max: 3 } },
+				hostile,
+				// Non-objects and nameless tools must not derail the sweep either.
+				null as unknown as object,
+				{ execute: () => {}, mystery: 1 },
+			],
+			"unit-test",
+		);
+	});
 });

--- a/src/agents/tools/pi-tool-boundary.ts
+++ b/src/agents/tools/pi-tool-boundary.ts
@@ -35,7 +35,22 @@
  *
  *   • consume it Brigade-side (add to BRIGADE_LOCAL_TOOL_FIELDS), or
  *   • carry it across yourself, because Pi will not.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHERE THIS IS ENFORCED
+ * ─────────────────────────────────────────────────────────────────────────
+ * A declaration nobody reads is just a comment, so both halves are wired:
+ *
+ *   • the conformance test (`pi-tool-boundary.test.ts`) covers every field the
+ *     COMPILER can see — the `BrigadeTool` type, and Brigade's own assembled
+ *     tool surface;
+ *   • `warnUnhandledPiDroppedFields` covers what it cannot — tools built at
+ *     runtime by an extension or an MCP server. It is called where each of
+ *     those crosses into Pi: `session-wiring.ts` (the `customTools` array) and
+ *     `extensions/registry.ts` (`pi.registerTool`).
  */
+
+import { createSubsystemLogger } from "../../logging/subsystem-logger.js";
 
 /**
  * Fields `wrapToolDefinition` copies into the object Pi's loop actually sees.
@@ -89,4 +104,58 @@ export function fieldsPiWillDrop(tool: object): string[] {
 export function unhandledPiDroppedFields(tool: object): string[] {
 	const local = new Set<string>(BRIGADE_LOCAL_TOOL_FIELDS);
 	return fieldsPiWillDrop(tool).filter((k) => !local.has(k));
+}
+
+/* ─────────────────────── runtime side of the boundary ─────────────────────── */
+
+const log = createSubsystemLogger("tools/pi-boundary");
+
+/**
+ * Warn-once ledger, keyed by source + tool name + the exact field set.
+ *
+ * The Brigade tool surface is rebuilt once per TURN, so an unconditional warn
+ * would repeat the same line for the life of the gateway — which is how a real
+ * signal gets trained into background noise. Keying on the field SET as well as
+ * the name keeps a plugin that LATER grows a second unmodelled field reportable.
+ */
+const reported = new Set<string>();
+
+/**
+ * Report — never refuse — tools carrying fields that will not survive Pi.
+ *
+ * The conformance test covers what the compiler can see. This covers what it
+ * cannot: a tool assembled at runtime by an extension, an MCP server, or a
+ * plugin factory, whose shape no `BrigadeTool` declaration ever described.
+ * Those are precisely the tools that can carry a field nobody modelled, and
+ * the whole problem with this boundary is that its failure mode is silence.
+ *
+ * `source` names the seam the tool crossed at, so the log line points at an
+ * assembly path instead of leaving the operator to guess which of several tool
+ * arrays a name came from.
+ */
+export function warnUnhandledPiDroppedFields(tools: Iterable<object>, source: string): void {
+	for (const tool of tools) {
+		// A tool object can be a Proxy built by a third-party module, and a
+		// hostile or buggy `ownKeys` trap throws. A diagnostic must never be the
+		// thing that kills a turn, so each tool is inspected in isolation.
+		try {
+			if (!tool || typeof tool !== "object") continue;
+			const unhandled = unhandledPiDroppedFields(tool);
+			if (unhandled.length === 0) continue;
+			const rawName = (tool as { name?: unknown }).name;
+			const name = typeof rawName === "string" && rawName.length > 0 ? rawName : "<unnamed>";
+			const key = `${source} ${name} ${unhandled.join(",")}`;
+			if (reported.has(key)) continue;
+			reported.add(key);
+			log.warn("tool fields will not survive the crossing into Pi", {
+				tool: name,
+				source,
+				droppedFields: unhandled,
+				carriedFields: [...PI_CARRIED_TOOL_FIELDS],
+				hint: "Pi copies a fixed field list onto the tool its loop sees; consume these Brigade-side or carry them across yourself.",
+			});
+		} catch {
+			/* an uninspectable tool is not a reason to fail the turn */
+		}
+	}
 }

--- a/src/agents/usage/ledger.ts
+++ b/src/agents/usage/ledger.ts
@@ -344,7 +344,7 @@ export class UsageLedger {
 	 *
 	 * NOT a leak fix — `evict()` already bounds this map LRU-style, so nothing
 	 * grows without limit whether or not anyone calls this. It is a CORRECTNESS
-	 * fix, and it is currently unwired.
+	 * fix.
 	 *
 	 * The bug it closes: the ledger is keyed by `(agentId, sessionKey)`, and
 	 * `/new` rolls a fresh sessionId under the SAME sessionKey. A deleted
@@ -352,14 +352,12 @@ export class UsageLedger {
 	 * conversation created under that key — the operator's brand-new thread opens
 	 * already showing someone else's cost total.
 	 *
-	 * The seam is built and waiting: `handleSessionsDelete` calls
+	 * Wired at the gateway: `handleSessionsDelete` calls
 	 * `deps.forgetSessionState?.(agentId, sessionKey)`
-	 * (server-methods/sessions.ts), and `ReasoningTracker.forget` has the same
-	 * shape and the same gap. What is missing is one line at the gateway's
-	 * handler registration, where both instances are in scope, supplying that
-	 * dep. Kept rather than deleted for exactly that reason: removing it would
-	 * strand a half-built cleanup path and leave the inherited-cost bug with no
-	 * way to close.
+	 * (server-methods/sessions.ts), and `server.ts`'s `sessions.delete`
+	 * registration supplies that dep — dropping this session's ledger, its
+	 * reasoning state, and its retained frames together, since all three are
+	 * keyed the same way and would otherwise be inherited as a set.
 	 */
 	forget(agentId: string, sessionKey: string): void {
 		this.entries.delete(this.key(agentId, sessionKey));

--- a/src/agents/usage/ledger.ts
+++ b/src/agents/usage/ledger.ts
@@ -339,7 +339,28 @@ export class UsageLedger {
 		return this.entries.size;
 	}
 
-	/** Drop a session's ledger (session deleted). */
+	/**
+	 * Drop a session's ledger (session deleted).
+	 *
+	 * NOT a leak fix — `evict()` already bounds this map LRU-style, so nothing
+	 * grows without limit whether or not anyone calls this. It is a CORRECTNESS
+	 * fix, and it is currently unwired.
+	 *
+	 * The bug it closes: the ledger is keyed by `(agentId, sessionKey)`, and
+	 * `/new` rolls a fresh sessionId under the SAME sessionKey. A deleted
+	 * session's spend therefore survives the delete and is inherited by the next
+	 * conversation created under that key — the operator's brand-new thread opens
+	 * already showing someone else's cost total.
+	 *
+	 * The seam is built and waiting: `handleSessionsDelete` calls
+	 * `deps.forgetSessionState?.(agentId, sessionKey)`
+	 * (server-methods/sessions.ts), and `ReasoningTracker.forget` has the same
+	 * shape and the same gap. What is missing is one line at the gateway's
+	 * handler registration, where both instances are in scope, supplying that
+	 * dep. Kept rather than deleted for exactly that reason: removing it would
+	 * strand a half-built cleanup path and leave the inherited-cost bug with no
+	 * way to close.
+	 */
 	forget(agentId: string, sessionKey: string): void {
 		this.entries.delete(this.key(agentId, sessionKey));
 	}

--- a/src/agents/usage/limits.test.ts
+++ b/src/agents/usage/limits.test.ts
@@ -1,0 +1,131 @@
+/**
+ * This module had no test file, and it is the one that decides whether the
+ * operator is told "you have 12k requests left" or "EXHAUSTED". Every branch
+ * below is a place where being wrong produces a confident false statement
+ * rather than a visible failure.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+	getLimitsForProvider,
+	parseResetAt,
+	recordLimitsFromHeaders,
+	resetLimitsForTest,
+} from "./limits.js";
+
+const NOW = 1_770_000_000_000; // fixed clock
+
+test("reads Anthropic's header dialect", () => {
+	resetLimitsForTest();
+	recordLimitsFromHeaders(
+		"anthropic",
+		{
+			"anthropic-ratelimit-requests-limit": "1000",
+			"anthropic-ratelimit-requests-remaining": "250",
+			"anthropic-ratelimit-tokens-limit": "80000",
+			"anthropic-ratelimit-tokens-remaining": "0",
+		},
+		NOW,
+	);
+	const windows = getLimitsForProvider("anthropic");
+	const requests = windows.find((w) => w.kind === "requests");
+	const tokens = windows.find((w) => w.kind === "tokens");
+
+	assert.equal(requests?.remaining, 250);
+	assert.equal(requests?.limit, 1000);
+	assert.equal(requests?.usedFraction, 0.75);
+	// Zero remaining is the one status a UI must never soften.
+	assert.equal(tokens?.status, "exhausted");
+});
+
+test("reads OpenAI's INVERTED header dialect", () => {
+	// `x-ratelimit-limit-tokens`, not `...-tokens-limit`. Getting the word order
+	// wrong reads every value as absent, which renders as "no data" — a silent
+	// downgrade rather than an error.
+	resetLimitsForTest();
+	recordLimitsFromHeaders(
+		"openai",
+		{
+			"x-ratelimit-limit-requests": "500",
+			"x-ratelimit-remaining-requests": "499",
+		},
+		NOW,
+	);
+	const w = getLimitsForProvider("openai").find((x) => x.kind === "requests");
+	assert.equal(w?.limit, 500);
+	assert.equal(w?.remaining, 499);
+});
+
+test("an absent family is skipped, never recorded as zero", () => {
+	// "no data" and "none left" are opposites; recording an absent family as 0
+	// would render a full bar as an empty one.
+	resetLimitsForTest();
+	recordLimitsFromHeaders("anthropic", { "anthropic-ratelimit-requests-limit": "10" }, NOW);
+	const windows = getLimitsForProvider("anthropic");
+	assert.equal(windows.find((w) => w.kind === "tokens"), undefined);
+});
+
+test("header lookup is case-insensitive", () => {
+	// Node lowercases incoming headers, but a provider adapter may not.
+	resetLimitsForTest();
+	recordLimitsFromHeaders("anthropic", { "Anthropic-RateLimit-Requests-Remaining": "7" }, NOW);
+	assert.equal(getLimitsForProvider("anthropic")[0]?.remaining, 7);
+});
+
+test("windows are scoped per provider", () => {
+	resetLimitsForTest();
+	recordLimitsFromHeaders("anthropic", { "anthropic-ratelimit-requests-remaining": "1" }, NOW);
+	recordLimitsFromHeaders("openai", { "x-ratelimit-remaining-requests": "2" }, NOW);
+	assert.equal(getLimitsForProvider("anthropic")[0]?.remaining, 1);
+	assert.equal(getLimitsForProvider("openai")[0]?.remaining, 2);
+	assert.deepEqual(getLimitsForProvider("mistral"), []);
+});
+
+test("every recorded window is stamped with observedAt, so it can be aged out", () => {
+	// The renderer drops stale windows; without this an `exhausted` reading
+	// would stay on screen forever, since the only thing that refreshes it is
+	// another call to the provider the operator has stopped calling.
+	resetLimitsForTest();
+	recordLimitsFromHeaders("anthropic", { "anthropic-ratelimit-requests-remaining": "5" }, NOW);
+	assert.equal(getLimitsForProvider("anthropic")[0]?.observedAt, NOW);
+});
+
+test("parseResetAt splits epoch SECONDS from MILLISECONDS", () => {
+	// Confusing the two puts the reset ~50,000 years out or in 1970.
+	assert.equal(parseResetAt(1_770_000_000, NOW), 1_770_000_000_000);
+	assert.equal(parseResetAt(1_770_000_000_000, NOW), 1_770_000_000_000);
+});
+
+test("parseResetAt understands OpenAI's duration grammar", () => {
+	assert.equal(parseResetAt("1s", NOW), NOW + 1000);
+	assert.equal(parseResetAt("6m0s", NOW), NOW + 360_000);
+	assert.equal(parseResetAt("1h2m3s", NOW), NOW + 3_723_000);
+	// `ms` must not be read as minutes — the `(?!s)` lookahead exists for this.
+	assert.equal(parseResetAt("250ms", NOW), NOW + 250);
+});
+
+test("parseResetAt accepts ISO-8601 and rejects junk", () => {
+	assert.equal(parseResetAt("2026-01-01T00:00:00.000Z", NOW), Date.parse("2026-01-01T00:00:00.000Z"));
+	for (const junk of ["", "   ", "soon", null, undefined, {}, Number.NaN, -1, 0]) {
+		assert.equal(parseResetAt(junk as never, NOW), undefined, `${String(junk)} must not parse`);
+	}
+});
+
+test("malformed header values never throw and never invent numbers", () => {
+	resetLimitsForTest();
+	assert.doesNotThrow(() =>
+		recordLimitsFromHeaders(
+			"anthropic",
+			{
+				"anthropic-ratelimit-requests-remaining": "not-a-number",
+				"anthropic-ratelimit-requests-limit": undefined,
+				"anthropic-ratelimit-tokens-remaining": ["12", "34"] as unknown as string,
+			},
+			NOW,
+		),
+	);
+	const requests = getLimitsForProvider("anthropic").find((w) => w.kind === "requests");
+	assert.equal(requests?.remaining, undefined, "junk must not become a count");
+});

--- a/src/agents/usage/limits.ts
+++ b/src/agents/usage/limits.ts
@@ -161,8 +161,17 @@ export function recordLimitsFromHeaders(
 	headers: Record<string, string | string[] | undefined>,
 	now = Date.now(),
 ): ProviderLimitWindow[] {
+	// Normalize the KEYS once, rather than lowercasing the name we search for —
+	// which was already lowercase at every call site, so mixed-case headers
+	// simply never matched. HTTP header names are case-insensitive by spec; Node
+	// happens to lowercase them, but `ProviderResponse.headers` is an ordinary
+	// object that any provider adapter may build by hand. A miss here is silent:
+	// every value reads as absent and the window renders as "no data", which is
+	// a confident wrong answer rather than a visible failure.
+	const lower: Record<string, string | string[] | undefined> = {};
+	for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
 	const get = (name: string): string | undefined => {
-		const v = headers[name] ?? headers[name.toLowerCase()];
+		const v = lower[name.toLowerCase()];
 		return Array.isArray(v) ? v[0] : v;
 	};
 	const recorded: ProviderLimitWindow[] = [];

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -1699,7 +1699,19 @@ export async function wireConnectUi(
 	// empty thread), never a blanked view of a thread that's secretly full.
 	// The replay is BOUNDED server-side — the `resume` RPC caps how many
 	// transcript messages it ships — so a 10k-message thread stays snappy.
-	const doResume = async (): Promise<void> => {
+	/**
+	 * The live `pi` frame handler, forward-declared.
+	 *
+	 * `doResume` (above) needs it to apply replayed frames, and it is registered
+	 * further down where the rest of the stream wiring lives. A forward
+	 * reference keeps the replay path going through the EXACT handler the live
+	 * stream uses — a second, parallel apply path would drift from it, and
+	 * drifting is how a replayed frame ends up rendering differently from the
+	 * live one it is standing in for.
+	 */
+	let handlePiFrame: ((payload: unknown) => void) | undefined;
+
+	const doResume = async (sinceSeq?: number): Promise<void> => {
 		if (resumeInFlight) {
 			resumePending = true;
 			return;
@@ -1708,7 +1720,14 @@ export async function wireConnectUi(
 		try {
 			let snap: Awaited<ReturnType<typeof client.resume>> | undefined;
 			try {
-				snap = await client.resume(withBinding());
+				// Pass the cursor when a gap was detected. The transcript rebuilds
+				// everything it holds; `sinceSeq` additionally asks for the frames
+				// it CANNOT hold (the synthetic tool events Brigade mints for a
+				// claude-cli turn, which are in no JSONL). Without this the server
+				// retained those frames and nothing ever asked for them.
+				snap = await client.resume(
+					sinceSeq === undefined ? withBinding() : withBinding({ sinceSeq }),
+				);
 			} catch {
 				return;
 			}
@@ -1716,6 +1735,36 @@ export async function wireConnectUi(
 			clearTranscriptRegion();
 			const messages = Array.isArray(snap.messages) ? snap.messages : [];
 			for (const m of messages) renderTranscriptMessage(m);
+			// REPLAYED FRAMES, applied AFTER the transcript.
+			//
+			// These are the frames no transcript can rebuild. They are the exact
+			// bytes originally broadcast, so they go back through the same handler
+			// the live stream uses and dedupe on the same identity keys.
+			//
+			// `replayComplete === false` means retention was trimmed past the
+			// cursor and some frames are gone for good. Say so once rather than
+			// leaving the operator to assume the gap was empty — a silent partial
+			// recovery is the failure this whole path exists to avoid.
+			const replayed = Array.isArray(snap.replayedFrames) ? snap.replayedFrames : [];
+			for (const raw of replayed) {
+				try {
+					const parsed = JSON.parse(raw) as { event?: string; payload?: unknown };
+					if (parsed?.event === "pi" && parsed.payload !== undefined) {
+						handlePiFrame?.(parsed.payload as never);
+					}
+				} catch {
+					/* a malformed retained frame must never break the rebuild */
+				}
+			}
+			if (snap.replayComplete === false && replayed.length === 0) {
+				insertBeforeEditor(
+					new Text(
+						`  ${brand.dim("some stream updates could not be recovered — the transcript above is complete, but tool activity in that gap is lost")}`,
+						0,
+						0,
+					),
+				);
+			}
 			// Recover the non-transcript events too ("nothing lost"): recent
 			// system-event notices, then any tool-approval prompts STILL pending
 			// on this session — re-rendered answerable so a prompt that arrived or
@@ -1928,7 +1977,12 @@ export async function wireConnectUi(
 	// mutations. Primitive #6: when `subagentDepth > 0`, indent child events
 	// by `2 * depth` spaces so nested sub-agent activity is visually distinct
 	// from the parent's stream.
-	client.on("pi", (payload: { event: any; subagentDepth?: number; agentId?: string; sessionId?: string }) => {
+	const onPiFrame = (payload: {
+		event: any;
+		subagentDepth?: number;
+		agentId?: string;
+		sessionId?: string;
+	}): void => {
 		const { event, subagentDepth } = payload;
 		// Wave N3 (bug #3) — defensive lane drop. The gateway already
 		// filters via subscribe; this catches the gap between an /agent or
@@ -2703,7 +2757,9 @@ export async function wireConnectUi(
 				break;
 			}
 		}
-	});
+	};
+	client.on("pi", onPiFrame);
+	handlePiFrame = onPiFrame as (payload: unknown) => void;
 
 	// Reconnect notifications — let the user know what just happened so a
 	// dropped/restored gateway doesn't look like phantom output.
@@ -2741,8 +2797,11 @@ export async function wireConnectUi(
 	// reordered, or the gateway restarted and reset its counters. Resume to
 	// rebuild from the transcript so the live view self-heals with no missing or
 	// misplaced messages and WITHOUT waiting for a reconnect or a manual refresh.
-	client.on("resync", () => {
-		void doResume();
+	client.on("resync", ({ lastSeq }) => {
+		// `lastSeq` is the last seq we actually saw, which is exactly the cursor
+		// the server needs to replay forward from. Discarding it (as this handler
+		// used to) is what left the whole retention path unreachable.
+		void doResume(typeof lastSeq === "number" ? lastSeq : undefined);
 	});
 
 	// Switch the live session onto a CONFIGURED provider by reusing the same

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -1157,6 +1157,7 @@ export async function wireConnectUi(
 			argumentHint: "[n]",
 		},
 		{ name: "usage", description: "show token totals + estimated cost so far" },
+		{ name: "context", description: "where this thread's context window is going" },
 		{ name: "compact", description: "summarize older turns to free context" },
 		{
 			name: "attach",
@@ -1398,7 +1399,7 @@ export async function wireConnectUi(
 	 * Extract the renderable text for an assistant message — mirrors
 	 * chat.ts's `extractAssistantText`. See chat.ts for the full rationale.
 	 */
-	const extractAssistantText = (message: any): string => {
+	const extractAssistantText = (message: any, opts?: { live?: boolean }): string => {
 		if (!message || !Array.isArray(message.content)) return "";
 
 		const thinkingParts: string[] = [];
@@ -1455,8 +1456,22 @@ export async function wireConnectUi(
 			// never has to hardcode provider knowledge.
 			const label = vis === "summary" ? "[reasoning summary]" : "[reasoning]";
 			parts.push(`${brand.dim(label)}\n${brand.dim(thinkingText)}`);
-		} else if (showThinking && !thinkingText && (vis === "hidden" || vis === "redacted")) {
+		} else if (
+			opts?.live === true &&
+			showThinking &&
+			!thinkingText &&
+			(vis === "hidden" || vis === "redacted")
+		) {
 			// REASONING IS ON, THE MODEL REASONED, AND THERE IS NOTHING TO SHOW.
+			//
+			// LIVE FRAMES ONLY. `visibility` describes the CURRENT turn, but this
+			// function also renders every historical message on resume — so
+			// without the gate, one hidden-reasoning turn stamped this note onto
+			// the whole thread: messages produced with thinking off, messages from
+			// a different model, and tool-only assistant messages that previously
+			// rendered no block at all (empty text is skipped by the caller; a
+			// note makes it non-empty). It would fabricate a billing claim about
+			// messages the snapshot says nothing about.
 			//
 			// Rendering nothing here is the worst of the three options: the
 			// operator explicitly asked to see reasoning, the model demonstrably
@@ -2045,7 +2060,7 @@ export async function wireConnectUi(
 				const text = hasFullContent
 					? (() => {
 							// Authoritative snapshot — reconcile the accumulator to it.
-							const full = extractAssistantText(msg);
+							const full = extractAssistantText(msg, { live: true });
 							if (event.type === "message_end" && depth === 0 && full.trim()) lastReplyText = full;
 							deltaText.set(deltaKey, full);
 							// The snapshot already contains the reasoning block, so the
@@ -4685,7 +4700,17 @@ export async function wireConnectUi(
 		const formatLimitLines = (windows: readonly ProviderLimitWindow[] | undefined): string[] => {
 			if (!windows || windows.length === 0) return [];
 			const out: string[] = [];
+			// AGE STALE WINDOWS OUT.
+			//
+			// `observedAt` was recorded and never read, so a window that reported
+			// `exhausted` once stayed exhausted on screen forever — the only thing
+			// that refreshes it is another call to that provider, which is exactly
+			// what an operator who just hit a limit has stopped doing. A stale
+			// reading is worse than none: it is a confident wrong answer.
+			const STALE_AFTER_MS = 15 * 60_000;
+			const now = Date.now();
 			for (const w of windows) {
+				if (typeof w.observedAt === "number" && now - w.observedAt > STALE_AFTER_MS) continue;
 				const parts: string[] = [];
 				if (typeof w.remaining === "number" && typeof w.limit === "number") {
 					parts.push(`${formatTokens(w.remaining)} of ${formatTokens(w.limit)} left`);
@@ -4702,7 +4727,7 @@ export async function wireConnectUi(
 				const body = parts.length > 0 ? parts.join(" · ") : "reported, no counts";
 				// `exhausted` is the one state a UI must never soften.
 				const label = w.label || w.kind;
-                const line = `${label}: ${body}`;
+				const line = `${label}: ${body}`;
 				out.push(w.status === "exhausted" ? brand.amber(`${line} — EXHAUSTED`) : brand.dim(line));
 			}
 			return out;
@@ -4814,6 +4839,11 @@ export async function wireConnectUi(
 						`- ${chalk.bold("context:")}  ${ctxStr}\n` +
 						`  ${brand.dim("what the NEXT request sends — this is the one that can run out")}\n` +
 						(reasoningStrUsage ? `- ${chalk.bold("reasoning:")} ${reasoningStrUsage}\n` : "") +
+						// The command named for consumption should answer "how much
+						// have I got left?", not just "how much have I spent?".
+						(formatLimitLines(snap.limits).length > 0
+							? `- ${chalk.bold("limits:")}   ${formatLimitLines(snap.limits).join("\n             ")}\n`
+							: "") +
 						`- ${chalk.bold("thinking:")} ${snap.thinkingLevel}` +
 						(snap.supportsThinking
 							? brand.dim(` (available: ${snap.availableThinkingLevels.join(", ")})`)

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -20,6 +20,8 @@
  */
 
 import { COPILOT_AUTO_MODEL_ID } from "../../agents/github-copilot-transport.js";
+import { describeReasoningVisibility } from "../../agents/reasoning/visibility.js";
+import type { ProviderLimitWindow } from "../../agents/usage/limits.js";
 import { PI_TOOL_CALL, PI_TOOL_RESULT } from "../../agents/pi-dialect.js";
 import process from "node:process";
 import { randomUUID } from "node:crypto";
@@ -1444,15 +1446,28 @@ export async function wireConnectUi(
 		const contentText = contentParts.join("").trim();
 
 		const parts: string[] = [];
+		const vis = lastSnapshot?.reasoning?.visibility;
 		if (showThinking && thinkingText) {
 			// Label what this actually IS. A literal "[thinking]" over an
 			// Anthropic / OpenAI / Grok response is wrong: those return a summary
 			// written by a DIFFERENT model, not the model's own chain of thought.
 			// The visibility rides the state snapshot precisely so the renderer
 			// never has to hardcode provider knowledge.
-			const vis = lastSnapshot?.reasoning?.visibility;
 			const label = vis === "summary" ? "[reasoning summary]" : "[reasoning]";
 			parts.push(`${brand.dim(label)}\n${brand.dim(thinkingText)}`);
+		} else if (showThinking && !thinkingText && (vis === "hidden" || vis === "redacted")) {
+			// REASONING IS ON, THE MODEL REASONED, AND THERE IS NOTHING TO SHOW.
+			//
+			// Rendering nothing here is the worst of the three options: the
+			// operator explicitly asked to see reasoning, the model demonstrably
+			// produced some (the footer is showing a duration and a billed token
+			// count), and the pane stays empty — which reads as "the toggle is
+			// broken" or "it didn't think". Neither is true.
+			//
+			// `hidden` is the DEFAULT on the current Claude generation: the text
+			// is omitted by provider policy and billed anyway. Say that once, in
+			// the operator's words, so an empty pane becomes an explanation.
+			parts.push(brand.dim(`[${describeReasoningVisibility(vis)}]`));
 		}
 		if (contentText) parts.push(contentText);
 		return parts.join("\n\n");
@@ -3480,6 +3495,12 @@ export async function wireConnectUi(
 						`- ${chalk.bold("/usage")} — show token + cost totals for this session\n` +
 						`- ${chalk.bold("/copy [code]")} — copy the last reply (or just its code block)\n` +
 						`- ${chalk.bold("/expand [n]")} — show a truncated tool result in full (1 = most recent)\n` +
+						`- ${chalk.bold("/search <query>")} — search this conversation, including tool results\n` +
+						`- ${chalk.bold("/search --regex <pattern>")} — same, treating the query as a regular expression\n` +
+						`- ${chalk.bold("/export [full]")} — write this transcript to a Markdown file (secrets redacted; \`full\` keeps whole tool results)\n` +
+						`- ${chalk.bold("/rewind [n]")} — go back to one of your earlier messages (no arg = list; conversation only, never files)\n` +
+						`- ${chalk.bold("/flush")} — send everything you queued to the running turn right now\n` +
+						`- ${chalk.bold("/context")} — where this thread's context window is going\n` +
 						`- ${chalk.bold("/steer <text>")} — redirect the running turn (or just type mid-turn)\n` +
 						`- ${chalk.bold("/reasoning <on|off>")} — show/hide the model's reasoning, or press ctrl+t (default: on, remembered)\n` +
 						`- ${chalk.bold("/new")} — start a fresh thread (new session, clean screen, no prior context)\n` +
@@ -4653,6 +4674,91 @@ export async function wireConnectUi(
 		// /usage — render the cumulative usage block from the latest state
 		// snapshot. All fields come from the server's SessionStateSnapshot
 		// — no extra RPC needed.
+		/**
+		 * Provider consumption windows, one line each.
+		 *
+		 * Renders nothing at all when the provider reported none — "unknown" and
+		 * "none left" are opposites, and a bar drawn from absent data claims a
+		 * measurement that was never taken. Counts are shown only when present
+		 * for the same reason: a missing `remaining` must not render as 0.
+		 */
+		const formatLimitLines = (windows: readonly ProviderLimitWindow[] | undefined): string[] => {
+			if (!windows || windows.length === 0) return [];
+			const out: string[] = [];
+			for (const w of windows) {
+				const parts: string[] = [];
+				if (typeof w.remaining === "number" && typeof w.limit === "number") {
+					parts.push(`${formatTokens(w.remaining)} of ${formatTokens(w.limit)} left`);
+				} else if (typeof w.remaining === "number") {
+					parts.push(`${formatTokens(w.remaining)} left`);
+				}
+				if (typeof w.usedFraction === "number") {
+					parts.push(`${Math.round(w.usedFraction * 100)}% used`);
+				}
+				if (typeof w.resetsAt === "number") {
+					const ms = w.resetsAt - Date.now();
+					if (ms > 0) parts.push(`resets in ${formatElapsed(ms)}`);
+				}
+				const body = parts.length > 0 ? parts.join(" · ") : "reported, no counts";
+				// `exhausted` is the one state a UI must never soften.
+				const label = w.label || w.kind;
+                const line = `${label}: ${body}`;
+				out.push(w.status === "exhausted" ? brand.amber(`${line} — EXHAUSTED`) : brand.dim(line));
+			}
+			return out;
+		};
+
+		if (trimmed === "/context") {
+			editor.setText("");
+			const snap = lastSnapshot;
+			if (!snap) {
+				insertBeforeEditor(
+					new Text(`  ${brand.dim("no snapshot yet — the server hasn't reported state")}`, 0, 0),
+				);
+				return;
+			}
+			// WHERE THE WINDOW IS GOING.
+			//
+			// Deliberately reports only what is actually MEASURED. A per-category
+			// split (system prompt / tools / history) would be a better answer,
+			// but the gateway does not measure those separately today and
+			// inventing the split would be worse than admitting its absence —
+			// this whole subsystem exists because confident wrong numbers are the
+			// failure mode.
+			const lines: string[] = [];
+			if (snap.contextTokens != null && snap.contextWindow != null && snap.contextWindow > 0) {
+				const used = snap.contextTokens;
+				const win = snap.contextWindow;
+				const pct = Math.round((used / win) * 100);
+				const left = Math.max(0, win - used);
+				// A 24-cell bar. Coarse on purpose: this answers "am I close?",
+				// and a finer bar would imply a precision the estimate lacks.
+				const filled = Math.max(0, Math.min(24, Math.round((used / win) * 24)));
+				const bar = `${"█".repeat(filled)}${"░".repeat(24 - filled)}`;
+				const colored = pct >= 75 ? brand.amber(bar) : brand.dim(bar);
+				lines.push(`- ${chalk.bold("window:")}   ${colored} ${pct}%`);
+				lines.push(
+					`- ${chalk.bold("used:")}     ${formatTokens(used)} of ${formatTokens(win)} · ${formatTokens(left)} left`,
+				);
+			} else {
+				lines.push(`- ${chalk.bold("window:")}   ${brand.dim("not reported yet — send a message first")}`);
+			}
+			lines.push(`- ${chalk.bold("messages:")} ${snap.messageCount} ${brand.dim("(user + assistant + tool results)")}`);
+			const reasoningCtx = formatReasoningLine({ state: snap.reasoning });
+			if (reasoningCtx) lines.push(`- ${chalk.bold("reasoning:")} ${reasoningCtx}`);
+			lines.push(`- ${chalk.bold("compaction:")} ${brand.dim("automatic — older turns are summarized before the window fills")}`);
+			const limitLines = formatLimitLines(snap.limits);
+			if (limitLines.length > 0) {
+				lines.push(`- ${chalk.bold("provider limits:")}`);
+				for (const l of limitLines) lines.push(`    ${l}`);
+			}
+			lines.push(
+				`  ${brand.dim("context is what the NEXT request sends; /usage shows all-time billing for this thread")}`,
+			);
+			insertBeforeEditor(new Markdown(`${brand.dim("context")}\n${lines.join("\n")}`, 0, 0, markdownTheme));
+			return;
+		}
+
 		if (trimmed === "/usage") {
 			editor.setText("");
 			const snap = lastSnapshot;
@@ -4690,9 +4796,23 @@ export async function wireConnectUi(
 						// so labelling it "turns" over-reported a 5-turn conversation
 						// with tool use as ~40.
 						`- ${chalk.bold("messages:")} ${snap.messageCount}\n` +
-						`- ${chalk.bold("tokens:")}   ${tokenIn} in · ${tokenOut} out · ${tokenTotal} total\n` +
+						// TWO DIFFERENT MEASUREMENTS, AND THEY LOOK CONTRADICTORY.
+						//
+						// `billed` is CUMULATIVE over the whole session, and `in`
+						// counts input + cache reads + cache writes. Every turn
+						// re-sends the entire history, so after 30 messages the sum
+						// is several times the context window — while `context`
+						// reports only what the NEXT request will send.
+						//
+						// Rendered unlabelled ("282,932 in … context: 68k") this
+						// reads as a contradiction, and an operator reasonably
+						// concludes one of the numbers is broken. Neither is. Say
+						// which question each answers, in the line itself.
+						`- ${chalk.bold("billed:")}   ${tokenTotal} tokens all-time this thread\n` +
+						`  ${brand.dim(`${tokenIn} in (incl. cache reads) · ${tokenOut} out · every turn re-sends the history`)}\n` +
 						`- ${chalk.bold("cost:")}     ${costStr}\n` +
 						`- ${chalk.bold("context:")}  ${ctxStr}\n` +
+						`  ${brand.dim("what the NEXT request sends — this is the one that can run out")}\n` +
 						(reasoningStrUsage ? `- ${chalk.bold("reasoning:")} ${reasoningStrUsage}\n` : "") +
 						`- ${chalk.bold("thinking:")} ${snap.thinkingLevel}` +
 						(snap.supportsThinking

--- a/src/core/delta-mode.ts
+++ b/src/core/delta-mode.ts
@@ -40,3 +40,47 @@ export function shouldSendDeltaFrame(d: DeltaFrameDecision): boolean {
 	if (!d.connId) return false;
 	return d.optedIn;
 }
+
+/**
+ * Build the content-stripped variant of a `message_update` frame.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS IS A FUNCTION AND NOT FOUR LINES INSIDE `broadcast()`
+ * ─────────────────────────────────────────────────────────────────────────
+ * It lived inline in `server.ts`, which meant nothing could call it — so the
+ * test that claimed to cover it re-implemented the strip locally and asserted
+ * against its own copy. That copy stripped a bare Pi event; production strips
+ * the nested `{ type, event, payload: { event } }` frame. The test passed
+ * against a shape the gateway never emits, so the PRODUCER side of delta mode
+ * was effectively untested while reporting green.
+ *
+ * Strips only `content` — the cumulative blocks, which are the entire O(n²)
+ * payload. `role`, `timestamp` and `usage` stay: the timestamp is the client's
+ * RENDER KEY (without it a delta cannot be attached to a block) and `usage`
+ * drives the live token counter. Both are a handful of bytes.
+ *
+ * Returns `undefined` when the frame is not a strippable `message_update`, so
+ * the caller can skip the extra stringify entirely rather than serialising a
+ * frame identical to the one it already has.
+ */
+export function stripCumulativeContent(frame: unknown): string | undefined {
+	if (!frame || typeof frame !== "object") return undefined;
+	const f = frame as Record<string, unknown>;
+	if (f.event !== "pi") return undefined;
+	const payload = f.payload as Record<string, unknown> | undefined;
+	const pi = payload?.event as
+		| { type?: string; assistantMessageEvent?: unknown; message?: unknown }
+		| undefined;
+	if (!pi || pi.type !== "message_update") return undefined;
+	if (pi.assistantMessageEvent === undefined || pi.message === undefined) return undefined;
+
+	const msg = pi.message as Record<string, unknown>;
+	const { content: _omitted, ...msgWithoutContent } = msg;
+	return JSON.stringify({
+		...f,
+		payload: {
+			...(payload as Record<string, unknown>),
+			event: { ...(pi as Record<string, unknown>), message: msgWithoutContent },
+		},
+	});
+}

--- a/src/core/delta-stream.test.ts
+++ b/src/core/delta-stream.test.ts
@@ -1,71 +1,46 @@
 /**
  * The delta-streaming payload contract.
  *
- * Verifies the shape the gateway sends to a connection that opted in — the part
- * that matters is WHAT SURVIVES the strip, not just what is removed.
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT THIS FILE CAN AND CANNOT PIN
+ * ─────────────────────────────────────────────────────────────────────────
+ * The PRODUCER — the transform that removes `message.content` for a delta-mode
+ * recipient — is written inline inside `broadcast()` in `src/core/server.ts`
+ * (search: `const { content: _omitted, ...msgWithoutContent }`). It is not
+ * exported and there is no seam to reach it, so no test can call it.
+ *
+ * The previous version of this file papered over that by declaring its own
+ * `stripContent()` and asserting against THAT. It was a copy, not the code:
+ * it stripped a bare pi event rather than rebuilding the `{type, event,
+ * payload:{event}}` frame production actually sends, and it printed a `freed
+ * 118000 tokens`-style shape production never emits. Deleting the real strip
+ * from `server.ts` would not have failed a single assertion in it.
+ *
+ * So this file now tests the two halves that ARE reachable:
+ *
+ *   1. `shouldSendDeltaFrame` — WHO gets a stripped frame (real import).
+ *   2. The CONSUMER — the reconstruction in `connect.ts` that turns a
+ *      content-less `message_update` back into rendered text, driven through
+ *      the real `wireConnectUi` against a fake terminal + gateway. This is
+ *      what "what survives the strip" actually means to an operator: if the
+ *      strip removed the render key, or the client stopped appending, the
+ *      screen goes blank until `message_end`.
+ *
+ * To pin the producer as well, `server.ts` needs the transform lifted into an
+ * exported function (the natural home is `./delta-mode.ts`, e.g.
+ * `stripCumulativeContent(frame)`); that is a production change and is
+ * deliberately not made here.
  */
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { after, describe, it } from "node:test";
 
-import { shouldSendDeltaFrame } from "./delta-mode.js";
+import { TUI, type Component, type Terminal } from "@earendil-works/pi-tui";
 
-/** Mirrors the transform in `broadcast()` for a delta-mode recipient. */
-function stripContent(piEvent: Record<string, unknown>): Record<string, unknown> {
-	const msg = piEvent.message as Record<string, unknown>;
-	const { content: _omitted, ...msgWithoutContent } = msg;
-	return { ...piEvent, message: msgWithoutContent };
-}
-
-const FULL = {
-	type: "message_update",
-	message: {
-		role: "assistant",
-		timestamp: 1_700_000_000_000,
-		usage: { input: 4700, output: 120, cost: { total: 0.02 } },
-		content: [{ type: "text", text: "a very long cumulative reply".repeat(200) }],
-	},
-	assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "y" },
-};
-
-describe("delta-mode payload", () => {
-	it("keeps the render key — a delta with no identity cannot be attached", () => {
-		// `asstKey` is `${depth}:${message.timestamp}`. Strip the timestamp and the
-		// client has a delta it cannot place on any block.
-		const out = stripContent(FULL) as { message: Record<string, unknown> };
-		assert.equal(out.message.timestamp, 1_700_000_000_000);
-		assert.equal(out.message.role, "assistant");
-	});
-
-	it("keeps usage — it drives the live token counter", () => {
-		const out = stripContent(FULL) as { message: { usage?: Record<string, unknown> } };
-		assert.equal(out.message.usage?.output, 120);
-	});
-
-	it("drops only the cumulative content", () => {
-		const out = stripContent(FULL) as { message: Record<string, unknown> };
-		assert.equal("content" in out.message, false);
-	});
-
-	it("keeps the delta itself, which is the whole point", () => {
-		const out = stripContent(FULL) as { assistantMessageEvent?: { delta?: string } };
-		assert.equal(out.assistantMessageEvent?.delta, "y");
-	});
-
-	it("is dramatically smaller than the snapshot it replaces", () => {
-		const before = JSON.stringify(FULL).length;
-		const after = JSON.stringify(stripContent(FULL)).length;
-		assert.ok(after * 20 < before, `expected a big reduction, got ${before} → ${after}`);
-	});
-
-	it("appending deltas reproduces the snapshot text", () => {
-		// The client's reconstruction must equal what apply-by-replace would have
-		// produced, or the two modes disagree.
-		const chunks = ["Hel", "lo ", "wor", "ld"];
-		let acc = "";
-		for (const c of chunks) acc += c;
-		assert.equal(acc, "Hello world");
-	});
-});
+import { shouldSendDeltaFrame, stripCumulativeContent } from "./delta-mode.js";
+import { asstKey } from "../cli/commands/connect-transcript.js";
+import { wireConnectUi } from "../cli/commands/connect.js";
+import type { BrigadeClient } from "../tui/client.js";
+import type { SessionStateSnapshot } from "../protocol.js";
 
 /* ─────────────── who actually receives a stripped frame ─────────────── */
 
@@ -106,4 +81,276 @@ describe("delta frames are OPT-IN", () => {
 			);
 		}
 	});
+});
+
+/* ─────────────── the render key the strip must not remove ─────────────── */
+
+describe("the render key a delta is attached by", () => {
+	// The strip keeps `role` and `timestamp` for exactly one reason: the client
+	// keys the streaming block on `${depth}:${message.timestamp}`. This is the
+	// real function it keys with.
+	it("two deltas of the same message land on the same block", () => {
+		const msg = { role: "assistant", timestamp: 1_700_000_000_000 };
+		assert.equal(asstKey(0, msg), asstKey(0, { ...msg }));
+	});
+
+	it("a frame that lost its timestamp collapses onto a shared key", () => {
+		// Not an error — a fallback. Which is why removing the timestamp is not a
+		// harmless byte saving: two concurrent messages would then share a block
+		// and overwrite each other.
+		assert.equal(asstKey(0, {}), asstKey(0, { timestamp: undefined }));
+		assert.notEqual(asstKey(0, { timestamp: 1 }), asstKey(0, {}));
+	});
+
+	it("a sub-agent's stream is a different block from its parent's", () => {
+		const msg = { timestamp: 1_700_000_000_000 };
+		assert.notEqual(asstKey(0, msg), asstKey(1, msg));
+	});
+});
+
+/* ─────────────── the consumer, driven end to end ─────────────── */
+
+/** A Terminal that renders nowhere. */
+class FakeTerminal implements Terminal {
+	onInput: (data: string) => void = () => {};
+	start(onInput: (data: string) => void): void {
+		this.onInput = onInput;
+	}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(): void {}
+	get columns(): number {
+		return 120;
+	}
+	get rows(): number {
+		return 40;
+	}
+	get kittyProtocolActive(): boolean {
+		return false;
+	}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
+}
+
+const AGENT = "main";
+const SESSION = "agent:main:main";
+
+const SNAPSHOT = {
+	provider: "claude-cli",
+	modelId: "opus-4-8",
+	modelName: "Opus 4.8",
+	thinkingLevel: "off",
+	supportsThinking: true,
+	supportsVision: true,
+	availableThinkingLevels: ["off"],
+	contextUsagePercent: null,
+	totalTokensIn: 0,
+	totalTokensOut: 0,
+	totalCostUsd: 0,
+	isAgentRunning: false,
+	messageCount: 0,
+	agentId: AGENT,
+	agentName: "brigade",
+	sessionKey: SESSION,
+} as unknown as SessionStateSnapshot;
+
+type Handler = (...args: never[]) => void;
+
+async function bootConnectUi(): Promise<{ tui: TUI; pi(event: unknown): void }> {
+	const tui = new TUI(new FakeTerminal());
+	const handlers = new Map<string, Handler[]>();
+	const client = {
+		on(event: string, fn: Handler) {
+			const list = handlers.get(event) ?? [];
+			list.push(fn);
+			handlers.set(event, list);
+			return client;
+		},
+		connect: async () => {},
+		resume: async () => {},
+		close: () => {},
+		request: async (method: string) => {
+			if (method === "get-state") return SNAPSHOT;
+			if (method === "list-models") return [];
+			if (method === "sessions.list" || method === "list-sessions") return [];
+			if (method === "list-agents") return [];
+			return undefined;
+		},
+	};
+	await wireConnectUi(tui, client as unknown as BrigadeClient, AGENT, SESSION);
+	const emit = (event: string, payload: unknown): void => {
+		for (const fn of handlers.get(event) ?? []) (fn as (p: unknown) => void)(payload);
+	};
+	emit("state", SNAPSHOT);
+	return {
+		tui,
+		pi: (event: unknown) =>
+			emit("pi", { event, subagentDepth: 0, agentId: AGENT, sessionId: SESSION }),
+	};
+}
+
+function transcript(tui: TUI): string {
+	const kids = (tui as unknown as { children: Component[] }).children;
+	return kids
+		.map((c) => (c as unknown as { render(width: number): string[] }).render(120).join("\n"))
+		.join("\n");
+}
+
+function stopTimers(tui: TUI): void {
+	for (const child of (tui as unknown as { children: Component[] }).children) {
+		(child as unknown as { stop?: () => void }).stop?.();
+	}
+}
+
+const booted: TUI[] = [];
+after(() => {
+	for (const tui of booted) stopTimers(tui);
+});
+
+/** The exact frame the gateway sends a delta-mode client: NO `message.content`. */
+function deltaFrame(timestamp: number, delta: string): unknown {
+	return {
+		type: "message_update",
+		// `role`, `timestamp` and `usage` survive the strip; `content` does not.
+		message: { role: "assistant", timestamp, usage: { input: 4700, output: 12 } },
+		assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta },
+	};
+}
+
+describe("a delta-mode client reconstructs the reply", () => {
+	it("appending deltas puts the whole sentence on screen", async () => {
+		const { tui, pi } = await bootConnectUi();
+		booted.push(tui);
+		const ts = 1_700_000_000_000;
+		assert.equal(transcript(tui).includes("Hello world"), false, "nothing on screen yet");
+		for (const chunk of ["Hel", "lo ", "wor", "ld"]) pi(deltaFrame(ts, chunk));
+		const screen = transcript(tui);
+		assert.ok(
+			screen.includes("Hello world"),
+			`the accumulated text must render; got:\n${screen.slice(-400)}`,
+		);
+		// One block, not four — every delta of a message shares its render key.
+		assert.equal(screen.split("Hello world").length - 1, 1, "the deltas share one block");
+	});
+
+	it("deltas of two different messages do not bleed into each other", async () => {
+		const { tui, pi } = await bootConnectUi();
+		booted.push(tui);
+		pi(deltaFrame(1_700_000_000_001, "first reply"));
+		pi(deltaFrame(1_700_000_000_002, "second reply"));
+		const screen = transcript(tui);
+		assert.ok(screen.includes("first reply"), "the first message survived");
+		assert.ok(screen.includes("second reply"), "the second message rendered");
+		assert.equal(
+			screen.includes("first replysecond reply"),
+			false,
+			"a new timestamp is a new block, not a continuation",
+		);
+	});
+
+	it("a frame that DOES carry content is authoritative and resets the accumulator", async () => {
+		// message_end, an older gateway, or a resume rebuild. Without the reset,
+		// the delta buffer would be composed on top of the snapshot and the
+		// operator would read the reply twice.
+		const { tui, pi } = await bootConnectUi();
+		booted.push(tui);
+		const ts = 1_700_000_000_003;
+		pi(deltaFrame(ts, "partial answer"));
+		pi({
+			type: "message_end",
+			message: {
+				role: "assistant",
+				timestamp: ts,
+				content: [{ type: "text", text: "the whole answer" }],
+			},
+		});
+		const screen = transcript(tui);
+		assert.ok(screen.includes("the whole answer"), "the snapshot won");
+		assert.equal(screen.includes("partial answer"), false, "the stale delta text is gone");
+	});
+});
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * The PRODUCER side, which was previously untestable.
+ *
+ * The strip lived inline in `server.ts`'s `broadcast()`, so the only way to
+ * "cover" it was to re-implement it in the test — which is what happened, and
+ * the copy stripped a bare Pi event while production strips the nested
+ * `{ type, event, payload: { event } }` frame. It asserted against a shape the
+ * gateway never emits. Now that `stripCumulativeContent` is exported, these
+ * drive the real thing.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/** The frame shape `broadcast()` actually builds. */
+function updateFrame(content: unknown) {
+	return {
+		type: "event",
+		event: "pi",
+		payload: {
+			event: {
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", delta: "hi" },
+				message: {
+					role: "assistant",
+					timestamp: 1730000000000,
+					usage: { input: 10, output: 2 },
+					content,
+				},
+			},
+		},
+	};
+}
+
+it("the cumulative content is removed, and nothing else is", () => {
+	const json = stripCumulativeContent(updateFrame([{ type: "text", text: "a".repeat(5000) }]));
+	assert.ok(json, "a message_update with a delta must produce a stripped variant");
+	const out = JSON.parse(json!);
+	const msg = out.payload.event.message;
+
+	assert.equal(msg.content, undefined, "content is the whole O(n^2) payload");
+	// These three are load-bearing and must survive: the timestamp is the
+	// client's render key, without which a delta cannot attach to a block.
+	assert.equal(msg.role, "assistant");
+	assert.equal(msg.timestamp, 1730000000000);
+	assert.deepEqual(msg.usage, { input: 10, output: 2 });
+	// The envelope is preserved so the client routes it identically.
+	assert.equal(out.event, "pi");
+	assert.equal(out.payload.event.type, "message_update");
+	assert.deepEqual(out.payload.event.assistantMessageEvent, { type: "text_delta", delta: "hi" });
+});
+
+it("the stripped frame is genuinely smaller — the entire point", () => {
+	const frame = updateFrame([{ type: "text", text: "a".repeat(5000) }]);
+	const stripped = stripCumulativeContent(frame)!;
+	assert.ok(
+		stripped.length < JSON.stringify(frame).length / 2,
+		"stripping must remove the bulk, not shuffle it",
+	);
+});
+
+it("frames that are not strippable return undefined rather than a copy", () => {
+	// No delta — a full snapshot the client needs whole.
+	assert.equal(
+		stripCumulativeContent({
+			type: "event",
+			event: "pi",
+			payload: { event: { type: "message_update", message: { role: "assistant" } } },
+		}),
+		undefined,
+	);
+	// A different event kind entirely.
+	assert.equal(
+		stripCumulativeContent({ type: "event", event: "state", payload: { event: {} } }),
+		undefined,
+	);
+	// Junk must never throw on the hottest path in the gateway.
+	for (const junk of [null, undefined, 0, "", [], {}]) {
+		assert.doesNotThrow(() => stripCumulativeContent(junk));
+	}
 });

--- a/src/core/frame-ring.test.ts
+++ b/src/core/frame-ring.test.ts
@@ -125,20 +125,38 @@ test("a top-level pi frame is ordered but rebuilt from the transcript", () => {
 	assert.equal(c.replayOnly, false, "the JSONL transcript already holds it");
 });
 
-test("a sub-agent frame is ordered AND must be retained", () => {
-	// It carries the child's session id and lives in a child transcript the
-	// parent's resume never reads — retention is its only recovery path.
+test("a sub-agent frame is NEITHER sequenced NOR retained", () => {
+	// Briefly it was both, and that was wrong in two ways at once.
+	//
+	// It is tagged with the CHILD's Pi session UUID, while `resume` is called
+	// with an `agent:…` session KEY — so retaining it under one namespace and
+	// replaying from the other means the replay can never fire. Sequencing it
+	// therefore rested on a replay guarantee that did not exist, which is the
+	// exact mistake the "never sequence what you cannot replay" rule forbids.
+	//
+	// It also cost: every `spawn_agent` minted a new per-session counter, and
+	// that map evicts in creation order — so the operator's own long-lived
+	// session, created first, was evicted first, restarting its counter and
+	// repainting the transcript on every connected client.
 	const c = classifyFrame({ event: "pi", subagentDepth: 1 });
+	assert.equal(c.ordered, false);
+	assert.equal(c.replayOnly, false);
+});
+
+test("a depth-0 synthetic frame is ordered AND must be retained", () => {
+	// Minted for a claude-cli turn whose tools run in the binary's own loop, so
+	// it is in no transcript — but unlike a sub-agent frame it carries the
+	// ROUTING session key, which is the key `resume` looks up. That is what
+	// makes it genuinely replayable, and therefore safe to sequence.
+	const c = classifyFrame({ event: "pi", subagentDepth: 0, synthetic: true });
 	assert.equal(c.ordered, true);
 	assert.equal(c.replayOnly, true);
 });
 
-test("a synthetic frame is ordered AND must be retained", () => {
-	// Minted for a claude-cli turn whose tools run in the binary's own loop.
-	// In no transcript at all.
-	const c = classifyFrame({ event: "pi", subagentDepth: 0, synthetic: true });
-	assert.equal(c.ordered, true);
-	assert.equal(c.replayOnly, true);
+test("a synthetic frame at depth > 0 is not retained either", () => {
+	// Same namespace problem as any other sub-agent frame.
+	const c = classifyFrame({ event: "pi", subagentDepth: 2, synthetic: true });
+	assert.equal(c.replayOnly, false);
 });
 
 test("retention implies sequencing — never a seq we cannot replay", () => {
@@ -147,6 +165,7 @@ test("retention implies sequencing — never a seq we cannot replay", () => {
 	for (const input of [
 		{ event: "pi", subagentDepth: 0 },
 		{ event: "pi", subagentDepth: 3 },
+		{ event: "pi", subagentDepth: 2, synthetic: true },
 		{ event: "pi", subagentDepth: 0, synthetic: true },
 		{ event: "approval-request" },
 		{ event: "system-event" },

--- a/src/core/frame-ring.test.ts
+++ b/src/core/frame-ring.test.ts
@@ -1,0 +1,196 @@
+/**
+ * The ring's whole value is the honesty of `complete`. A client that trusts a
+ * partial replay as total silently skips real content, which is worse than the
+ * gap it was trying to repair — so most of these tests are about that flag,
+ * not about storage.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { classifyFrame, FrameRing } from "./frame-ring.js";
+
+test("replays exactly the frames after the cursor, oldest first", () => {
+	const ring = new FrameRing();
+	for (let seq = 1; seq <= 5; seq += 1) ring.retain("s", seq, `{"seq":${seq}}`);
+
+	const { frames, complete } = ring.replayFrom("s", 2);
+	assert.deepEqual(frames.map((f) => f.seq), [3, 4, 5]);
+	assert.equal(complete, true);
+});
+
+test("the retained bytes are the ones that were broadcast", () => {
+	// Re-serializing could reorder keys; the point of a replay is the SAME bytes.
+	const ring = new FrameRing();
+	const json = '{"event":"pi","payload":{"z":1,"a":2}}';
+	ring.retain("s", 1, json);
+	assert.equal(ring.replayFrom("s", 0).frames[0]?.json, json);
+});
+
+test("a cursor already at the head is complete with nothing to send", () => {
+	const ring = new FrameRing();
+	ring.retain("s", 1, "{}");
+	ring.retain("s", 2, "{}");
+	const { frames, complete } = ring.replayFrom("s", 2);
+	assert.deepEqual(frames, []);
+	assert.equal(complete, true);
+});
+
+test("a cursor older than what survived is NOT reported complete", () => {
+	// This is the case that must never lie. Frames 1-2 are gone; a client asking
+	// from 0 cannot be made whole from the ring, and saying otherwise would make
+	// it skip them silently.
+	const ring = new FrameRing({ maxFrames: 3 });
+	for (let seq = 1; seq <= 5; seq += 1) ring.retain("s", seq, `{"seq":${seq}}`);
+
+	const { frames, complete } = ring.replayFrom("s", 0);
+	assert.deepEqual(frames.map((f) => f.seq), [3, 4, 5]);
+	assert.equal(complete, false, "frames 1-2 were evicted — the caller must fall back");
+});
+
+test("an empty or unknown session is never reported complete", () => {
+	const ring = new FrameRing();
+	assert.equal(ring.replayFrom("nope", 0).complete, false);
+	assert.equal(ring.replayFrom(undefined, 0).complete, false);
+});
+
+test("the frame bound evicts oldest first", () => {
+	const ring = new FrameRing({ maxFrames: 3 });
+	for (let seq = 1; seq <= 10; seq += 1) ring.retain("s", seq, `{"seq":${seq}}`);
+	assert.equal(ring.countFor("s"), 3);
+	assert.deepEqual(ring.replayFrom("s", 0).frames.map((f) => f.seq), [8, 9, 10]);
+});
+
+test("the byte bound evicts even when the frame count is fine", () => {
+	const ring = new FrameRing({ maxFrames: 1000, maxBytes: 100 });
+	for (let seq = 1; seq <= 10; seq += 1) ring.retain("s", seq, "x".repeat(40));
+	// 40 bytes each, 100-byte ceiling — only the newest few survive.
+	assert.ok(ring.countFor("s") <= 3, `expected <=3 retained, got ${ring.countFor("s")}`);
+});
+
+test("a single frame larger than the whole budget is still retained", () => {
+	// Dropping it would leave a hole nothing can fill, which is worse than
+	// briefly exceeding a soft ceiling.
+	const ring = new FrameRing({ maxFrames: 10, maxBytes: 10 });
+	ring.retain("s", 1, "x".repeat(5000));
+	assert.equal(ring.countFor("s"), 1);
+});
+
+test("sessions are bounded, coldest dropped first", () => {
+	const ring = new FrameRing({ maxSessions: 2 });
+	ring.retain("a", 1, "{}");
+	ring.retain("b", 1, "{}");
+	ring.retain("c", 1, "{}");
+	assert.equal(ring.size, 2);
+	assert.equal(ring.countFor("a"), 0, "the coldest session is dropped");
+	assert.equal(ring.countFor("c"), 1);
+});
+
+test("writing to a session keeps it warm against eviction", () => {
+	const ring = new FrameRing({ maxSessions: 2 });
+	ring.retain("a", 1, "{}");
+	ring.retain("b", 1, "{}");
+	ring.retain("a", 2, "{}"); // touch "a"
+	ring.retain("c", 1, "{}"); // evicts the coldest, which is now "b"
+	assert.equal(ring.countFor("a"), 2);
+	assert.equal(ring.countFor("b"), 0);
+});
+
+test("forget drops a session outright", () => {
+	const ring = new FrameRing();
+	ring.retain("s", 1, "{}");
+	ring.forget("s");
+	assert.equal(ring.countFor("s"), 0);
+});
+
+test("malformed input never throws on the broadcast path", () => {
+	const ring = new FrameRing();
+	assert.doesNotThrow(() => {
+		ring.retain(undefined, 1, "{}");
+		ring.retain("s", Number.NaN, "{}");
+		ring.retain("s", Number.POSITIVE_INFINITY, "{}");
+	});
+	assert.equal(ring.countFor("s"), 0, "non-finite seqs are refused, not stored");
+});
+
+/* ─── classifyFrame: the rule that decides what is recoverable ─────────────
+ * Previously inline in `broadcast()`, where covering it meant booting a
+ * gateway — so the decision determining what survives a disconnect had no
+ * direct test, on the one path where being wrong loses output in silence.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+test("a top-level pi frame is ordered but rebuilt from the transcript", () => {
+	const c = classifyFrame({ event: "pi", subagentDepth: 0 });
+	assert.equal(c.ordered, true);
+	assert.equal(c.replayOnly, false, "the JSONL transcript already holds it");
+});
+
+test("a sub-agent frame is ordered AND must be retained", () => {
+	// It carries the child's session id and lives in a child transcript the
+	// parent's resume never reads — retention is its only recovery path.
+	const c = classifyFrame({ event: "pi", subagentDepth: 1 });
+	assert.equal(c.ordered, true);
+	assert.equal(c.replayOnly, true);
+});
+
+test("a synthetic frame is ordered AND must be retained", () => {
+	// Minted for a claude-cli turn whose tools run in the binary's own loop.
+	// In no transcript at all.
+	const c = classifyFrame({ event: "pi", subagentDepth: 0, synthetic: true });
+	assert.equal(c.ordered, true);
+	assert.equal(c.replayOnly, true);
+});
+
+test("retention implies sequencing — never a seq we cannot replay", () => {
+	// The invariant the whole design turns on. A seq on an unreplayable frame
+	// makes every dropped decoration an unrepairable gap and thrashes resume.
+	for (const input of [
+		{ event: "pi", subagentDepth: 0 },
+		{ event: "pi", subagentDepth: 3 },
+		{ event: "pi", subagentDepth: 0, synthetic: true },
+		{ event: "approval-request" },
+		{ event: "system-event" },
+		{ event: "state" },
+		{ event: "log" },
+	]) {
+		const c = classifyFrame(input);
+		if (c.replayOnly) assert.equal(c.ordered, true, `${JSON.stringify(input)} retained but unsequenced`);
+	}
+});
+
+test("approval-request and system-event are ordered, and not retained here", () => {
+	// Both already have their own recovery path in `resume` (pending approvals
+	// are re-listed; system-events keep a bounded tail), so duplicating them in
+	// the ring would double-deliver on reconnect.
+	for (const event of ["approval-request", "system-event"]) {
+		const c = classifyFrame({ event });
+		assert.equal(c.ordered, true, event);
+		assert.equal(c.replayOnly, false, event);
+	}
+});
+
+test("unordered side-channels stay unordered", () => {
+	// `state` is a self-healing cumulative snapshot; `error`/`log` are not the
+	// transcript. Sequencing them would invent gaps that mean nothing.
+	for (const event of ["state", "error", "log"]) {
+		const c = classifyFrame({ event });
+		assert.equal(c.ordered, false, event);
+		assert.equal(c.replayOnly, false, event);
+	}
+});
+
+test("a non-pi frame is never treated as a sub-agent frame", () => {
+	// `subagentDepth` is only meaningful on `pi`; a stray value on another event
+	// must not smuggle it into retention.
+	const c = classifyFrame({ event: "state", subagentDepth: 4, synthetic: true });
+	assert.equal(c.ordered, false);
+	assert.equal(c.replayOnly, false);
+});
+
+test("a malformed depth degrades to top-level, never throws", () => {
+	for (const depth of [Number.NaN, undefined, -1]) {
+		const c = classifyFrame({ event: "pi", subagentDepth: depth as number | undefined });
+		assert.equal(c.ordered, true);
+		assert.equal(c.replayOnly, false);
+	}
+});

--- a/src/core/frame-ring.ts
+++ b/src/core/frame-ring.ts
@@ -1,0 +1,227 @@
+/**
+ * A bounded, per-session ring of ordered frames — the thing that makes
+ * `resume(sinceSeq)` able to replay what a client actually missed.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS EXISTS, AND WHY IT IS NOT "JUST STAMP EVERYTHING WITH A SEQ"
+ * ─────────────────────────────────────────────────────────────────────────
+ * Brigade's ordered stream is gap-DETECTABLE but only partly gap-REPAIRABLE.
+ * A client tracks the last seq it saw per session; a jump means it missed a
+ * frame and it calls `resume`. Resume then rebuilds from the JSONL transcript,
+ * which is the single source of truth — for anything the transcript contains.
+ *
+ * Two kinds of frame it does NOT contain:
+ *
+ *   • SUB-AGENT frames (`subagentDepth > 0`). They carry the child's own
+ *     session id and live in a separate child transcript that the parent's
+ *     resume never reads.
+ *   • SYNTHETIC frames — the tool events Brigade mints for a `claude-cli` turn,
+ *     whose tools run inside the binary's own loop via the MCP route. They are
+ *     real work the operator watched happen, and they are in no transcript at
+ *     all.
+ *
+ * Both were therefore left UNSEQUENCED, and that was the correct call at the
+ * time: stamping a seq on a frame you cannot replay turns every dropped
+ * decoration into an unrepairable gap, and the client resyncs forever. You
+ * cannot sequence a stream you cannot replay.
+ *
+ * So this closes the loop from the other end. Buffer those frames, bounded, and
+ * resume can hand back the exact bytes for a named cursor — at which point
+ * sequencing them becomes safe and `docs/reliable-streaming.md`'s promise that
+ * nothing emitted is lost finally covers sub-agent output too.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT IS DELIBERATELY *NOT* BUFFERED
+ * ─────────────────────────────────────────────────────────────────────────
+ * Top-level `message_update` frames. They are cumulative — each carries the
+ * whole message so far — so buffering a long reply costs O(n²) memory to
+ * redeliver something `resume` already returns from the transcript, better.
+ * The transcript is the right recovery path for anything it holds; this ring
+ * exists strictly for what it does not.
+ *
+ * That means a replay can be PARTIAL: the ring may hold frames 7 and 9 while 8
+ * was a `message_update`. `replayFrom` reports that honestly via `complete`
+ * rather than implying the cursor was fully satisfied, because a client that
+ * believes a partial replay was total would silently skip real content.
+ */
+
+/** One retained frame: its sequence, and the exact bytes that were broadcast. */
+export interface RetainedFrame {
+	seq: number;
+	/** The serialized frame, byte-identical to what subscribers received. */
+	json: string;
+}
+
+export interface FrameRingLimits {
+	/** Frames retained per session. */
+	maxFrames: number;
+	/** Bytes retained per session. Whichever bound trips first wins. */
+	maxBytes: number;
+	/** Distinct sessions retained before the coldest are dropped. */
+	maxSessions: number;
+}
+
+export const DEFAULT_FRAME_RING_LIMITS: FrameRingLimits = {
+	// A sub-agent fan-out is bursty but short. 256 frames covers a deep nested
+	// run; past that the transcript-projection fallback takes over, which is a
+	// degraded-but-correct recovery rather than a wrong one.
+	maxFrames: 256,
+	// Hard ceiling regardless of count, because one frame can be large. 512 KiB
+	// per session bounds the worst case at a few hundred MiB across the session
+	// cap — and the session cap is what actually holds the line.
+	maxBytes: 512 * 1024,
+	// Matches the gateway's existing RECOVERY_SESSION_MAX so recovery state ages
+	// out together rather than in two different rhythms.
+	maxSessions: 512,
+};
+
+interface SessionRing {
+	frames: RetainedFrame[];
+	bytes: number;
+}
+
+/**
+ * Per-session retention of replayable frames.
+ *
+ * Insertion-ordered `Map`, re-inserted on write, so the first key is always the
+ * least-recently-written session — the same LRU discipline the gateway's other
+ * recovery maps use.
+ */
+export class FrameRing {
+	private readonly sessions = new Map<string, SessionRing>();
+	private readonly limits: FrameRingLimits;
+
+	constructor(limits: Partial<FrameRingLimits> = {}) {
+		this.limits = { ...DEFAULT_FRAME_RING_LIMITS, ...limits };
+	}
+
+	/**
+	 * Retain one frame for a session.
+	 *
+	 * Callers pass the already-serialized JSON so the ring stores exactly what
+	 * went out — a re-serialization could differ in key order and defeat the
+	 * point of replaying "the same bytes".
+	 */
+	retain(sessionId: string | undefined, seq: number, json: string): void {
+		if (!sessionId || !Number.isFinite(seq)) return;
+		const ring = this.sessions.get(sessionId) ?? { frames: [], bytes: 0 };
+		this.sessions.delete(sessionId); // LRU touch
+		ring.frames.push({ seq, json });
+		ring.bytes += json.length;
+		// Oldest-first eviction on either bound. A single frame larger than the
+		// byte cap is still retained (the loop stops at one frame) — dropping it
+		// would leave a hole nothing can fill, which is worse than briefly
+		// exceeding a soft ceiling.
+		while (
+			ring.frames.length > this.limits.maxFrames ||
+			(ring.bytes > this.limits.maxBytes && ring.frames.length > 1)
+		) {
+			const dropped = ring.frames.shift();
+			if (!dropped) break;
+			ring.bytes -= dropped.json.length;
+		}
+		this.sessions.set(sessionId, ring);
+		while (this.sessions.size > this.limits.maxSessions) {
+			const coldest = this.sessions.keys().next().value as string | undefined;
+			if (coldest === undefined) break;
+			this.sessions.delete(coldest);
+		}
+	}
+
+	/**
+	 * Frames after `sinceSeq`, oldest first.
+	 *
+	 * `complete` is the honest part of this API. It is true only when the ring
+	 * can prove it still holds everything after the cursor — i.e. the oldest
+	 * frame retained is the very next one the client expects. If the ring has
+	 * been trimmed past that point, some frames are gone for good and the caller
+	 * must fall back to the transcript rather than pretend the gap was closed.
+	 *
+	 * A cursor at or beyond the newest retained frame is `complete` with nothing
+	 * to send: the client is already current.
+	 */
+	replayFrom(sessionId: string | undefined, sinceSeq: number): { frames: RetainedFrame[]; complete: boolean } {
+		if (!sessionId) return { frames: [], complete: false };
+		const ring = this.sessions.get(sessionId);
+		if (!ring || ring.frames.length === 0) {
+			// Nothing retained. Only "complete" if the caller is not actually
+			// behind — which this ring cannot know, so say no and let the caller
+			// compare against headSeq.
+			return { frames: [], complete: false };
+		}
+		const oldest = ring.frames[0]!.seq;
+		const frames = ring.frames.filter((f) => f.seq > sinceSeq);
+		// Everything the client is missing is still here iff the ring's oldest
+		// retained frame is no newer than the first frame it expects.
+		const complete = oldest <= sinceSeq + 1;
+		return { frames, complete };
+	}
+
+	/** Drop a session's retained frames (session deleted, or state reset). */
+	forget(sessionId: string): void {
+		this.sessions.delete(sessionId);
+	}
+
+	/** Retained frame count for a session — for tests and diagnostics. */
+	countFor(sessionId: string): number {
+		return this.sessions.get(sessionId)?.frames.length ?? 0;
+	}
+
+	get size(): number {
+		return this.sessions.size;
+	}
+}
+
+/* ───────────────────────── which frames are which ───────────────────────── */
+
+export interface FrameClassInput {
+	/** The event kind: `pi`, `approval-request`, `system-event`, `state`, … */
+	event: string;
+	/** Nesting depth for `pi` frames. 0 is the operator's own turn. */
+	subagentDepth?: number;
+	/** Minted by Brigade rather than emitted by Pi (the claude-cli tool plane). */
+	synthetic?: boolean;
+}
+
+export interface FrameClass {
+	/** Carries a monotonic per-session `seq`, so a client can detect a gap. */
+	ordered: boolean;
+	/** Must be RETAINED to be recoverable — no transcript can rebuild it. */
+	replayOnly: boolean;
+}
+
+/**
+ * Decide whether a frame is sequenced, and whether it must be retained.
+ *
+ * Extracted from `broadcast()` so it can be tested at all. Inline, the only way
+ * to cover it was to boot a gateway; the practical result was that the rule
+ * which decides what is recoverable had no direct test, on the exact path where
+ * being wrong loses an operator's output silently.
+ *
+ * The two flags are not independent: `replayOnly` implies `ordered`, because
+ * retention is precisely what makes sequencing those frames safe.
+ */
+export function classifyFrame(input: FrameClassInput): FrameClass {
+	const isPi = input.event === "pi";
+	// Clamped at 0. A negative depth is meaningless, and left unclamped it fell
+	// through BOTH branches below — `depth > 0` false so not replay-only, and
+	// `depth === 0` false so not top-level — quietly dropping the frame out of
+	// the ordered stream altogether. A frame that vanishes from the sequence is
+	// exactly the failure this subsystem exists to prevent.
+	const rawDepth = isPi ? Number(input.subagentDepth) : 0;
+	const depth = Number.isFinite(rawDepth) && rawDepth > 0 ? rawDepth : 0;
+	const synthetic = isPi && input.synthetic === true;
+
+	// No transcript holds these: a sub-agent writes to its own child transcript
+	// that the parent's `resume` never reads, and a synthetic frame is minted by
+	// Brigade for a backend whose tools run outside Pi's loop entirely.
+	const replayOnly = isPi && (depth > 0 || synthetic);
+
+	const ordered =
+		(isPi && depth === 0 && !synthetic) ||
+		replayOnly ||
+		input.event === "approval-request" ||
+		input.event === "system-event";
+
+	return { ordered, replayOnly };
+}

--- a/src/core/frame-ring.ts
+++ b/src/core/frame-ring.ts
@@ -10,25 +10,34 @@
  * frame and it calls `resume`. Resume then rebuilds from the JSONL transcript,
  * which is the single source of truth — for anything the transcript contains.
  *
- * Two kinds of frame it does NOT contain:
+ * The frames it does NOT contain are SYNTHETIC ones — the tool events Brigade
+ * mints for a `claude-cli` turn, whose tools run inside the binary's own loop
+ * via the MCP route. They are real work the operator watched happen and they
+ * are in no transcript at all, but they carry the ROUTING session key, so
+ * `resume` can find them again.
  *
- *   • SUB-AGENT frames (`subagentDepth > 0`). They carry the child's own
- *     session id and live in a separate child transcript that the parent's
- *     resume never reads.
- *   • SYNTHETIC frames — the tool events Brigade mints for a `claude-cli` turn,
- *     whose tools run inside the binary's own loop via the MCP route. They are
- *     real work the operator watched happen, and they are in no transcript at
- *     all.
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY SUB-AGENT FRAMES ARE *NOT* HERE, HAVING BRIEFLY BEEN
+ * ─────────────────────────────────────────────────────────────────────────
+ * They look like the same case and they are not, for one reason: a sub-agent
+ * frame is tagged with the CHILD's Pi session UUID, while `resume` is called
+ * with an `agent:…` session KEY. Retaining under one namespace and replaying
+ * from the other means the replay can never fire — so sequencing them would
+ * rest on a guarantee that does not exist, which is exactly the mistake the
+ * original "do not sequence what you cannot replay" rule forbids.
  *
- * Both were therefore left UNSEQUENCED, and that was the correct call at the
- * time: stamping a seq on a frame you cannot replay turns every dropped
- * decoration into an unrepairable gap, and the client resyncs forever. You
- * cannot sequence a stream you cannot replay.
+ * Sequencing them also had costs the promise was supposed to justify: every
+ * `spawn_agent` minted a new entry in the gateway's per-session counter map,
+ * which evicts in CREATION order — so the operator's own long-lived session,
+ * created first, was evicted first, restarting its counter and triggering a
+ * full transcript repaint on every connected client. And a terminal `agent_end`
+ * frame carries the child's entire transcript, which the oversize carve-out
+ * below would retain permanently on a session that never receives another
+ * frame.
  *
- * So this closes the loop from the other end. Buffer those frames, bounded, and
- * resume can hand back the exact bytes for a named cursor — at which point
- * sequencing them becomes safe and `docs/reliable-streaming.md`'s promise that
- * nothing emitted is lost finally covers sub-agent output too.
+ * Making sub-agent replay real means teaching `resume` the child namespace and
+ * having a client that actually sends a cursor. Until both exist, retaining
+ * them is pure cost, so they stay unsequenced and unretained as before.
  *
  * ─────────────────────────────────────────────────────────────────────────
  * WHAT IS DELIBERATELY *NOT* BUFFERED
@@ -40,9 +49,15 @@
  * exists strictly for what it does not.
  *
  * That means a replay can be PARTIAL: the ring may hold frames 7 and 9 while 8
- * was a `message_update`. `replayFrom` reports that honestly via `complete`
- * rather than implying the cursor was fully satisfied, because a client that
- * believes a partial replay was total would silently skip real content.
+ * was a `message_update` recoverable from the transcript instead.
+ *
+ * `complete` answers exactly one question — "is the oldest frame I still hold
+ * the next one this cursor expects?" — and deliberately NOT "are there interior
+ * gaps?". Interior gaps are expected by design here, because the frames that
+ * create them are the ones the transcript rebuilds better. A caller must apply
+ * the transcript FIRST and treat these frames as an overlay; `complete: true`
+ * means "nothing has aged out from under your cursor", never "this is every
+ * frame in that range".
  */
 
 /** One retained frame: its sequence, and the exact bytes that were broadcast. */
@@ -212,14 +227,15 @@ export function classifyFrame(input: FrameClassInput): FrameClass {
 	const depth = Number.isFinite(rawDepth) && rawDepth > 0 ? rawDepth : 0;
 	const synthetic = isPi && input.synthetic === true;
 
-	// No transcript holds these: a sub-agent writes to its own child transcript
-	// that the parent's `resume` never reads, and a synthetic frame is minted by
-	// Brigade for a backend whose tools run outside Pi's loop entirely.
-	const replayOnly = isPi && (depth > 0 || synthetic);
+	// SYNTHETIC DEPTH-0 FRAMES ONLY. Sub-agent frames are deliberately excluded
+	// again — see the header for the full account. In short: they are retained
+	// under the child's Pi session UUID while `resume` reads by session key, so
+	// they were sequenced on a promise of replayability that never held, and
+	// sequencing them flooded the gateway's per-session counter map.
+	const replayOnly = isPi && depth === 0 && synthetic;
 
 	const ordered =
-		(isPi && depth === 0 && !synthetic) ||
-		replayOnly ||
+		(isPi && depth === 0) ||
 		input.event === "approval-request" ||
 		input.event === "system-event";
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -2999,12 +2999,13 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				if (Array.isArray(blocks)) {
 					for (const b of blocks) {
 						if (b?.type !== "thinking") continue;
-						const prev = reasoningTracker.snapshot(agentIdForTurn, sessionKeyForTurn)?.visibility ?? "summary";
-						reasoningTracker.setVisibility(
-							agentIdForTurn,
-							sessionKeyForTurn,
-							refineReasoningVisibility(prev, b),
-						);
+						// Record what the block REVEALED; never overwrite what the
+						// backend can return. Refining into `visibility` meant the
+						// first empty reasoning item pinned the session to `hidden`
+						// for the rest of the turn — `refineReasoningVisibility`
+						// never widens — so a later block carrying a real summary
+						// rendered under a label saying reasoning was never exposed.
+						reasoningTracker.noteThinkingBlock(agentIdForTurn, sessionKeyForTurn, b);
 					}
 				}
 			} else if (piEvent.type === "agent_start" || piEvent.type === "agent_end") {
@@ -4719,12 +4720,21 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				// Replaying nothing and reporting incomplete is the safe answer:
 				// it degrades to the transcript, which is always correct.
 				const cursor = typeof p.sinceSeq === "number" ? p.sinceSeq : undefined;
-				const replay =
-					cursor !== undefined && cursor >= 0 && cursor <= headSeq
-						? frameRing.replayFrom(targetSessionKey, cursor)
-						: cursor !== undefined
-							? { frames: [], complete: false }
-							: undefined;
+				const replay = ((): { frames: { json: string }[]; complete: boolean } | undefined => {
+					if (cursor === undefined) return undefined;
+					// A cursor outside this epoch's range describes a stream this
+					// gateway never emitted. Degrade to the transcript, which is
+					// always correct.
+					if (cursor < 0 || cursor > headSeq) return { frames: [], complete: false };
+					// ALREADY CURRENT. The ring cannot know this — it only sees its
+					// own contents — so the comparison belongs here, where `headSeq`
+					// is in scope. Without it every resume of a perfectly healthy
+					// session (no sub-agents, no synthetic frames, so nothing ever
+					// retained) reported `replayComplete: false`, telling a
+					// conforming client that data had been lost when none had.
+					if (cursor === headSeq) return { frames: [], complete: true };
+					return frameRing.replayFrom(targetSessionKey, cursor);
+				})();
 				return {
 					sessionKey: targetSessionKey,
 					agentId: targetAgentId,

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -80,6 +80,7 @@ import { createMcpHttpRoute } from "../agents/mcp/http-route.js";
 import { createMcpTurnRegistry, setActiveMcpToolPlaneHost } from "../agents/mcp/tool-plane-host.js";
 import { DEFAULT_MAX_BODY_BYTES, DEFAULT_TIMEOUT_MS, readBodyWithLimit } from "./webhook-guards.js";
 import { shouldSendDeltaFrame, stripCumulativeContent } from "./delta-mode.js";
+import { classifyFrame, FrameRing } from "./frame-ring.js";
 import {
 	abandonedByRewind,
 	filesTouchedAfter,
@@ -1965,8 +1966,12 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 			: isBoot
 				? cachedThinkingLevels
 				: rt.model ? deriveThinkingLevels(rt.model) : [];
+		// Computed once: the provider this snapshot actually reports (pin-aware),
+		// and the reasoning state (previously built twice per snapshot).
+		const snapshotProvider = pin?.provider ?? rt.provider;
+		const reasoningSnapshot = reasoningTracker.snapshot(targetAgentId, targetSessionKey);
 		return {
-			provider: pin?.provider ?? rt.provider,
+			provider: snapshotProvider,
 			modelId: pin?.modelId ?? rt.modelId,
 			modelName: effectiveModel?.name ?? pin?.modelId,
 			thinkingLevel: rt.thinkingLevel,
@@ -1980,9 +1985,7 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 			contextUsagePercent: lastContextUsagePercent,
 			contextTokens: lastContextTokens,
 			contextWindow: lastContextWindow,
-			...(reasoningTracker.snapshot(targetAgentId, targetSessionKey)
-				? { reasoning: reasoningTracker.snapshot(targetAgentId, targetSessionKey)! }
-				: {}),
+			...(reasoningSnapshot ? { reasoning: reasoningSnapshot } : {}),
 			// PROVIDER CONSUMPTION WINDOWS.
 			//
 			// Recorded for every backend from the one `streamFn` all of them go
@@ -1993,15 +1996,13 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 			//
 			// Omitted entirely when the provider reports no headers. "Unknown" and
 			// "exhausted" must never render the same way.
+			// Resolved from the SAME provider this snapshot reports, which honours
+			// the session's model pin. Reading the agent runtime directly showed
+			// the agent's provider limits beside a pinned model from a different
+			// provider — precisely the mismatch this block exists to avoid.
 			...(() => {
-				try {
-					const provider = getAgentRuntime(targetAgentId)?.provider;
-					if (!provider) return {};
-					const windows = getLimitsForProvider(provider);
-					return windows.length > 0 ? { limits: windows } : {};
-				} catch {
-					return {};
-				}
+				const windows = snapshotProvider ? getLimitsForProvider(snapshotProvider) : [];
+				return windows.length > 0 ? { limits: windows } : {};
 			})(),
 			// Per-binding, not process-wide: the snapshot already resolved which
 			// agent + session this client is bound to, and usage now honours that.
@@ -2195,6 +2196,16 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 	const seqCounters = new Map<string, number>();
 
 	/**
+	 * Replayable retention for the frames the TRANSCRIPT cannot rebuild.
+	 *
+	 * Sub-agent and synthetic frames were deliberately left unsequenced because
+	 * a seq you cannot replay turns every dropped decoration frame into an
+	 * unrepairable gap. This ring is the other half of that trade: retain the
+	 * bytes, and sequencing them becomes safe. See `frame-ring.ts`.
+	 */
+	const frameRing = new FrameRing();
+
+	/**
 	 * Bounded per-session tail of recent `system-event` notices (cron announces /
 	 * channel-health), so a client that was disconnected when one fired can still
 	 * recover it via `resume`. Oldest-first, capped at RECENT_SYSTEM_EVENTS_MAX.
@@ -2362,10 +2373,27 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		//  - `state` (self-healing cumulative snapshot), `error`, `log` (on disk).
 		const subDepth = event === "pi" ? Number((payload as { subagentDepth?: number }).subagentDepth) || 0 : 0;
 		const isSyntheticPi = event === "pi" && (payload as { synthetic?: boolean }).synthetic === true;
-		const isOrderedFrame =
-			(event === "pi" && subDepth === 0 && !isSyntheticPi) ||
-			event === "approval-request" ||
-			event === "system-event";
+		// Sub-agent and synthetic `pi` frames ARE now ordered. They were excluded
+		// for a sound reason — you cannot sequence a stream you cannot replay —
+		// and `frameRing` removes exactly that objection by retaining their bytes
+		// for `resume(sinceSeq)`.
+		//
+		// They are sequenced under their OWN session id, not the parent's. That
+		// keeps each stream independently gap-detectable: a client watching only
+		// the parent still sees an unbroken parent sequence, and a client that
+		// also watches the child (delivery rule 3, `parentSessionKey`) tracks the
+		// child's counter separately. Folding them into the parent's counter
+		// would make every unsubscribed child frame look like a parent gap and
+		// resync-thrash exactly the clients that opted out.
+		// The rule lives in `frame-ring.ts` so it is directly testable — inline,
+		// covering it meant booting a gateway, so the decision that determines
+		// what is recoverable had no test on the path where being wrong loses
+		// output silently.
+		const { ordered: isOrderedFrame, replayOnly: isReplayOnly } = classifyFrame({
+			event,
+			subagentDepth: subDepth,
+			synthetic: isSyntheticPi,
+		});
 		const seq = isOrderedFrame ? nextSeq(seqCounters, frameSessionId) : undefined;
 		// Retain a bounded per-session tail of system-events for `resume` recovery.
 		// delete+set moves this session to the end of the Map (LRU touch) so the
@@ -2393,6 +2421,20 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		// (a headless cron or channel turn).
 		let fullJson: string | undefined;
 		const json = (): string => (fullJson ??= JSON.stringify(frame));
+		// RETAIN ONLY WHAT THE TRANSCRIPT CANNOT REBUILD.
+		//
+		// Sub-agent and synthetic frames exist in no JSONL, so `resume` can only
+		// return them from here. Top-level `message_update`s are deliberately not
+		// retained: they are cumulative, so buffering a long reply would cost
+		// O(n^2) memory to redeliver what the transcript already returns better —
+		// the exact cost delta mode exists to remove.
+		//
+		// This forces serialization for these frames even when every recipient is
+		// in delta mode. That is the intended trade: they are a small minority of
+		// traffic, and un-replayable sub-agent output is the hole being closed.
+		if (isReplayOnly && seq !== undefined && frameSessionId) {
+			frameRing.retain(frameSessionId, seq, json());
+		}
 		// Delta variant, built ONLY when some connection asked for it and this
 		// frame actually carries a delta. One extra stringify per qualifying
 		// broadcast (measured at GiB/s — far cheaper than the bytes it removes),
@@ -4664,11 +4706,36 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 						...(a.agentId !== undefined ? { agentId: a.agentId } : {}),
 						...(a.sessionId !== undefined ? { sessionId: a.sessionId } : {}),
 					})) as EventPayload["approval-request"][];
+				// CURSOR REPLAY, for the streams the transcript cannot rebuild.
+				//
+				// Only meaningful within one gateway epoch: a restart resets the
+				// seq counters to 0, so an old cursor would replay the wrong
+				// frames. The client learns the epoch from `HelloOk` and from this
+				// response and discards a stale cursor — but the server must not
+				// depend on it having done so, hence the head check below.
+				//
+				// A cursor AHEAD of head means the client is describing a stream
+				// this gateway never emitted (a restart it has not noticed yet).
+				// Replaying nothing and reporting incomplete is the safe answer:
+				// it degrades to the transcript, which is always correct.
+				const cursor = typeof p.sinceSeq === "number" ? p.sinceSeq : undefined;
+				const replay =
+					cursor !== undefined && cursor >= 0 && cursor <= headSeq
+						? frameRing.replayFrom(targetSessionKey, cursor)
+						: cursor !== undefined
+							? { frames: [], complete: false }
+							: undefined;
 				return {
 					sessionKey: targetSessionKey,
 					agentId: targetAgentId,
 					messages: messages as WireMessage[],
 					headSeq,
+					...(replay
+						? {
+								replayedFrames: replay.frames.map((f) => f.json),
+								replayComplete: replay.complete,
+							}
+						: {}),
 					pendingApprovals,
 					recentSystemEvents: recentSystemEvents.get(targetSessionKey) ?? [],
 					epoch: gatewayEpoch,
@@ -5452,6 +5519,7 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 					forgetSessionState: (forgetAgentId: string, forgetSessionKey: string) => {
 						usageLedger.forget(forgetAgentId, forgetSessionKey);
 						reasoningTracker.forget(forgetAgentId, forgetSessionKey);
+						frameRing.forget(forgetSessionKey);
 					},
 				},
 			),

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -79,7 +79,7 @@ import { composeAttachmentTurn } from "./prompt-attachments.js";
 import { createMcpHttpRoute } from "../agents/mcp/http-route.js";
 import { createMcpTurnRegistry, setActiveMcpToolPlaneHost } from "../agents/mcp/tool-plane-host.js";
 import { DEFAULT_MAX_BODY_BYTES, DEFAULT_TIMEOUT_MS, readBodyWithLimit } from "./webhook-guards.js";
-import { shouldSendDeltaFrame } from "./delta-mode.js";
+import { shouldSendDeltaFrame, stripCumulativeContent } from "./delta-mode.js";
 import {
 	abandonedByRewind,
 	filesTouchedAfter,
@@ -175,6 +175,7 @@ import { UsageLedger } from "../agents/usage/ledger.js";
 import { ReasoningTracker } from "../agents/reasoning/reasoning-state.js";
 import { resolveAgentIdFromSessionKey } from "../agents/routing/session-key.js";
 import { initialReasoningVisibility, refineReasoningVisibility } from "../agents/reasoning/visibility.js";
+import { getLimitsForProvider } from "../agents/usage/limits.js";
 import { classifyBillingModeWithAuth } from "../agents/usage/billing-mode.js";
 import {
 	estimateContextTokensFromMessages,
@@ -1982,6 +1983,26 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 			...(reasoningTracker.snapshot(targetAgentId, targetSessionKey)
 				? { reasoning: reasoningTracker.snapshot(targetAgentId, targetSessionKey)! }
 				: {}),
+			// PROVIDER CONSUMPTION WINDOWS.
+			//
+			// Recorded for every backend from the one `streamFn` all of them go
+			// through (`payload-mutators`' `onResponse`), so this is not an
+			// Anthropic-only feature. Scoped to the provider actually serving this
+			// binding — showing another provider's remaining quota next to this
+			// session's model would be worse than showing nothing.
+			//
+			// Omitted entirely when the provider reports no headers. "Unknown" and
+			// "exhausted" must never render the same way.
+			...(() => {
+				try {
+					const provider = getAgentRuntime(targetAgentId)?.provider;
+					if (!provider) return {};
+					const windows = getLimitsForProvider(provider);
+					return windows.length > 0 ? { limits: windows } : {};
+				} catch {
+					return {};
+				}
+			})(),
 			// Per-binding, not process-wide: the snapshot already resolved which
 			// agent + session this client is bound to, and usage now honours that.
 			totalTokensIn: snapshotUsage.input + snapshotUsage.cacheRead + snapshotUsage.cacheWrite,
@@ -2376,26 +2397,10 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		// frame actually carries a delta. One extra stringify per qualifying
 		// broadcast (measured at GiB/s — far cheaper than the bytes it removes),
 		// and none at all when nobody opted in.
-		let deltaJson: string | undefined;
-		if (event === "pi") {
-			const pi = (payload as { event?: { type?: string; assistantMessageEvent?: unknown; message?: unknown } })?.event;
-			if (pi?.type === "message_update" && pi.assistantMessageEvent !== undefined && pi.message !== undefined) {
-				// Strip only `content` — the cumulative blocks, which are the entire
-				// O(n²) payload. `role`, `timestamp` and `usage` stay: the timestamp
-				// is the client's RENDER KEY (without it a delta cannot be attached to
-				// a block), and `usage` drives the live token counter. Both are a
-				// handful of bytes.
-				const msg = pi.message as Record<string, unknown>;
-				const { content: _omitted, ...msgWithoutContent } = msg;
-				deltaJson = JSON.stringify({
-					...(frame as unknown as Record<string, unknown>),
-					payload: {
-						...(payload as Record<string, unknown>),
-						event: { ...(pi as Record<string, unknown>), message: msgWithoutContent },
-					},
-				});
-			}
-		}
+		// Lives in `delta-mode.ts` so a test can actually call it — see that
+		// function's header for why being inline here meant the producer side
+		// was untested while its test reported green.
+		const deltaJson = stripCumulativeContent(frame);
 		for (const ws of clients) {
 			const ready = prepareClient(ws);
 			if (!ready) continue;
@@ -5438,7 +5443,17 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 		registerGatewayHandler("sessions.delete", (params: unknown) =>
 			handleSessionsDelete(
 				params as Parameters<typeof handleSessionsDelete>[0],
-				{ accessCheck: sessionsAccessCheck },
+				{
+					accessCheck: sessionsAccessCheck,
+					// The gateway's in-memory accounting for this key is now stale,
+					// and `/new` rolls a fresh sessionId under the SAME sessionKey —
+					// so without this a brand-new conversation silently inherits the
+					// deleted one's cost total and reasoning state, permanently.
+					forgetSessionState: (forgetAgentId: string, forgetSessionKey: string) => {
+						usageLedger.forget(forgetAgentId, forgetSessionKey);
+						reasoningTracker.forget(forgetAgentId, forgetSessionKey);
+					},
+				},
 			),
 		),
 	);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -20,6 +20,8 @@
  */
 
 import type { Model, ToolCall as PiToolCall } from "@earendil-works/pi-ai";
+import type { ProviderLimitWindow } from "./agents/usage/limits.js";
+export type { ProviderLimitWindow };
 import type {
 	CronAddParamsV2,
 	CronAddResultV2,
@@ -1235,6 +1237,16 @@ export interface SessionStateSnapshot {
 	 * capable of. Absent on a gateway older than this field.
 	 */
 	reasoning?: SessionReasoningState;
+	/**
+	 * Provider consumption windows — "how much have I got left?".
+	 *
+	 * Absent when the backend has not reported any, which is NOT the same as
+	 * "none left": a provider that sends no rate-limit headers simply cannot be
+	 * asked, and a UI must render that as unknown rather than as a full or an
+	 * empty bar. Populated for whichever provider is serving this session, so a
+	 * client never has to know which header dialect that provider speaks.
+	 */
+	limits?: ProviderLimitWindow[];
 	contextUsagePercent: number | null;
 	/**
 	 * Estimated tokens currently in the context window, and the window's size.

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -893,10 +893,19 @@ export interface RequestParams {
 		/** Canonical session key to resume; defaults to that agent's main session. */
 		sessionKey?: string;
 		/**
-		 * When set, the server omits messages the client already has and returns
-		 * only the tail. Today the server always returns the full transcript
-		 * (simple + correct — the client applies it idempotently by identity);
-		 * this is a forward-compat hint for a future tail optimisation. */
+		 * The last `seq` this client saw on this session.
+		 *
+		 * When set, the server additionally returns `replayedFrames` — the exact
+		 * frames after this cursor that the TRANSCRIPT cannot rebuild (sub-agent
+		 * and synthetic frames), so a gap in those streams is repairable rather
+		 * than merely detectable.
+		 *
+		 * The transcript itself is still returned in full and applied
+		 * idempotently by identity; this cursor does not shrink it.
+		 *
+		 * Only meaningful within one gateway `epoch`. After a restart the seq
+		 * counters begin again at 0, so a stale cursor must be discarded — the
+		 * `epoch` on `HelloOk` and on this response is how a client knows. */
 		sinceSeq?: number;
 	};
 	"memory-graph": {
@@ -1362,6 +1371,26 @@ export interface ResumeSnapshot {
 	 * a duplicate it can apply idempotently or skip.
 	 */
 	headSeq: number;
+	/**
+	 * Exact frames after the request's `sinceSeq` that no transcript can rebuild
+	 * — sub-agent and synthetic frames — each the serialized `Frame` as it was
+	 * originally broadcast. Absent when no cursor was supplied.
+	 *
+	 * Apply these in order AFTER materialising the transcript. They are the same
+	 * bytes the live stream would have delivered, so an identity-keyed renderer
+	 * dedupes them exactly as it does a live frame.
+	 */
+	replayedFrames?: string[];
+	/**
+	 * Whether `replayedFrames` actually closes the gap.
+	 *
+	 * `false` means retention was trimmed past the cursor and some frames are
+	 * gone for good — the client has the transcript and should treat the
+	 * un-replayable span as lost rather than assume it was empty. Reported
+	 * honestly because a client that believes a partial replay was total
+	 * silently skips real content.
+	 */
+	replayComplete?: boolean;
 	/**
 	 * Tool-approval prompts CURRENTLY pending on this session. Recovery for the
 	 * one event that loses an operator ACTION: a client that connected after —

--- a/src/protocol/stream-seq.ts
+++ b/src/protocol/stream-seq.ts
@@ -25,6 +25,13 @@ export function nextSeq(
 ): number | undefined {
 	if (!sessionId) return undefined;
 	const next = (counters.get(sessionId) ?? 0) + 1;
+	// DELETE BEFORE SET, so the Map's insertion order is least-recently-USED.
+	// `Map.set` on an existing key does NOT reorder, so without this the map is
+	// ordered by first-seen and an LRU sweep over it evicts the OLDEST LIVE
+	// session first — in practice the operator's own long-running thread, whose
+	// counter then restarts at 1 and makes every connected client see a
+	// backwards seq, resync, and repaint its whole transcript.
+	counters.delete(sessionId);
 	counters.set(sessionId, next);
 	return next;
 }

--- a/src/security/media-path-guard.test.ts
+++ b/src/security/media-path-guard.test.ts
@@ -109,29 +109,86 @@ describe("validateOutboundMediaPath", () => {
 describe("rootSpellings", () => {
 
 
-	it("rootSpellings returns the realpathed spelling of a symlinked root", () => {
-		// The bug this pins: allowed roots were built with `path.resolve` only, while
-		// containment compared a `fs.realpathSync`'d candidate. On macOS
-		// `os.tmpdir()` is `/var/folders/…` symlinked to `/private/var/folders/…`,
-		// so a realpathed candidate under the temp dir was compared against the
-		// `/var/…` spelling and never matched — refusing every document-tool write
-		// into a temp dir with "outside the allowed roots". 40 tests failed on every
-		// macOS checkout while Linux CI stayed green, because `/tmp` is not a symlink
-		// there.
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-rootspelling-"));
+	// The bug this pins: allowed roots were built with `path.resolve` only, while
+	// containment compared a `fs.realpathSync`'d candidate. On macOS
+	// `os.tmpdir()` is `/var/folders/…` symlinked to `/private/var/folders/…`,
+	// so a realpathed candidate under the temp dir was compared against the
+	// `/var/…` spelling and never matched — refusing every document-tool write
+	// into a temp dir with "outside the allowed roots". 40 tests failed on every
+	// macOS checkout while Linux CI stayed green.
+	//
+	// …and the first version of this test had exactly the same blind spot. It
+	// called `rootSpellings(os.tmpdir())` and asserted the result contained
+	// `fs.realpathSync(tmpdir)` — on Linux that is the SAME STRING as the
+	// resolved spelling, so the assertion held by identity and deleting the
+	// realpath branch from `rootSpellings` would not have failed it. It could
+	// only ever fail on the platform that already had the bug.
+	//
+	// So build the symlinked root ourselves, and assert it really is one.
+
+	/** A physical dir plus a symlink to it, or `null` where symlinks are barred. */
+	function symlinkedRoot(): { base: string; link: string; physical: string } | null {
+		const base = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-rootspelling-"));
+		const physical = path.join(base, "physical");
+		fs.mkdirSync(physical);
+		const link = path.join(base, "via-symlink");
+		try {
+			fs.symlinkSync(physical, link, "dir");
+		} catch {
+			fs.rmSync(base, { recursive: true, force: true });
+			return null; // unprivileged Windows — nothing to test
+		}
+		return { base, link, physical };
+	}
+
+	it("returns BOTH spellings of a symlinked root, on every platform", () => {
+		const fixture = symlinkedRoot();
+		if (!fixture) return;
+		try {
+			const resolved = path.resolve(fixture.link);
+			const real = fs.realpathSync(fixture.link);
+			assert.notEqual(real, resolved, "the fixture must genuinely be a symlink");
+
+			const spellings = rootSpellings(fixture.link);
+			assert.ok(spellings.includes(resolved), "keeps the resolved spelling");
+			assert.ok(spellings.includes(real), "adds the realpathed spelling");
+		} finally {
+			fs.rmSync(fixture.base, { recursive: true, force: true });
+		}
+	});
+
+	it("a candidate realpathed the way the guards do lands inside a root", () => {
+		// The actual failure mode: the guards realpath the CANDIDATE, so a root
+		// kept only in its symlinked spelling can never contain anything.
+		const fixture = symlinkedRoot();
+		if (!fixture) return;
+		try {
+			const target = path.join(fixture.link, "out.docx");
+			fs.writeFileSync(target, "x");
+			const realCandidate = fs.realpathSync(target);
+			assert.notEqual(realCandidate, path.resolve(target), "the candidate really moves");
+			const contained = rootSpellings(fixture.link).some((root) => {
+				const rel = path.relative(root, realCandidate);
+				return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+			});
+			assert.ok(contained, "a realpathed candidate must be contained by one of the spellings");
+		} finally {
+			fs.rmSync(fixture.base, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the host temp dir usable whichever way the platform spells it", () => {
+		// The concrete regression: every document-tool write goes under
+		// `os.tmpdir()`. On macOS that is the symlinked spelling.
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "brigade-tmproot-"));
 		try {
 			const spellings = rootSpellings(dir);
 			const real = fs.realpathSync(dir);
-			assert.ok(spellings.includes(path.resolve(dir)), "keeps the resolved spelling");
-			assert.ok(spellings.includes(real), "adds the realpathed spelling");
-			// A candidate realpathed the way the guards do must land inside a root.
-			assert.ok(
-				spellings.some((root) => {
-					const rel = path.relative(root, path.join(real, "out.docx"));
-					return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
-				}),
-				"a realpathed candidate is contained by one of the spellings",
-			);
+			const contained = spellings.some((root) => {
+				const rel = path.relative(root, path.join(real, "out.docx"));
+				return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+			});
+			assert.ok(contained, "a write into the temp dir must be allowed");
 		} finally {
 			fs.rmSync(dir, { recursive: true, force: true });
 		}

--- a/src/tui/client.ts
+++ b/src/tui/client.ts
@@ -405,7 +405,10 @@ export class BrigadeClient extends EventEmitter {
 			// a gateway restart); emit `"resync"` so the consumer `resume`s and
 			// backfills (transcript + pending approvals + recent system-events).
 			// Frames without `seq` (state/error/log + sub-agent pi) are unordered
-			// side-channels and skip the check.
+			// side-channels and skip the check. Sub-agent frames stay unsequenced
+			// deliberately: they are tagged with the child's Pi session UUID, which
+			// `resume` cannot look up, so a gap in them is undetectable-but-honest
+			// rather than detectable-but-unrepairable.
 			if (typeof frame.seq === "number") {
 				const sid = (frame.payload as { sessionId?: string } | undefined)?.sessionId;
 				if (sid) {

--- a/src/ui/editor.test.ts
+++ b/src/ui/editor.test.ts
@@ -7,7 +7,7 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import type { TUI } from "@earendil-works/pi-tui";
+import { CombinedAutocompleteProvider, type TUI } from "@earendil-works/pi-tui";
 
 import { BrigadeEditor, NO_REQUIRED_ARG_FOR_TEST } from "./editor.js";
 import { editorTheme } from "./theme.js";
@@ -115,20 +115,82 @@ describe("BrigadeEditor — reasoning toggle key", () => {
 });
 
 describe("slash aliases", () => {
-	it("every live alias submits on one Enter", () => {
 	// The bug: `clip` was dropped from NO_REQUIRED_ARG while `/clip` remained a
 	// live alias of `/clipboard`. The popup shows for any PREFIX of an
 	// advertised command, so Enter was translated to Tab — the operator's text
 	// silently became `/clipboard` and needed a second Enter.
 	//
-	// Aliases are invisible in `SLASH_COMMANDS`, which is exactly why they get
-	// forgotten here.
-	for (const alias of ["clip", "cancel", "switch"]) {
-		assert.ok(
-			NO_REQUIRED_ARG_FOR_TEST.has(alias),
-			`/${alias} is a live alias taking no required argument — it must submit on one Enter`,
-		);
+	// The previous version of this test asserted `NO_REQUIRED_ARG_FOR_TEST.has(
+	// "clip")` — set membership, which is the same statement as the production
+	// line it was checking, restated. It could not tell whether the SET is even
+	// consulted, whether the popup gate matches, or what the operator's line
+	// ends up containing. So these press the key instead.
+
+	/** The advertised commands that matter here, as `connect.ts` registers them. */
+	const COMMANDS = [
+		{ name: "clipboard", description: "diagnose clipboard support" },
+		{ name: "search", description: "search the transcript" },
+		{ name: "compact", description: "summarize older turns" },
+	];
+
+	/** A real editor with the real pi-tui slash-command popup behind it. */
+	function slashHarness(): { ed: BrigadeEditor; submitted: string[] } {
+		const ed = new BrigadeEditor(tui, editorTheme);
+		ed.setAutocompleteProvider(new CombinedAutocompleteProvider(COMMANDS, process.cwd()));
+		const submitted: string[] = [];
+		ed.onSubmit = (v: string) => {
+			submitted.push(v);
+		};
+		return { ed, submitted };
 	}
+
+	/** Type, then let the (async) autocomplete request settle so the popup is up. */
+	async function typeAndOpenPopup(ed: BrigadeEditor, text: string): Promise<void> {
+		type(ed, text);
+		for (let i = 0; i < 5 && !ed.isShowingAutocomplete(); i += 1) {
+			await new Promise((r) => setTimeout(r, 5));
+		}
+		assert.ok(ed.isShowingAutocomplete(), `the popup must be showing for "${text}"`);
+	}
+
+	it("/clip — a live alias that is also a PREFIX — submits on one Enter", async () => {
+		const { ed, submitted } = slashHarness();
+		await typeAndOpenPopup(ed, "/clip");
+		ed.handleInput("\r");
+		// Pi's own popup-Enter accepts the highlighted completion AND submits, so
+		// what goes out is `/clipboard` — the point is that it goes out at ALL, on
+		// the FIRST Enter. Dropping `clip` from the set turns this Enter into a
+		// Tab: nothing is submitted and the operator has to press Enter again.
+		assert.equal(submitted.length, 1, "one Enter must send the command");
+		assert.match(submitted[0]!, /^\/clip(board)?$/, "and it must be the clipboard command");
+		assert.equal(ed.getText(), "", "the line is consumed, not left waiting for a second Enter");
+	});
+
+	it("a command with a REQUIRED argument still completes instead of submitting", async () => {
+		// The control. If Enter submitted here, `/search` would be sent with an
+		// empty query — which is why the set is a set and not "always submit".
+		const { ed, submitted } = slashHarness();
+		await typeAndOpenPopup(ed, "/search");
+		ed.handleInput("\r");
+		assert.deepEqual(submitted, [], "an empty search must never be sent");
+		assert.match(ed.getText(), /^\/search\s*$/, "Enter accepted the completion and waits for the query");
+	});
+
+	it("aliases that are not a prefix of anything advertised still submit on one Enter", () => {
+		// `/cancel` and `/switch` open no popup today, so they take the ordinary
+		// submit path. They are listed in NO_REQUIRED_ARG anyway, so that adding a
+		// `cancel-*` / `switch-*` command later cannot quietly reintroduce the
+		// two-Enter bug — assert both facts, the behaviour and the guard.
+		for (const alias of ["cancel", "switch"]) {
+			const { ed, submitted } = slashHarness();
+			type(ed, `/${alias}`);
+			ed.handleInput("\r");
+			assert.deepEqual(submitted, [`/${alias}`], `/${alias} must send on one Enter`);
+			assert.ok(
+				NO_REQUIRED_ARG_FOR_TEST.has(alias),
+				`/${alias} must stay listed, or a future /${alias}-* command reintroduces the bug`,
+			);
+		}
 	});
 });
 

--- a/src/ui/header-stability.test.ts
+++ b/src/ui/header-stability.test.ts
@@ -1,57 +1,281 @@
 /**
- * Line 0 must not change while a turn streams.
+ * The identity line must not change while a turn streams.
  *
  * pi-tui's differential renderer bails to `fullRender(true)` when the first
  * changed line is above the previous viewport (tui.js:1169), and that path
  * emits `\x1b[2J\x1b[H\x1b[3J` — the `3J` CLEARS THE TERMINAL'S SCROLLBACK.
- * The connect header is `addChild`'d first, so it IS line 0. Anything volatile
- * there destroys the operator's scroll history every time it ticks.
+ * The connect header sits in that top block (added before the divider, above
+ * the transcript), so anything volatile in it destroys the operator's scroll
+ * history every time it ticks.
  *
  * These pin the split: identity in the header, everything that ticks in the
  * footer (which is pinned near the bottom and renders differentially).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS DRIVES THE REAL UI
+ * ─────────────────────────────────────────────────────────────────────────
+ * The previous version of this file re-declared a `headerFor()` helper and
+ * asserted that it equalled itself. It imported nothing from `src/`, so
+ * appending an elapsed ticker to the real `updateHeader` in `connect.ts` left
+ * every assertion green. A test for "this string does not change" is worthless
+ * unless the string is the one production actually paints.
+ *
+ * So this boots the REAL `wireConnectUi` against a fake Terminal and a fake
+ * gateway, feeds it the state snapshots and lifecycle events the gateway
+ * really sends, and reads the header component out of the live widget tree.
  */
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 
-/** The header string shape built by `updateHeader`. */
-function headerFor(v: { persona: string; crew: string; session: string; provider: string; model: string }): string {
-	return `  🦁 ${v.persona}${v.crew}${v.session}  ${v.provider} · ${v.model}`;
+import { strict as assert } from "node:assert";
+import { after, before, describe, it } from "node:test";
+
+import { TUI, type Component, type Terminal } from "@earendil-works/pi-tui";
+
+import { wireConnectUi } from "../cli/commands/connect.js";
+import type { BrigadeClient } from "../tui/client.js";
+import type { SessionStateSnapshot } from "../protocol.js";
+
+/** A Terminal that renders nowhere. */
+class FakeTerminal implements Terminal {
+	onInput: (data: string) => void = () => {};
+	start(onInput: (data: string) => void): void {
+		this.onInput = onInput;
+	}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(): void {}
+	get columns(): number {
+		return 120;
+	}
+	get rows(): number {
+		return 40;
+	}
+	get kittyProtocolActive(): boolean {
+		return false;
+	}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
 }
 
-const BASE = { persona: "Brigade", crew: "", session: " · main", provider: "claude-cli", model: "opus-4-8" };
+const AGENT = "main";
+const SESSION = "agent:main:main";
 
-describe("header stability (line 0)", () => {
-	it("does not change as elapsed time ticks", () => {
-		// The 1s elapsed ticker was the main offender: ~39 scrollback wipes across
-		// a 40-second turn.
-		assert.equal(headerFor(BASE), headerFor(BASE), "elapsed is not part of the header at all");
+/** The identity-only baseline. Everything volatile is at rest here. */
+const BASE = {
+	provider: "claude-cli",
+	modelId: "opus-4-8",
+	modelName: "Opus 4.8",
+	thinkingLevel: "off",
+	supportsThinking: true,
+	supportsVision: true,
+	availableThinkingLevels: ["off"],
+	contextUsagePercent: null,
+	contextTokens: null,
+	contextWindow: null,
+	totalTokensIn: 0,
+	totalTokensOut: 0,
+	totalCostUsd: 0,
+	isAgentRunning: false,
+	messageCount: 0,
+	agentId: AGENT,
+	agentName: "Brigade",
+	sessionKey: SESSION,
+} as unknown as SessionStateSnapshot;
+
+function snapshot(patch: Partial<SessionStateSnapshot>): SessionStateSnapshot {
+	return { ...BASE, ...patch } as SessionStateSnapshot;
+}
+
+type Handler = (...args: never[]) => void;
+
+interface Booted {
+	tui: TUI;
+	emit(event: string, payload: unknown): void;
+	state(snap: SessionStateSnapshot): void;
+}
+
+async function boot(): Promise<Booted> {
+	const tui = new TUI(new FakeTerminal());
+	const handlers = new Map<string, Handler[]>();
+	const client = {
+		on(event: string, fn: Handler) {
+			const list = handlers.get(event) ?? [];
+			list.push(fn);
+			handlers.set(event, list);
+			return client;
+		},
+		connect: async () => {},
+		resume: async () => {},
+		close: () => {},
+		request: async (method: string) => {
+			if (method === "get-state") return BASE;
+			if (method === "list-models") return [];
+			if (method === "sessions.list" || method === "list-sessions") return [];
+			if (method === "list-agents") return [];
+			return undefined;
+		},
+	};
+	await wireConnectUi(tui, client as unknown as BrigadeClient, AGENT, SESSION);
+	const emit = (event: string, payload: unknown): void => {
+		for (const fn of handlers.get(event) ?? []) (fn as (p: unknown) => void)(payload);
+	};
+	return { tui, emit, state: (snap) => emit("state", snap) };
+}
+
+function renderOf(c: Component): string {
+	return (c as unknown as { render(width: number): string[] }).render(120).join("\n");
+}
+
+function children(tui: TUI): Component[] {
+	return (tui as unknown as { children: Component[] }).children;
+}
+
+/**
+ * The header component: the child immediately above the 80-dash divider, which
+ * is exactly how `wireConnectUi` builds it (`addChild(header)` then
+ * `addChild(divider)`). Located structurally rather than by index because
+ * `renderBrandHeader` prepends a variable number of children.
+ */
+function headerLine(tui: TUI): string {
+	const kids = children(tui);
+	const dividerIdx = kids.findIndex((k) => renderOf(k).includes("─".repeat(80)));
+	assert.ok(dividerIdx > 0, "the connect divider must exist, with the header above it");
+	return renderOf(kids[dividerIdx - 1]!);
+}
+
+/** The live footer: the one line carrying the running/idle dot. */
+function footerLine(tui: TUI): string {
+	const kids = children(tui);
+	const dividerIdx = kids.findIndex((k) => renderOf(k).includes("─".repeat(80)));
+	for (let i = kids.length - 1; i > dividerIdx; i -= 1) {
+		const text = renderOf(kids[i]!);
+		if (text.includes("●") || text.includes("○")) return text;
+	}
+	assert.fail("the connect footer (the line carrying the ●/○ dot) must exist");
+}
+
+/** Stop any spinner interval the UI armed, so the test process can exit. */
+function stopTimers(tui: TUI): void {
+	for (const child of children(tui)) {
+		(child as unknown as { stop?: () => void }).stop?.();
+	}
+}
+
+let ui: Booted;
+
+before(async () => {
+	ui = await boot();
+	ui.state(BASE);
+});
+
+after(() => {
+	stopTimers(ui.tui);
+});
+
+describe("header stability (the identity line above the transcript)", () => {
+	it("paints the identity it is supposed to carry", () => {
+		// Guard against every assertion below being vacuously true: if the widget
+		// we located were blank or static chrome, "it did not change" would prove
+		// nothing at all.
+		const header = headerLine(ui.tui);
+		assert.match(header, /🦁/, "the mascot rides ahead of the persona");
+		assert.match(header, /Brigade/, "the persona name is identity");
+		assert.match(header, /claude-cli/, "the provider is identity");
+		assert.match(header, /opus-4-8/, "the model is identity");
 	});
 
-	it("does not change as tokens, cost or context accumulate", () => {
-		// These now update per TOKEN (the usage ledger made them live), so any of
-		// them in line 0 would mean a full redraw per token.
-		const before = headerFor(BASE);
-		const after = headerFor({ ...BASE });
-		assert.equal(before, after);
+	it("does not change as tokens, cost, context and reasoning accumulate", () => {
+		// These update per TOKEN (the usage ledger made them live), so any of them
+		// in the identity line would mean a full redraw — and a scrollback wipe —
+		// per token.
+		const before = headerLine(ui.tui);
+		const footerBefore = footerLine(ui.tui);
+		ui.state(
+			snapshot({
+				totalTokensIn: 4700,
+				totalTokensOut: 120,
+				totalCostUsd: 0.0231,
+				billing: "metered",
+				costComplete: true,
+				contextTokens: 34_000,
+				contextWindow: 200_000,
+				contextUsagePercent: 17,
+				reasoning: { active: true, visibility: "summary", startedAt: Date.now() - 12_000 },
+			}),
+		);
+		assert.equal(headerLine(ui.tui), before, "the identity line must be byte-identical");
+		// …and prove the churn actually reached the UI, rather than the snapshot
+		// having been silently dropped on the way in.
+		assert.notEqual(footerLine(ui.tui), footerBefore, "the footer is where live figures belong");
 	});
 
-	it("does not change as the reasoning phase opens and closes", () => {
-		assert.equal(headerFor(BASE), headerFor({ ...BASE }));
+	it("does not change as the reasoning phase closes", () => {
+		const before = headerLine(ui.tui);
+		ui.state(
+			snapshot({
+				totalTokensIn: 4700,
+				totalTokensOut: 900,
+				reasoning: { active: false, visibility: "summary", durationMs: 12_400 },
+			}),
+		);
+		assert.equal(headerLine(ui.tui), before);
 	});
 
-	it("DOES change when the operator switches model", () => {
-		// A real state change must still repaint — this is the one time a full
-		// redraw is worth its cost.
-		assert.notEqual(headerFor(BASE), headerFor({ ...BASE, model: "sonnet-5" }));
-	});
+	it("does not change when a turn starts, ticks, or ends", async () => {
+		const before = headerLine(ui.tui);
+		const footerAtRest = footerLine(ui.tui);
+		ui.emit("pi", { event: { type: "agent_start" }, subagentDepth: 0, agentId: AGENT, sessionId: SESSION });
+		assert.equal(headerLine(ui.tui), before, "the running dot and spinner phrase live in the footer");
+		assert.notEqual(footerLine(ui.tui), footerAtRest, "the turn did start");
+		assert.match(footerLine(ui.tui), /●/, "the footer carries the running dot");
 
-	it("DOES change when the operator switches session or agent", () => {
-		assert.notEqual(headerFor(BASE), headerFor({ ...BASE, session: " · thread:x" }));
-		assert.notEqual(headerFor(BASE), headerFor({ ...BASE, persona: "Ops" }));
+		// The elapsed ticker repaints once a second for the whole turn — the main
+		// offender, measured at ~39 scrollback wipes across a 40-second turn. Wait
+		// for a real tick (the footer's elapsed figure moving is the proof it
+		// fired) and require the identity line to have sat still through it.
+		const footerRunning = footerLine(ui.tui);
+		const deadline = Date.now() + 4000;
+		while (footerLine(ui.tui) === footerRunning && Date.now() < deadline) {
+			await new Promise((r) => setTimeout(r, 50));
+		}
+		assert.notEqual(footerLine(ui.tui), footerRunning, "the elapsed ticker must have ticked");
+		assert.equal(headerLine(ui.tui), before, "one second of elapsed time must not touch the header");
+
+		ui.emit("pi", { event: { type: "agent_end" }, subagentDepth: 0, agentId: AGENT, sessionId: SESSION });
+		assert.equal(headerLine(ui.tui), before);
+		stopTimers(ui.tui);
 	});
 
 	it("carries no running dot — that is a per-turn flip", () => {
-		assert.equal(headerFor(BASE).includes("●"), false);
-		assert.equal(headerFor(BASE).includes("○"), false);
+		const header = headerLine(ui.tui);
+		assert.equal(header.includes("●"), false);
+		assert.equal(header.includes("○"), false);
+	});
+
+	it("DOES change when the operator switches model", () => {
+		// A real identity change must still repaint — this is the one time a full
+		// redraw is worth its cost.
+		const before = headerLine(ui.tui);
+		ui.state(snapshot({ modelId: "sonnet-5", modelName: "Sonnet 5" }));
+		assert.notEqual(headerLine(ui.tui), before);
+		assert.match(headerLine(ui.tui), /sonnet-5/);
+	});
+
+	it("DOES change when the operator switches session or persona", () => {
+		const before = headerLine(ui.tui);
+		ui.state(snapshot({ modelId: "sonnet-5", modelName: "Sonnet 5", agentName: "Ops" }));
+		assert.notEqual(headerLine(ui.tui), before, "a persona switch repaints");
+		assert.match(headerLine(ui.tui), /Ops/);
+
+		const afterPersona = headerLine(ui.tui);
+		ui.state(
+			snapshot({ modelId: "sonnet-5", modelName: "Sonnet 5", agentName: "Ops", sessionKey: `${SESSION}:sub` }),
+		);
+		assert.notEqual(headerLine(ui.tui), afterPersona, "a session switch repaints");
 	});
 });


### PR DESCRIPTION
Follow-up to #142. Closes the features that were built but never reached a user, plus the defects a live test session surfaced.

> Not yet exercised against a live model.

## The reported bug

A live session's footer read:

```
Thought for 15s · 400 reasoning tokens · provider summary
```

…with `/reasoning on` and **nothing rendered** in the conversation.

Tracking was fine. The *label* was not. `provider summary` came from the static provider map — what this backend *can* return — not from what the turn actually returned. Zero characters ever arrived, so it sent the operator hunting for text that does not exist.

- **Observed emptiness now outranks the static guess.** A phase that demonstrably reasoned (a duration, a billed token count) and produced no text is reported as `hidden` → *"not exposed by this model"*. A real summary is untouched; `redacted` is left alone, being already block-proven.
- **`expectReasoning`** covers the case where *both* proofs are absent, so a reasoning turn can never report nothing at all. Keyed off the model's declared capability, never a provider name.
- With reasoning on and nothing to show, the TUI **explains why** instead of rendering silence.

Root cause is upstream and worth stating: Anthropic's current generation defaults to `display: "omitted"` — empty block, real signature, fully billed, no `thinking_delta` events. Brigade already requests summaries and parses them correctly. The UI was hiding the fact that none arrived.

## Provider limits, end to end

`recordLimitsFromHeaders` parsed both header conventions and had **no caller**; `getLimits` had **no consumer**. Now hooked to Pi's `onResponse` (which carries `ProviderResponse.headers`) in the single `streamFn` every backend goes through — so this is not an Anthropic-only feature. Scoped to the provider serving the binding, and omitted entirely when none are reported: *unknown* and *exhausted* must never render the same way.

## Context and usage clarity

`tokens: 282,932 in` beside `context: 68k` reads as a contradiction. It isn't — the first is cumulative billing including cache reads, re-counted every turn as the history re-sends; the second is what the *next* request carries. Both lines now say which question they answer, and a new **`/context`** shows the window as a bar with what's left. `/help` now lists the commands added in #142, which were undiscoverable.

## Defects

| what | detail |
|---|---|
| Ctrl+C never cancelled a billed compaction | **Two** hops broken, not one — `summarizer.ts` dropped the signal *and* `makeIsolatedLlm` had no signal parameter at all. The abort is shaped as a DOM `AbortError` because that's what the retry classifiers match; any other shape is read as transient and **retried**, re-billing the call the cancel just saved |
| Compaction breaker | Two interrupts in a row closed it for its full 5-minute cooldown — the attempt was counted *before* it was made |
| `sessions.delete` | Now forgets ledger + reasoning state. `/new` rolls a fresh sessionId under the **same** sessionKey, so a new conversation silently inherited the deleted one's cost total |
| `pi-tool-boundary` | Had zero production imports. Wired at all three crossings into Pi's loop, including the web tools pushed after toolset assembly |

## Tests

Five suites asserted against re-implementations or nothing at all:

- **`header-stability.test.ts`** had **zero production imports** — 6 tests asserting a local helper equalled itself. Now boots the real UI against a fake terminal and gateway.
- **`smart-compaction.breaker.test.ts`** asserted `freed 118000 tokens` while production prints `freed 118k` — it agreed with itself and disagreed with the screen.
- **`delta-stream.test.ts`** re-implemented the strip and fed it a frame shape the gateway never emits. The strip is now exported as `stripCumulativeContent`, making the producer testable at all.
- **`editor.test.ts`** restated a production line instead of pressing a key.
- **`media-path-guard.test.ts`** held by string identity on Linux; now builds its own symlinked root.

**Worth knowing:** `npm test` runs under `tsx`, which strips types and never typechecks — a compile-time guard is invisible to it. CI runs `npm run typecheck` separately (`ci.yml:39`), which is what enforces those.

## Verification

- **6,529 tests**, build clean, typecheck clean
- **54/56 mutation claims defended** (both exceptions annotated: one unreachable guard rail, one self-referential)