### PR TITLE
fix: reasoning tokens on every provider, and an update check that actually re-checks

### DIFF
--- a/src/agents/reasoning/format.test.ts
+++ b/src/agents/reasoning/format.test.ts
@@ -127,3 +127,53 @@ test("a completed phase uses the duration carried on the state", () => {
 	});
 	assert.equal(line, "Thought for 12s · 4.2k reasoning tokens · provider summary");
 });
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Reasoning VOLUME when the token count is unavailable.
+ *
+ * A reasoning-token count reaches Brigade from exactly one backend —
+ * `claude-cli`, which parses `output_tokens_details.thinking_tokens` from the
+ * binary's own stream. Pi's `Usage` has no `reasoningTokens` field, and Pi
+ * folds reasoning tokens into `output`, so every Pi-native provider reports
+ * none.
+ *
+ * Reported live: the same model showed `400 reasoning tokens` on claude-cli
+ * and nothing at all on OpenRouter, with no explanation for the difference.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+test("falls back to reasoning VOLUME when no token count is reported", () => {
+	const line = formatReasoningLine({
+		state: { active: false, visibility: "summary", chars: 4200, durationMs: 12_000 },
+	});
+	assert.match(line ?? "", /4\.2k chars of reasoning/);
+	assert.ok(!/reasoning tokens/.test(line ?? ""), "must not imply a token count it lacks");
+});
+
+test("a real token count still wins over the volume fallback", () => {
+	const line = formatReasoningLine({
+		state: { active: false, visibility: "summary", tokens: 400, chars: 4200, durationMs: 12_000 },
+	});
+	assert.match(line ?? "", /400 reasoning tokens/);
+	assert.ok(!/chars of reasoning/.test(line ?? ""), "tokens are the better measure; show one, not both");
+});
+
+test("neither is invented when nothing was measured", () => {
+	// An omitted-but-billed phase: real duration, no text, no count. Printing a
+	// zero for either would claim a measurement we do not have.
+	const line = formatReasoningLine({
+		state: { active: false, visibility: "hidden", chars: 0, durationMs: 15_000 },
+	});
+	assert.ok(!/reasoning tokens/.test(line ?? ""));
+	assert.ok(!/chars of reasoning/.test(line ?? ""));
+	assert.match(line ?? "", /not exposed by this model/);
+});
+
+test("volume shows DURING an active phase, so a long think visibly progresses", () => {
+	// The property tokens lack: usage arrives at message end, chars stream.
+	const line = formatReasoningLine({
+		state: { active: true, visibility: "summary", chars: 1500, startedAt: Date.now() - 5000 },
+		now: Date.now(),
+	});
+	assert.match(line ?? "", /Thinking/);
+	assert.match(line ?? "", /1\.5k chars of reasoning/);
+});

--- a/src/agents/reasoning/format.ts
+++ b/src/agents/reasoning/format.ts
@@ -118,6 +118,27 @@ export function formatReasoningLine(input: ReasoningLineInput): string | undefin
 	// Absent must never render as `0`: that would claim a measurement we do not have.
 	if (typeof s.tokens === "number" && s.tokens > 0) {
 		parts.push(`${formatTokens(s.tokens)} reasoning tokens`);
+	} else if (typeof s.chars === "number" && s.chars > 0) {
+		// FALL BACK TO WHAT WE ACTUALLY MEASURED.
+		//
+		// A reasoning-token COUNT reaches Brigade from exactly one backend:
+		// `claude-cli`, which parses `output_tokens_details.thinking_tokens` out
+		// of the binary's own stream and attaches it. Every Pi-native provider —
+		// OpenRouter, the Anthropic API, OpenAI — reports nothing, because Pi
+		// folds reasoning tokens into `output` before Brigade sees a usage
+		// record. `Usage` has no `reasoningTokens` field at all.
+		//
+		// So on most backends the line read `Thinking 2m 44s… · provider summary`
+		// while the same model on `claude-cli` read `… · 400 reasoning tokens ·
+		// provider summary`, with nothing to explain the difference. The operator
+		// reasonably reads the gap as a bug.
+		//
+		// Characters of reasoning text ARE counted, on every backend, from the
+		// deltas as they stream. It is a different unit and it is labelled as
+		// one — never dressed up as a token count we do not have. It also has a
+		// property tokens lack: it grows LIVE during the phase, so a long think
+		// visibly progresses instead of sitting on a bare timer.
+		parts.push(`${formatTokens(s.chars)} chars of reasoning`);
 	}
 
 	const suffix = reasoningSuffix(s.visibility);

--- a/src/agents/usage/reasoning-tokens.test.ts
+++ b/src/agents/usage/reasoning-tokens.test.ts
@@ -1,0 +1,64 @@
+/**
+ * One number, five provider spellings. Getting this wrong does not throw — it
+ * silently reports "no reasoning" for a turn that reasoned, which is why the
+ * figure appeared on one transport and nowhere else for so long.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { extractReasoningTokens } from "./reasoning-tokens.js";
+
+test("Anthropic: output_tokens_details.thinking_tokens", () => {
+	assert.equal(extractReasoningTokens({ output_tokens_details: { thinking_tokens: 400 } }), 400);
+});
+
+test("OpenAI and every API that copied its schema (OpenRouter included)", () => {
+	assert.equal(
+		extractReasoningTokens({ completion_tokens_details: { reasoning_tokens: 6126 } }),
+		6126,
+	);
+});
+
+test("Google Gemini: thoughtsTokenCount, flat or under usageMetadata", () => {
+	assert.equal(extractReasoningTokens({ thoughtsTokenCount: 91 }), 91);
+	assert.equal(extractReasoningTokens({ usageMetadata: { thoughtsTokenCount: 91 } }), 91);
+});
+
+test("flat spellings used by local runtimes", () => {
+	assert.equal(extractReasoningTokens({ reasoning_tokens: 12 }), 12);
+	assert.equal(extractReasoningTokens({ thinking_tokens: 13 }), 13);
+});
+
+test("already-normalised input round-trips", () => {
+	assert.equal(extractReasoningTokens({ reasoningTokens: 77 }), 77);
+});
+
+test("NOT REPORTED is undefined, never zero", () => {
+	// The distinction the whole subsystem rests on: "the provider said nothing"
+	// and "the model did not reason" are different facts, and printing 0 for the
+	// first asserts a measurement nobody took.
+	assert.equal(extractReasoningTokens({ input: 10, output: 5 }), undefined);
+	assert.equal(extractReasoningTokens({}), undefined);
+	assert.equal(extractReasoningTokens(undefined), undefined);
+	assert.equal(extractReasoningTokens(null), undefined);
+});
+
+test("a genuine zero is preserved", () => {
+	// Anthropic reports 0 for an easy prompt at high effort — that IS a
+	// measurement, and it means "the model chose not to think".
+	assert.equal(extractReasoningTokens({ output_tokens_details: { thinking_tokens: 0 } }), 0);
+});
+
+test("numeric strings are accepted; junk is not", () => {
+	assert.equal(extractReasoningTokens({ reasoning_tokens: "128" }), 128);
+	for (const junk of [{ reasoning_tokens: "abc" }, { reasoning_tokens: -5 }, { reasoning_tokens: Number.NaN }]) {
+		assert.equal(extractReasoningTokens(junk), undefined, JSON.stringify(junk));
+	}
+});
+
+test("malformed shapes never throw on the usage path", () => {
+	for (const junk of [0, "", [], { output_tokens_details: 5 }, { completion_tokens_details: null }]) {
+		assert.doesNotThrow(() => extractReasoningTokens(junk));
+	}
+});

--- a/src/agents/usage/reasoning-tokens.ts
+++ b/src/agents/usage/reasoning-tokens.ts
@@ -1,0 +1,97 @@
+/**
+ * Reasoning-token counts, normalised across every provider shape.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS IS ONE FUNCTION AND NOT A PER-BACKEND READ
+ * ─────────────────────────────────────────────────────────────────────────
+ * Brigade used to get this figure from exactly one place: the `claude-cli`
+ * stream parser, which reached into that binary's own usage record. Every
+ * other backend reported nothing, so the same model showed
+ * `400 reasoning tokens` on one transport and a bare timer on another, with
+ * nothing on screen to explain the difference. The reader in the gateway made
+ * it worse by consulting `message.usage.reasoningTokens` through an `as any`
+ * cast — a field Pi's `Usage` does not declare — so the compiler could not
+ * point out that it is `undefined` everywhere except the one transport that
+ * happens to set it.
+ *
+ * The providers do not disagree about the NUMBER, only about where to put it.
+ * Collecting the shapes here means adding a backend costs nothing: whatever
+ * usage object it produces, this reads it, and every renderer benefits at
+ * once.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE SHAPES, AND WHERE THEY COME FROM
+ * ─────────────────────────────────────────────────────────────────────────
+ *   Anthropic          usage.output_tokens_details.thinking_tokens
+ *   OpenAI + compat    usage.completion_tokens_details.reasoning_tokens
+ *                      (OpenRouter, Azure, Groq, Together, Fireworks … all
+ *                      inherit this from the OpenAI schema)
+ *   Google Gemini      usageMetadata.thoughtsTokenCount
+ *   Ollama / local     thinking_tokens, flat
+ *   Brigade-internal   reasoningTokens, already normalised
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHAT THIS CANNOT DO, STATED PLAINLY
+ * ─────────────────────────────────────────────────────────────────────────
+ * It normalises a usage object it is GIVEN. It cannot conjure one that never
+ * arrives, and for Pi-native providers none does: Pi folds reasoning tokens
+ * into `output` before Brigade sees a usage record, and its only stream hooks
+ * are `onPayload` (the request) and `onResponse` (status + headers, before the
+ * body is read). There is no seam for the response body.
+ *
+ * So this makes every transport Brigade OWNS report the real figure, and every
+ * transport Pi owns report honestly nothing — at which point the renderer
+ * falls back to reasoning VOLUME, which is measured from the deltas on every
+ * backend. Absent must never render as zero: "not reported" and "none" are
+ * different facts, and only one of them is a measurement.
+ */
+
+/** A count is only meaningful when it is a finite, non-negative number. */
+function asCount(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+	// Some transports relay usage as JSON text with numeric strings.
+	if (typeof value === "string" && value.trim()) {
+		const n = Number(value.trim());
+		if (Number.isFinite(n) && n >= 0) return n;
+	}
+	return undefined;
+}
+
+function nested(source: unknown, key: string): unknown {
+	if (!source || typeof source !== "object") return undefined;
+	return (source as Record<string, unknown>)[key];
+}
+
+/**
+ * Reasoning tokens from any provider's usage object, or `undefined`.
+ *
+ * `undefined` means NOT REPORTED. It is never coerced to 0 — a renderer that
+ * printed "0 reasoning tokens" for a provider that simply does not say would
+ * be asserting a measurement nobody took, which is the whole failure mode this
+ * subsystem exists to avoid.
+ */
+export function extractReasoningTokens(usage: unknown): number | undefined {
+	if (!usage || typeof usage !== "object") return undefined;
+	const u = usage as Record<string, unknown>;
+
+	// Already normalised — Brigade's own transports, and anything that has
+	// passed through here before.
+	const direct = asCount(u.reasoningTokens);
+	if (direct !== undefined) return direct;
+
+	// Anthropic.
+	const anthropic = asCount(nested(u.output_tokens_details, "thinking_tokens"));
+	if (anthropic !== undefined) return anthropic;
+
+	// OpenAI and every API that copied its schema, OpenRouter included.
+	const openai = asCount(nested(u.completion_tokens_details, "reasoning_tokens"));
+	if (openai !== undefined) return openai;
+
+	// Google Gemini, which reports usage under its own envelope.
+	const gemini =
+		asCount(u.thoughtsTokenCount) ?? asCount(nested(u.usageMetadata, "thoughtsTokenCount"));
+	if (gemini !== undefined) return gemini;
+
+	// Flat spellings used by local runtimes and a few relays.
+	return asCount(u.reasoning_tokens) ?? asCount(u.thinking_tokens);
+}

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -3749,7 +3749,7 @@ export async function wireConnectUi(
 						`- ${chalk.bold("/expand [n]")} — show a truncated tool result in full (1 = most recent)\n` +
 						`- ${chalk.bold("/search <query>")} — search this conversation, including tool results\n` +
 						`- ${chalk.bold("/search --regex <pattern>")} — same, treating the query as a regular expression\n` +
-						`- ${chalk.bold("/export [full]")} — write this transcript to a Markdown file (secrets redacted; \`full\` keeps whole tool results)\n` +
+						`- ${chalk.bold("/export [full] [thinking]")} — write this transcript to a Markdown file (secrets redacted; \`full\` keeps whole tool results, \`thinking\` includes the model's reasoning)\n` +
 						`- ${chalk.bold("/rewind [n]")} — go back to one of your earlier messages (no arg = list; conversation only, never files)\n` +
 						`- ${chalk.bold("/flush")} — send everything you queued to the running turn right now\n` +
 						`- ${chalk.bold("/context")} — where this thread's context window is going\n` +
@@ -4889,6 +4889,7 @@ export async function wireConnectUi(
 				const home = os.homedir();
 				const rendered = renderTranscriptMarkdown(messages, {
 					full,
+					includeThinking,
 					sessionKey: boundSessionKey,
 					now: () => at,
 					// Per-block redaction BEFORE truncation. A PEM key clipped at 2000

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -3904,7 +3904,24 @@ export async function wireConnectUi(
 				);
 			}
 			updateHeader();
-			void applySubscription();
+			// SWITCH THE VIEW, NOT JUST THE INPUT.
+			//
+			// Binding used to change where your typing GOES while leaving the
+			// previous thread's conversation on screen. You then read one thread
+			// and talked to another, with only the header line distinguishing
+			// them — and the header is the thing people stop seeing after a
+			// minute. `/new` has always cleared the region; binding to an
+			// EXISTING thread is the same context switch and needs the same
+			// treatment, plus the target's history rendered in place of what was
+			// there.
+			//
+			// Resubscribe FIRST so the gateway is already sending this thread's
+			// frames before we paint its transcript; otherwise a reply arriving
+			// mid-rebuild would be dropped by the off-lane guard.
+			void (async () => {
+				await applySubscription();
+				await doResume();
+			})();
 			return;
 		}
 
@@ -4290,7 +4307,24 @@ export async function wireConnectUi(
 				),
 			);
 			updateHeader();
-			void applySubscription();
+			// SWITCH THE VIEW, NOT JUST THE INPUT.
+			//
+			// Binding used to change where your typing GOES while leaving the
+			// previous thread's conversation on screen. You then read one thread
+			// and talked to another, with only the header line distinguishing
+			// them — and the header is the thing people stop seeing after a
+			// minute. `/new` has always cleared the region; binding to an
+			// EXISTING thread is the same context switch and needs the same
+			// treatment, plus the target's history rendered in place of what was
+			// there.
+			//
+			// Resubscribe FIRST so the gateway is already sending this thread's
+			// frames before we paint its transcript; otherwise a reply arriving
+			// mid-rebuild would be dropped by the off-lane guard.
+			void (async () => {
+				await applySubscription();
+				await doResume();
+			})();
 			return;
 		}
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -4818,9 +4818,26 @@ export async function wireConnectUi(
 		if (trimmed === "/export" || trimmed.startsWith("/export ")) {
 			editor.setText("");
 			const arg = trimmed === "/export" ? "" : trimmed.slice("/export ".length).trim();
-			const full = arg === "full";
-			if (arg && !full) {
-				insertBeforeEditor(new Text(`  ${brand.dim("usage: /export [full]")}`, 0, 0));
+			const words = arg ? arg.split(/\s+/) : [];
+			const full = words.includes("full");
+			// REASONING IS OPT-IN, AND UNTIL NOW IT WAS UNREACHABLE.
+			//
+			// The renderer has supported `includeThinking` since it was written,
+			// and nothing ever passed it — so the only way to see reasoning was to
+			// catch it live as it streamed. Miss it, or run with `/reasoning off`,
+			// and it was gone: there is no expand affordance in the TUI either.
+			//
+			// It stays opt-in rather than becoming the default. Reasoning is the
+			// largest single thing in a transcript, and it is the part most likely
+			// to contain something the operator would not choose to publish —
+			// which is exactly why the exporter excluded it by default to begin
+			// with. Asking for it is one word.
+			const includeThinking = words.includes("thinking");
+			const unknown = words.filter((w) => w !== "full" && w !== "thinking");
+			if (unknown.length > 0) {
+				insertBeforeEditor(
+					new Text(`  ${brand.dim("usage: /export [full] [thinking]")}`, 0, 0),
+				);
 				tui.requestRender();
 				return;
 			}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -25,6 +25,7 @@
  */
 
 import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http";
+import { extractReasoningTokens } from "../agents/usage/reasoning-tokens.js";
 import { requestForcedCompaction } from "../agents/compaction/force-request.js";
 import { createServer as createTcpServer } from "node:net";
 import { pathToFileURL } from "node:url";
@@ -2962,15 +2963,22 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 				reasoningTracker.beginTurn(agentIdForTurn, sessionKeyForTurn);
 			} else if (piEvent.type === "message_update") {
 				usageLedger.observePartial(agentIdForTurn, sessionKeyForTurn, (piEvent as any).message?.usage);
-				// Reasoning tokens, when the backend reports them. Pi folds them into
-				// `output` for its own providers, but Brigade's own transports read
-				// the raw relayed API frames and can carry the breakdown. Absent
-				// stays absent — the tracker ignores non-numbers, and the renderer
-				// omits the figure rather than printing a zero it cannot vouch for.
+				// Reasoning tokens, normalised across every provider shape.
+				//
+				// This used to read `usage.reasoningTokens` — a field Pi's `Usage`
+				// does not declare — through an `as any`, so it resolved for
+				// exactly one transport and silently to `undefined` everywhere
+				// else. `extractReasoningTokens` knows the Anthropic, OpenAI,
+				// Gemini and flat spellings, so any backend that reports the figure
+				// is read without a per-provider branch here.
+				//
+				// Absent stays absent: the tracker ignores non-numbers and the
+				// renderer falls back to reasoning VOLUME rather than printing a
+				// zero it cannot vouch for.
 				reasoningTracker.setTokens(
 					agentIdForTurn,
 					sessionKeyForTurn,
-					(piEvent as any).message?.usage?.reasoningTokens,
+					extractReasoningTokens((piEvent as any).message?.usage),
 				);
 				// Drive the live reasoning phase from the INNER streaming event.
 				// Pi carries `thinking_start` / `thinking_delta` / `thinking_end`
@@ -6540,6 +6548,36 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 	// wait on the npm registry, and an offline machine must boot in silence. The
 	// result rides the next state snapshot to every attached client, which ASKS the
 	// operator — we never update anything on our own. See `core/update-check.ts`.
+	// RE-CHECK PERIODICALLY, NOT ONCE AT BOOT.
+	//
+	// This ran exactly once, at startup, which makes the answer wrong for the
+	// normal case: a gateway that has been up for days booted BEFORE the release
+	// it is being asked about. `latestUpdate` stays `undefined`, and `/update`
+	// answers "You're on the latest published version" about a version that is
+	// no longer the latest — confidently, and self-reinforcingly, since the
+	// longer it runs the staler it gets. Observed with 1.35.1 published and
+	// 1.35.0 installed.
+	//
+	// Six hours is well under the interval at which anyone would notice a missed
+	// release, and it is one HEAD-ish request to the npm registry — negligible
+	// beside a daemon that streams tokens all day. `unref` so a pending timer can
+	// never hold the process open, and the check never rejects, so a laptop that
+	// is offline for a week simply keeps the last answer it had.
+	const UPDATE_RECHECK_MS = 6 * 60 * 60 * 1000;
+	const updateRecheck = setInterval(() => {
+		void checkForUpdate()
+			.then((found) => {
+				if (!found || found.latest === latestUpdate?.latest) return;
+				latestUpdate = found;
+				broadcastStateAllBindings();
+			})
+			.catch(() => {
+				/* never rejects; belt for a future refactor */
+			});
+	}, UPDATE_RECHECK_MS);
+	updateRecheck.unref?.();
+	disposeHandlers.push(() => clearInterval(updateRecheck));
+
 	void checkForUpdate()
 		.then((found) => {
 			if (!found) return;

--- a/src/ui/transcript-export.test.ts
+++ b/src/ui/transcript-export.test.ts
@@ -168,3 +168,45 @@ test("redaction runs before truncation, not after", () => {
 	});
 	assert.equal(sawLength, 9000, "the redactor saw a clipped body — ordering is wrong");
 });
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * `includeThinking` was supported by this renderer from the day it was
+ * written, and no caller ever passed it — so reasoning could not be exported
+ * at all. A code-quality bot caught the flag being parsed in the TUI and
+ * dropped on the floor, which is the same "built but never called" shape this
+ * whole batch of work exists to remove.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+test("reasoning is excluded by default", () => {
+	const md = renderTranscriptMarkdown(
+		[
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "SECRET-CHAIN-OF-THOUGHT" },
+					{ type: "text", text: "the answer" },
+				],
+			} as never,
+		],
+		{ now: () => new Date(0) },
+	);
+	assert.ok(!md.includes("SECRET-CHAIN-OF-THOUGHT"), "thinking must not leak into a default export");
+	assert.match(md, /the answer/);
+});
+
+test("reasoning is included when asked for, and the banner says so", () => {
+	const md = renderTranscriptMarkdown(
+		[
+			{
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "SECRET-CHAIN-OF-THOUGHT" },
+					{ type: "text", text: "the answer" },
+				],
+			} as never,
+		],
+		{ includeThinking: true, now: () => new Date(0) },
+	);
+	assert.match(md, /SECRET-CHAIN-OF-THOUGHT/);
+	assert.match(md, /Includes the model's reasoning/, "the artifact must disclose what it carries");
+});

--- a/src/ui/transcript-export.ts
+++ b/src/ui/transcript-export.ts
@@ -141,6 +141,17 @@ export function renderTranscriptMarkdown(
 	out.push(
 		"> Secrets matching common patterns have been redacted, and home paths replaced with `~`.",
 	);
+	// SAY WHEN REASONING IS IN THE FILE.
+	//
+	// It is excluded by default precisely because it is the part most likely to
+	// contain something the operator would not choose to publish. When they DO
+	// ask for it, the artifact should say so — an export that travels to a bug
+	// report should not surprise the next reader, or the person attaching it.
+	if (opts.includeThinking) {
+		out.push(
+			"> **Includes the model's reasoning** (`/export thinking`) — review it before sharing.",
+		);
+	}
 	out.push("> This is pattern matching, not a guarantee — **read before sharing.**");
 	out.push("");
 	out.push("---");


### PR DESCRIPTION
Two bugs found by using it, both the same shape: **a number that appears on one backend and silently not on another**, with nothing on screen to explain the difference.

## Reasoning tokens were `claude-cli`-only

The gateway read `message.usage.reasoningTokens` through an `as any` cast. **Pi's `Usage` declares no such field**, so the compiler couldn't point out that it resolves for exactly one transport — `claude-cli`, which builds its own usage record — and to `undefined` everywhere else.

Live symptom: the same model showed `400 reasoning tokens` on claude-cli and a bare `Thinking 2m 44s…` on OpenRouter.

`extractReasoningTokens` normalises the shapes providers actually use:

| provider | shape |
|---|---|
| Anthropic | `output_tokens_details.thinking_tokens` |
| OpenAI + compat | `completion_tokens_details.reasoning_tokens` (OpenRouter, Azure, Groq, Together, Fireworks all inherit this) |
| Google Gemini | `thoughtsTokenCount`, flat or under `usageMetadata` |
| local runtimes | `reasoning_tokens` / `thinking_tokens` |

Adding a backend now costs nothing — whatever usage object it produces is read without a per-provider branch at the call site.

### What it cannot do, stated in the module

It normalises a usage object it is **given**, and for Pi-native providers none arrives: Pi folds reasoning tokens into `output` before Brigade sees a usage record, and its only stream hooks are `onPayload` (the request) and `onResponse` (status + headers, *before the body is read*). There is no seam for the response body.

So the renderer falls back to what **is** measured on every backend — reasoning **volume**, counted from the deltas as they stream. It's a different unit and is labelled as one, never dressed up as a token count. It also does something tokens can't: it grows **live** during the phase, so a long think visibly progresses instead of sitting on a bare timer.

`undefined` still never renders as `0` — *"not reported"* and *"none"* are different facts, and only one of them is a measurement. A genuine `0` (Anthropic returns it for an easy prompt even at `high`) is preserved.

## `/update` never re-checked

`checkForUpdate()` ran **exactly once, at boot**. That makes the answer wrong for the normal case — a gateway up for days booted *before* the release it's being asked about — so `latestUpdate` stayed `undefined` and `/update` answered *"You're on the latest published version"* about a version that was no longer the latest. Confidently wrong, and self-reinforcing: the longer it runs, the staler it gets.

Observed directly: npm had **1.35.1**, the machine had **1.35.0** installed, and `/update` reported it was current.

Now re-checked every six hours on an `unref`'d timer cleared on shutdown. A periodic check rather than a new RPC, so the Desktop and Watch clients get it without a protocol change.

## Verification

6590 tests, typecheck and build clean.