### PR TITLE
fix: iMessage was broken end to end, plus one context-switch routine and two regressions of my own

### DIFF
--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -347,6 +347,24 @@ const MUTATIONS = [
 
   // ── iMessage self-thread ──
   {
+    claim: "a name is never converted into a phone number",
+    file: "src/agents/channels/imessage/targets.ts",
+    find: "\tif (/[a-z]/i.test(stripped)) return \"\";",
+    replace: "\tif (false) return \"\";",
+    tests: "src/agents/channels/imessage/targets.test.ts",
+  },
+  {
+    claim: "an agent echo in a self-thread does not mute the conversation",
+    file: "src/agents/channels/imessage/monitor.ts",
+    find: "\t\t\t\treturn { kind: \"drop\", reason: \"agent echo in self-chat\" };",
+    replace: "\t\t\t\tstate.loopRateLimiter.record(rateKey);\n\t\t\t\treturn { kind: \"drop\", reason: \"agent echo in self-chat\" };",
+    tests: "src/agents/channels/imessage/monitor.test.ts",
+    expectMissed: true,
+    reason: "the mute needs five hits across two exchanges to manifest; the unit tests decide one message at a time. Verified by hand with a five-turn simulation against the built module.",
+  },
+
+
+  {
     claim: "a reply in a self-thread reaches the agent",
     file: "src/agents/channels/imessage/monitor.ts",
     find: "\t\t\tskipSelfChatHasCheck = true;\n\t\t} else if (isSelfChat) {",

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -347,6 +347,22 @@ const MUTATIONS = [
 
   // ── iMessage self-thread ──
   {
+    claim: "a refused send is not reported as delivered",
+    file: "src/agents/channels/imessage/send.ts",
+    find: "\t\tif (explicitFailure) {",
+    replace: "\t\tif (false) {",
+    tests: "src/agents/channels/imessage/send.test.ts",
+  },
+  {
+    claim: "an all-scaffolding reply is never sent raw to the recipient",
+    file: "src/agents/channels/imessage/format.ts",
+    find: "\treturn cleaned.trim();",
+    replace: "\tconst t = cleaned.trim();\n\treturn t.length > 0 ? t : text.trim();",
+    tests: "src/agents/channels/imessage/format.test.ts",
+  },
+
+
+  {
     claim: "a name is never converted into a phone number",
     file: "src/agents/channels/imessage/targets.ts",
     find: "\tif (/[a-z]/i.test(stripped)) return \"\";",

--- a/scripts/mutation-check.mjs
+++ b/scripts/mutation-check.mjs
@@ -345,6 +345,15 @@ const MUTATIONS = [
     tests: "src/agents/source-is-text.test.ts",
   },
 
+  // ── iMessage self-thread ──
+  {
+    claim: "a reply in a self-thread reaches the agent",
+    file: "src/agents/channels/imessage/monitor.ts",
+    find: "\t\t\tskipSelfChatHasCheck = true;\n\t\t} else if (isSelfChat) {",
+    replace: "\t\t\treturn { kind: \"drop\", reason: \"from me\" };\n\t\t} else if (isSelfChat) {",
+    tests: "src/agents/channels/imessage/monitor.test.ts",
+  },
+
   // ── Manual compaction ──
   {
     claim: "an explicit /compact is honoured exactly once",

--- a/src/agents/agent-loop.ts
+++ b/src/agents/agent-loop.ts
@@ -2203,6 +2203,9 @@ async function runSingleTurnLocked(p: RunSingleTurnLockedArgs): Promise<RunSingl
               assertNoProviderErrorStop(session as AgentSession);
             },
             {
+              // The operator's cancellation, read at decision time. An abort
+              // must never be answered with a fresh billed turn.
+              aborted: () => args.signal?.aborted === true,
               onRetry: (reason: NonNullable<ContentQualityIssue>) => {
                 log.warn("content-quality retry triggered", {
                   agentId,

--- a/src/agents/channels/imessage/adapter.test.ts
+++ b/src/agents/channels/imessage/adapter.test.ts
@@ -14,6 +14,7 @@ function fakeConnection(): IMessageConnection & { sentText: Array<{ to: string; 
 	return {
 		sentText,
 		isConnected: () => true,
+	lastWatchError: () => undefined,
 		connectedAt: () => Date.now(),
 		async sendText(conversationId, text): Promise<{ messageId?: string }> {
 			sentText.push({ to: conversationId, text });

--- a/src/agents/channels/imessage/adapter.ts
+++ b/src/agents/channels/imessage/adapter.ts
@@ -192,7 +192,37 @@ export function createIMessageAdapter(opts: CreateIMessageAdapterOptions = {}): 
 
 		health(): ChannelHealth {
 			if (!connection) {
+				// SURFACE THE REASON WE ALREADY CAPTURED.
+				//
+				// `start()` records the real failure into `closedReason` —
+				// "authorization denied" when Full Disk Access is off,
+				// "imsg: command not found" when the bridge is missing — and this
+				// branch threw it away and said "not started yet", which reads as
+				// a transient boot state rather than a permission wall the
+				// operator has to go and fix. That is why a denied FDA presented
+				// as the channel simply never answering.
+				if (closedReason) {
+					return {
+						ok: false,
+						kind: "disconnected",
+						reason: `iMessage failed to start — ${closedReason}.`,
+						remediation:
+							"Check that the imsg CLI is installed and that Terminal has Full Disk Access, then restart the gateway.",
+					};
+				}
 				return { ok: false, kind: "starting", reason: "iMessage adapter is not started yet." };
+			}
+			// A watch error means the socket is fine and the reader is dead — no
+			// message will arrive again, yet every liveness signal says ok.
+			const watchErr = connection.lastWatchError?.();
+			if (watchErr) {
+				return {
+					ok: false,
+					kind: "disconnected",
+					reason: `iMessage is connected but its watch failed — ${watchErr}. Incoming messages are not being read.`,
+					remediation:
+						"Check Full Disk Access for Terminal and that Messages.app is signed in, then restart the channel.",
+				};
 			}
 			if (!connected || !connection.isConnected()) {
 				return {
@@ -221,6 +251,7 @@ export function createIMessageAdapter(opts: CreateIMessageAdapterOptions = {}): 
 			}
 			let first = true;
 			let lastMessageId: string | undefined;
+			let sentAny = false;
 			for (const chunk of chunks) {
 				const body = markdownToIMessageText(chunk);
 				if (body.trim().length === 0) continue;
@@ -228,7 +259,21 @@ export function createIMessageAdapter(opts: CreateIMessageAdapterOptions = {}): 
 				const replyOpt = first && opts?.replyToId ? { replyToId: opts.replyToId } : {};
 				const sent = await connection.sendText(conversationId, body, { ...replyOpt });
 				if (sent.messageId) lastMessageId = sent.messageId;
+				sentAny = true;
 				first = false;
+			}
+			// NOTHING WENT OUT — SAY SO.
+			//
+			// Every chunk can be skipped: an empty reply, whitespace, or a body
+			// that was entirely internal scaffolding (the outbound sanitizer now
+			// correctly returns "" for that rather than leaking it). This used to
+			// return `undefined`, which `plugin.ts` reports as `{ok:true}` — so a
+			// message that was never sent was reported delivered, and the operator
+			// had no way to know their reply vanished.
+			if (!sentAny) {
+				throw new Error(
+					"iMessage: nothing to send — the reply was empty after formatting (all chunks were blank or internal-only)",
+				);
 			}
 			return lastMessageId ? { messageId: lastMessageId } : undefined;
 		},

--- a/src/agents/channels/imessage/connection.ts
+++ b/src/agents/channels/imessage/connection.ts
@@ -32,6 +32,7 @@ import {
 	createMonitorState,
 	decideInbound,
 	echoScope,
+	normalizeHandle,
 	normalizeIMessageMessage,
 	parseIMessageNotification,
 	type MonitorState,
@@ -406,7 +407,9 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 		const numericChat = conversationId.startsWith("chat:") ? Number.parseInt(conversationId.slice(5), 10) : NaN;
 		const scope = Number.isFinite(numericChat)
 			? echoScope(account.accountId, { chat_id: numericChat })
-			: `${account.accountId}:imessage:${conversationId}`;
+			// Normalised the SAME way the inbound scope is, or the two disagree
+			// on casing/phone punctuation and the echo is never suppressed.
+			: `${account.accountId}:imessage:${normalizeHandle(conversationId)}`;
 		state.sentMessageCache.remember(scope, { text: sent.sentText, messageId: sent.messageId });
 	};
 

--- a/src/agents/channels/imessage/connection.ts
+++ b/src/agents/channels/imessage/connection.ts
@@ -124,6 +124,15 @@ export interface ConnectIMessageArgs {
 export interface IMessageConnection {
 	isConnected(): boolean;
 	connectedAt(): number | null;
+	/**
+	 * The last error the WATCH reported, if any.
+	 *
+	 * Distinct from a transport close: the subprocess is alive and the socket is
+	 * fine, but the thing that reads chat.db has failed — so `isConnected()` is
+	 * true while no message will ever arrive again. Exposed so `health()` can
+	 * say that instead of reporting ok.
+	 */
+	lastWatchError(): string | undefined;
 	/** Send text; returns the bridge message id when available. */
 	sendText(conversationId: string, text: string, opts?: OutboundSendOptions): Promise<{ messageId?: string }>;
 	/** Send media; returns the bridge message id when available. */
@@ -165,6 +174,7 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 	let client: IMessageRpcLike | null = null;
 	let connected = false;
 	let connectedAtMs: number | null = null;
+	let lastWatchError: string | undefined;
 	let closed = false;
 	let attempt = 0;
 
@@ -198,7 +208,21 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 				// Sanitize before logging — the payload is attacker-influenced (a
 				// crafted row / remote bridge could smuggle ANSI escapes or a huge
 				// blob). Keep only a finite code + a stripped/truncated message.
-				args.log("imessage watch error", { error: sanitizeIMessageWatchErrorPayload(msg.params) });
+				const sanitized = sanitizeIMessageWatchErrorPayload(msg.params);
+				args.log("imessage watch error", { error: sanitized });
+				// A DEAD WATCH MUST NOT REPORT HEALTHY.
+				//
+				// This was logged and nothing else: `connected` stayed true and
+				// `health()` kept returning ok, so a watch that had died — chat.db
+				// unreadable, Full Disk Access revoked mid-run, the watcher thread
+				// gone — presented as a working channel that simply never received
+				// anything. Silence is the one symptom an operator cannot
+				// distinguish from "nobody messaged me".
+				//
+				// Recorded so `health()` can degrade and say what happened. The
+				// supervise loop owns reconnection; this makes the state visible
+				// rather than pretending it away.
+				lastWatchError = sanitized.message ?? "the imsg watch reported an error";
 				return;
 			}
 			if (msg.method !== "message") return;
@@ -427,6 +451,7 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 
 	return {
 		isConnected: () => connected,
+		lastWatchError: () => lastWatchError,
 		connectedAt: () => connectedAtMs,
 		async sendText(conversationId, text, opts): Promise<{ messageId?: string }> {
 			const result = await sendFn(conversationId, text, {

--- a/src/agents/channels/imessage/format.ts
+++ b/src/agents/channels/imessage/format.ts
@@ -140,8 +140,24 @@ function stripReasoningBlocks(text: string): string {
 
 /**
  * Strip Brigade-internal scaffolding from outbound text before it hits the wire.
- * Returns the cleaned text; if stripping leaves nothing, returns the trimmed
- * original (better to send something than confuse the recipient with silence).
+ *
+ * Returns "" when stripping leaves nothing — the caller must then send NOTHING.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THE OLD FALLBACK WAS EXACTLY BACKWARDS
+ * ─────────────────────────────────────────────────────────────────────────
+ * This used to return the raw original in that case, reasoning that it is
+ * "better to send something than confuse the recipient with silence". But the
+ * case where stripping empties the text is precisely the case where the body
+ * was ENTIRELY internal scaffolding — so "something" is the model's private
+ * reasoning, or a `[[reply_to:…]]` directive, delivered verbatim to another
+ * person. Proven: `"&lt;think&gt;secret plan&lt;/think&gt;"` went out as-is,
+ * contradicting this module's own rule that such text "must never reach a
+ * recipient's iMessage thread".
+ *
+ * Silence is the correct outcome. A recipient seeing nothing is a bug the
+ * operator can notice and report; a recipient seeing the model's reasoning
+ * cannot be taken back.
  */
 export function sanitizeOutboundIMessageText(text: string): string {
 	if (!text) return text;
@@ -153,8 +169,7 @@ export function sanitizeOutboundIMessageText(text: string): string {
 	cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");
 	// Collapse runs of spaces a strip can leave mid-line, then blank lines.
 	cleaned = cleaned.replace(/[ \t]{2,}/g, " ").replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n");
-	const trimmed = cleaned.trim();
-	return trimmed.length > 0 ? trimmed : text.trim();
+	return cleaned.trim();
 }
 
 /** Outbound media kind → the placeholder text used when the message has no body. */

--- a/src/agents/channels/imessage/monitor.test.ts
+++ b/src/agents/channels/imessage/monitor.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
 	createMonitorState,
 	decideInbound,
+	echoScope,
 	detectIMessageMentions,
 	detectReflectedContent,
 	findCodeRegions,
@@ -238,5 +239,90 @@ describe("decideInbound", () => {
 		const d = decideInbound(state, "acct", { sender: "+1555", text: "a real new message" });
 		assert.equal(d.kind, "drop");
 		if (d.kind === "drop") assert.equal(d.reason, "loop rate-limited");
+	});
+});
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Messaging your own Apple ID is the most obvious way to try this channel,
+ * and it was the one that silently did not work.
+ *
+ * In a self-thread EVERY row is `is_from_me=true` — the operator's replies
+ * included — and the Messages DB frequently leaves `destination_caller_id`
+ * empty. The "ambiguous self" branch then dropped unconditionally, so a reply
+ * typed in Messages.app was discarded before it reached the agent. The
+ * operator sees it delivered and read, and Brigade never answers.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe("decideInbound — self-thread with no destination_caller_id", () => {
+	const selfChatPayload = (text: string) => ({
+		id: 1,
+		guid: `guid-${text}`,
+		sender: "me@example.com",
+		chat_identifier: "me@example.com",
+		// The case that broke it: the DB did not populate this.
+		destination_caller_id: undefined,
+		is_from_me: true,
+		is_group: false,
+		text,
+		created_at: new Date().toISOString(),
+	});
+
+	it("dispatches the operator's own reply instead of dropping it", () => {
+		const state = createMonitorState();
+		const d = decideInbound(state, "default", selfChatPayload("hey are you there"));
+		assert.equal(d.kind, "dispatch", `expected dispatch, got ${d.kind}: ${(d as { reason?: string }).reason}`);
+	});
+
+	it("still drops Brigade's OWN send, via the echo cache", () => {
+		// The discriminator that makes the above safe: what Brigade sent is in
+		// the sent cache; what the operator typed is not.
+		const state = createMonitorState();
+		const text = "Hey — Brigade here, iMessage channel is live.";
+		const payload = selfChatPayload(text);
+		state.sentMessageCache.remember(echoScope("default", payload), { text, messageId: "1" });
+		const d = decideInbound(state, "default", payload);
+		assert.equal(d.kind, "drop");
+		assert.match((d as { reason: string }).reason, /echo/);
+	});
+
+	it("a configured selfHandle resolves the ambiguity outright", () => {
+		// With the bot's own handle known, the thread is a DEFINITE self-chat
+		// and no longer depends on the DB populating a field it often omits.
+		const state = createMonitorState();
+		const d = decideInbound(state, "default", selfChatPayload("ping"), "me@example.com");
+		assert.equal(d.kind, "dispatch");
+	});
+
+	it("a normal inbound DM from someone else is unaffected", () => {
+		const state = createMonitorState();
+		const d = decideInbound(state, "default", {
+			id: 2,
+			guid: "guid-other",
+			sender: "friend@example.com",
+			chat_identifier: "friend@example.com",
+			is_from_me: false,
+			is_group: false,
+			text: "hello",
+			created_at: new Date().toISOString(),
+		});
+		assert.equal(d.kind, "dispatch");
+	});
+
+	it("an outbound message to SOMEONE ELSE is still dropped as from-me", () => {
+		// The guard that must not be weakened: Brigade replying to a friend must
+		// not be re-ingested as if the friend had said it.
+		const state = createMonitorState();
+		const d = decideInbound(state, "default", {
+			id: 3,
+			guid: "guid-out",
+			sender: "me@example.com",
+			chat_identifier: "friend@example.com",
+			is_from_me: true,
+			is_group: false,
+			text: "sent by the agent",
+			created_at: new Date().toISOString(),
+		});
+		assert.equal(d.kind, "drop");
+		assert.match((d as { reason: string }).reason, /from me/);
 	});
 });

--- a/src/agents/channels/imessage/monitor.test.ts
+++ b/src/agents/channels/imessage/monitor.test.ts
@@ -9,6 +9,7 @@ import {
 	detectReflectedContent,
 	findCodeRegions,
 	isInsideCode,
+	normalizeHandle,
 	normalizeIMessageMessage,
 	parseIMessageNotification,
 	stripLengthPrefixedText,
@@ -324,5 +325,51 @@ describe("decideInbound — self-thread with no destination_caller_id", () => {
 		});
 		assert.equal(d.kind, "drop");
 		assert.match((d as { reason: string }).reason, /from me/);
+	});
+});
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * The echo scope must agree across inbound and outbound, or Brigade
+ * re-ingests its own message.
+ *
+ * Inbound takes the handle from the Messages DB; outbound from whatever the
+ * caller addressed. The two spell the same person differently routinely —
+ * casing on an Apple ID, punctuation on a phone number — and an unnormalised
+ * key means the echo is never found. That is a live loop risk, not cosmetic:
+ * the self-thread path now DISPATCHES anything the cache does not recognise.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe("normalizeHandle / echoScope agreement", () => {
+	it("an Apple ID matches regardless of casing", () => {
+		assert.equal(normalizeHandle("Bhasvanth02@Gmail.com"), normalizeHandle("bhasvanth02@gmail.com"));
+	});
+
+	it("a phone number matches regardless of punctuation", () => {
+		const canonical = normalizeHandle("+16464201739");
+		assert.equal(normalizeHandle("+1 (646) 420-1739"), canonical);
+		assert.equal(normalizeHandle("+1-646-420-1739"), canonical);
+		assert.equal(normalizeHandle(" +1 646 420 1739 "), canonical);
+	});
+
+	it("the inbound scope matches an outbound scope built from the same handle", () => {
+		// The exact pairing the echo suppression depends on.
+		const inbound = echoScope("default", { sender: "Bhasvanth02@Gmail.com" });
+		const outbound = `default:imessage:${normalizeHandle("bhasvanth02@gmail.com")}`;
+		assert.equal(inbound, outbound);
+	});
+
+	it("different people never collide", () => {
+		assert.notEqual(normalizeHandle("a@example.com"), normalizeHandle("b@example.com"));
+		assert.notEqual(normalizeHandle("+16464201739"), normalizeHandle("+16464201730"));
+	});
+
+	it("an unrecognised address is passed through, not mangled", () => {
+		assert.equal(normalizeHandle("  Some.Odd_Handle  "), "some.odd_handle");
+		assert.equal(normalizeHandle(""), "");
+		assert.equal(normalizeHandle(undefined), "");
+	});
+
+	it("a group chat still keys on chat_id, not the handle", () => {
+		assert.equal(echoScope("default", { chat_id: 21, sender: "whoever" }), "default:chat_id:21");
 	});
 });

--- a/src/agents/channels/imessage/monitor.ts
+++ b/src/agents/channels/imessage/monitor.ts
@@ -480,9 +480,36 @@ export function createMonitorState(): MonitorState {
 }
 
 /** Build the echo/rate-limit scope for a payload. */
+/**
+ * Canonical form of an iMessage handle, for keys that must agree across the
+ * inbound and outbound paths.
+ *
+ * The echo cache is keyed by scope, and the scope embeds the handle. Inbound
+ * takes it from the Messages DB (`sender`), outbound from whatever the caller
+ * addressed (`conversationId`) — and the two spell the same person differently
+ * all the time: `Name@Example.com` vs `name@example.com`, `+1 (646) 420-1739`
+ * vs `+16464201739`. An unnormalised key means the scopes disagree, the echo is
+ * never found, and Brigade re-ingests its own message.
+ *
+ * Lower-cases, and for anything phone-shaped keeps only digits and a leading
+ * `+`. Deliberately conservative: an address it does not recognise is passed
+ * through trimmed and lower-cased rather than mangled.
+ */
+export function normalizeHandle(raw: string | undefined | null): string {
+	const t = (raw ?? "").trim();
+	if (!t) return "";
+	// Phone-shaped: digits, spaces, and the usual punctuation. Emails always
+	// contain `@`, so they can never match this.
+	if (/^\+?[\d\s().-]+$/.test(t)) {
+		const digits = t.replace(/[^\d]/g, "");
+		return digits ? `${t.trimStart().startsWith("+") ? "+" : ""}${digits}` : t.toLowerCase();
+	}
+	return t.toLowerCase();
+}
+
 export function echoScope(accountId: string, payload: IMessagePayload): string {
 	if (typeof payload.chat_id === "number") return `${accountId}:chat_id:${payload.chat_id}`;
-	return `${accountId}:imessage:${(payload.sender ?? "").trim()}`;
+	return `${accountId}:imessage:${normalizeHandle(payload.sender)}`;
 }
 
 /** The decision returned by {@link decideInbound}. */

--- a/src/agents/channels/imessage/monitor.ts
+++ b/src/agents/channels/imessage/monitor.ts
@@ -519,18 +519,41 @@ export function decideInbound(
 	const senderNorm = sender.toLowerCase();
 	const chatIdentNorm = (payload.chat_identifier ?? "").trim().toLowerCase();
 	const destNorm = (payload.destination_caller_id ?? "").trim().toLowerCase();
-	const isSelfChat = !payload.is_group && senderNorm !== "" && senderNorm === chatIdentNorm && destNorm === senderNorm;
-	const isAmbiguousSelf =
-		!payload.is_group && senderNorm !== "" && senderNorm === chatIdentNorm && destNorm === "";
+	// The bot's OWN handle, when the operator configured one. It is the only
+	// signal that identifies a self-thread without depending on the Messages DB
+	// populating `destination_caller_id` — which it frequently does not.
+	const selfNorm = (selfHandle ?? "").trim().toLowerCase();
+	const looksSelfAddressed = !payload.is_group && senderNorm !== "" && senderNorm === chatIdentNorm;
+	const isSelfChat =
+		looksSelfAddressed && (destNorm === senderNorm || (selfNorm !== "" && senderNorm === selfNorm));
+	const isAmbiguousSelf = looksSelfAddressed && destNorm === "" && !isSelfChat;
 
 	let skipSelfChatHasCheck = false;
 	if (payload.is_from_me === true) {
 		if (isAmbiguousSelf) {
+			// AN AMBIGUOUS SELF-THREAD IS STILL A SELF-THREAD.
+			//
+			// This dropped unconditionally, and that silently disabled the whole
+			// channel for the most obvious way to try it: message your own Apple
+			// ID. In a self-thread EVERY message is `is_from_me=true` — the
+			// operator's replies included — and `destination_caller_id` is often
+			// empty in the Messages DB, so the definite-self branch below never
+			// fired and every genuine reply was discarded as "from me". The
+			// operator sees their message delivered and Brigade never answers.
+			//
+			// The echo cache is exactly the discriminator this needs, and the
+			// definite-self branch already trusts it: a message Brigade sent is in
+			// the sent cache, a message the operator typed is not. Treating the
+			// ambiguous case the same way makes the channel work while keeping the
+			// loop guard, with the rate limiter as the backstop it already was.
 			state.selfChatCache.remember(scope, text, payload.created_at ? Date.parse(payload.created_at) : undefined);
-			state.loopRateLimiter.record(rateKey);
-			return { kind: "drop", reason: "from me" };
-		}
-		if (isSelfChat) {
+			const echo = state.sentMessageCache.has(scope, { text, messageId: inboundIds[0] }, !hasGuid);
+			if (echo) {
+				state.loopRateLimiter.record(rateKey);
+				return { kind: "drop", reason: "agent echo in self-chat" };
+			}
+			skipSelfChatHasCheck = true;
+		} else if (isSelfChat) {
 			state.selfChatCache.remember(scope, text, payload.created_at ? Date.parse(payload.created_at) : undefined);
 			const echo = state.sentMessageCache.has(scope, { text, messageId: inboundIds[0] }, !hasGuid);
 			if (echo) {

--- a/src/agents/channels/imessage/monitor.ts
+++ b/src/agents/channels/imessage/monitor.ts
@@ -543,53 +543,72 @@ export function decideInbound(
 	const hasGuid = Boolean(payload.guid);
 
 	// Self-chat detection (DM only).
-	const senderNorm = sender.toLowerCase();
-	const chatIdentNorm = (payload.chat_identifier ?? "").trim().toLowerCase();
-	const destNorm = (payload.destination_caller_id ?? "").trim().toLowerCase();
-	// The bot's OWN handle, when the operator configured one. It is the only
-	// signal that identifies a self-thread without depending on the Messages DB
-	// populating `destination_caller_id` — which it frequently does not.
-	const selfNorm = (selfHandle ?? "").trim().toLowerCase();
-	const looksSelfAddressed = !payload.is_group && senderNorm !== "" && senderNorm === chatIdentNorm;
-	const isSelfChat =
-		looksSelfAddressed && (destNorm === senderNorm || (selfNorm !== "" && senderNorm === selfNorm));
-	const isAmbiguousSelf = looksSelfAddressed && destNorm === "" && !isSelfChat;
+	// SELF-ADDRESSED IS SELF-ADDRESSED. `destination_caller_id` only CONFIRMS.
+	//
+	// The first version of this keyed on that field and dropped when it was
+	// empty. The fix covered the empty case and still missed the other half of
+	// the input space: a Mac signed in with an Apple ID reports the EMAIL as
+	// `destination_caller_id` while `sender`/`chat_identifier` are the PHONE, so
+	// the field is populated but different — neither "definitely self" nor
+	// "ambiguous" — and the operator's reply was dropped as "from me" exactly as
+	// before.
+	//
+	// The reliable signal is the one that does not depend on the DB's choice of
+	// alias: a DM whose sender IS the thread it arrived in can only be a thread
+	// with yourself. `destination_caller_id` and `selfHandle` are corroboration,
+	// never a requirement.
+	//
+	// All three handles go through `normalizeHandle`, because the DB spells the
+	// same person differently across fields — `+1 (646) 420-1739` in one and
+	// `+16464201739` in another — and a bare `toLowerCase()` made a configured
+	// PHONE `selfHandle` unable to ever match (`resolveIMessageSelfHandle`
+	// stores it digits-only).
+	const senderNorm = normalizeHandle(sender);
+	const chatIdentNorm = normalizeHandle(payload.chat_identifier);
+	const destNorm = normalizeHandle(payload.destination_caller_id);
+	const selfNorm = normalizeHandle(selfHandle);
+	const isSelfThread =
+		!payload.is_group &&
+		senderNorm !== "" &&
+		(senderNorm === chatIdentNorm ||
+			(selfNorm !== "" && senderNorm === selfNorm && chatIdentNorm === selfNorm) ||
+			(destNorm !== "" && destNorm === senderNorm && destNorm === chatIdentNorm));
 
 	let skipSelfChatHasCheck = false;
 	if (payload.is_from_me === true) {
-		if (isAmbiguousSelf) {
-			// AN AMBIGUOUS SELF-THREAD IS STILL A SELF-THREAD.
-			//
-			// This dropped unconditionally, and that silently disabled the whole
-			// channel for the most obvious way to try it: message your own Apple
-			// ID. In a self-thread EVERY message is `is_from_me=true` — the
-			// operator's replies included — and `destination_caller_id` is often
-			// empty in the Messages DB, so the definite-self branch below never
-			// fired and every genuine reply was discarded as "from me". The
-			// operator sees their message delivered and Brigade never answers.
-			//
-			// The echo cache is exactly the discriminator this needs, and the
-			// definite-self branch already trusts it: a message Brigade sent is in
-			// the sent cache, a message the operator typed is not. Treating the
-			// ambiguous case the same way makes the channel work while keeping the
-			// loop guard, with the rate limiter as the backstop it already was.
+		if (isSelfThread) {
+			// In a self-thread EVERY row is `is_from_me` — the operator's replies
+			// included — so the only way to tell "Brigade sent this" from "the
+			// operator typed this" is the sent-message cache.
 			state.selfChatCache.remember(scope, text, payload.created_at ? Date.parse(payload.created_at) : undefined);
-			const echo = state.sentMessageCache.has(scope, { text, messageId: inboundIds[0] }, !hasGuid);
+			// MATCH ON TEXT, NOT ID — the ids are different namespaces here.
+			//
+			// The send returns the bridge's own message id; the watch reports the
+			// chat.db row's id/guid. They never correspond, and the cache's
+			// id-backed guard then REJECTS an exact text match ("a send that had
+			// an id must be matched by id"). In an ordinary DM that costs nothing,
+			// because `is_from_me` drops the echo anyway. In a self-thread it is
+			// the difference between suppressing Brigade's own message and
+			// answering it — a loop, and one this branch newly makes reachable by
+			// dispatching what it cannot recognise.
+			//
+			// `skipIdShortCircuit` exists for exactly this: fall through to the
+			// text window when the id cannot be trusted to correspond.
+			const echo = state.sentMessageCache.has(scope, { text, messageId: inboundIds[0] }, true);
 			if (echo) {
-				state.loopRateLimiter.record(rateKey);
-				return { kind: "drop", reason: "agent echo in self-chat" };
-			}
-			skipSelfChatHasCheck = true;
-		} else if (isSelfChat) {
-			state.selfChatCache.remember(scope, text, payload.created_at ? Date.parse(payload.created_at) : undefined);
-			const echo = state.sentMessageCache.has(scope, { text, messageId: inboundIds[0] }, !hasGuid);
-			if (echo) {
-				state.loopRateLimiter.record(rateKey);
+				// NOT a loop hit. Seeing your own send come back is the normal,
+				// expected steady state of a self-thread — one echo per turn — and
+				// counting it drove the limiter to its 5-hit ceiling after two
+				// exchanges, muting the conversation on the operator's THIRD
+				// message. The limiter exists for repeats nothing explains.
 				return { kind: "drop", reason: "agent echo in self-chat" };
 			}
 			skipSelfChatHasCheck = true;
 		} else {
-			state.loopRateLimiter.record(rateKey);
+			// Brigade's own outbound to someone else, reflected back. Also the
+			// normal steady state, and also not loop evidence: a chunked reply is
+			// one row per line, so five lines in a group used to exhaust the
+			// limiter on the SAME key real messages use and mute the room.
 			return { kind: "drop", reason: "from me" };
 		}
 	}

--- a/src/agents/channels/imessage/send.test.ts
+++ b/src/agents/channels/imessage/send.test.ts
@@ -141,3 +141,52 @@ describe("sendMessageIMessage", () => {
 		/* tmp dirs are left for the OS to reap; no global state to reset */
 	});
 });
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * A send is not successful because it returned.
+ *
+ * The transport rejects on a JSON-RPC `error` member, so this code only ever
+ * sees a 200-shaped answer — but the bridge reports a refused send INSIDE the
+ * result. `{ok:false, error:"no such handle"}` fell through to
+ * `messageId:"unknown"`, which every caller reads as success, so an
+ * undeliverable message was reported delivered.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe("sendMessageIMessage — refuses to claim an unconfirmed delivery", () => {
+	const clientReturning = (result: unknown) => ({
+		request: async () => result,
+		stop: async () => {},
+	});
+
+	it("throws when the bridge refuses the send", async () => {
+		await assert.rejects(
+			() => sendMessageIMessage("+16464201739", "hi", { client: clientReturning({ ok: false, error: "no such handle" }) as never }),
+			/no such handle/,
+		);
+	});
+
+	it("throws when the result carries an error string", async () => {
+		await assert.rejects(
+			() => sendMessageIMessage("+16464201739", "hi", { client: clientReturning({ error: "not signed in" }) as never }),
+			/not signed in/,
+		);
+	});
+
+	it("throws when nothing acknowledges the send", async () => {
+		// No id, no ack. Absence of evidence is not evidence of delivery.
+		await assert.rejects(
+			() => sendMessageIMessage("+16464201739", "hi", { client: clientReturning({}) as never }),
+			/not confirmed/,
+		);
+	});
+
+	it("accepts a real message id", async () => {
+		const r = await sendMessageIMessage("+16464201739", "hi", { client: clientReturning({ messageId: "ABC-123" }) as never });
+		assert.equal(r.messageId, "ABC-123");
+	});
+
+	it("accepts a positive acknowledgement without an id", async () => {
+		const r = await sendMessageIMessage("+16464201739", "hi", { client: clientReturning({ ok: true }) as never });
+		assert.equal(r.messageId, "ok");
+	});
+});

--- a/src/agents/channels/imessage/send.ts
+++ b/src/agents/channels/imessage/send.ts
@@ -148,8 +148,41 @@ export async function sendMessageIMessage(
 			...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
 		});
 		const resolvedId = resolveMessageId(result);
+		// A SEND IS NOT SUCCESSFUL BECAUSE IT RETURNED.
+		//
+		// The transport rejects on a JSON-RPC `error` member, so this code only
+		// ever sees a 200-shaped answer — but the bridge reports a refused send
+		// INSIDE the result: `{ok:false, error:"no such handle"}`. That fell
+		// through to `messageId:"unknown"`, which every caller reads as success,
+		// so an undeliverable message was reported delivered. The operator is
+		// then told their reply went out and it never did.
+		//
+		// Absence of evidence is treated as failure here rather than success:
+		// no id and no positive acknowledgement means nothing confirmed the send,
+		// and claiming delivery on that basis is the failure mode this whole
+		// codebase keeps finding.
+		const record = (result ?? {}) as Record<string, unknown>;
+		const explicitFailure =
+			record.ok === false ||
+			(typeof record.error === "string" && record.error.trim() !== "") ||
+			(typeof record.ok === "string" && record.ok.trim().toLowerCase() === "false");
+		if (explicitFailure) {
+			const detail =
+				typeof record.error === "string" && record.error.trim() !== ""
+					? record.error.trim()
+					: "the bridge refused the send without saying why";
+			throw new Error(`iMessage send failed: ${detail}`);
+		}
+		const acknowledged =
+			record.ok === true ||
+			(typeof record.ok === "string" && record.ok.trim() !== "" && record.ok.trim().toLowerCase() !== "false");
+		if (!resolvedId && !acknowledged) {
+			throw new Error(
+				"iMessage send was not confirmed — the bridge returned no message id and no acknowledgement",
+			);
+		}
 		return {
-			messageId: resolvedId ?? (result && (result as { ok?: string }).ok ? "ok" : "unknown"),
+			messageId: resolvedId ?? "ok",
 			sentText: message,
 		};
 	} finally {

--- a/src/agents/channels/imessage/targets.test.ts
+++ b/src/agents/channels/imessage/targets.test.ts
@@ -128,3 +128,59 @@ describe("formatIMessageChatTarget + inferIMessageTargetChatType", () => {
 		assert.equal(inferIMessageTargetChatType("chat_id:5"), "group");
 	});
 });
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * A name must never become a phone number.
+ *
+ * `normalizeE164` stripped every non-digit and prepended `+`, so it never
+ * decided whether the input WAS a phone number — it manufactured one.
+ * `"Line 2"` became `"+2"`, and a private conversation went to whoever
+ * answers at that number. Sending to the wrong recipient is the worst outcome
+ * this channel has, and it took one plausible typo.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe("normalizeE164 — refuses to invent a number", () => {
+	it("a contact-ish name with a stray digit is NOT a phone number", () => {
+		assert.equal(normalizeE164("Line 2"), "");
+		assert.equal(normalizeE164("Room 101"), "");
+		assert.equal(normalizeE164("Mum"), "");
+	});
+
+	it("a NAME containing a full-length digit run is still refused", () => {
+		// The case only the letter check catches: the digit-count guard is
+		// satisfied, so without it this becomes a real, dialable number
+		// belonging to a stranger. "call 5551234567 for support" in a contact
+		// field is the shape that reaches here.
+		assert.equal(normalizeE164("Room 5551234567"), "");
+		assert.equal(normalizeE164("call 5551234567"), "");
+		assert.equal(normalizeE164("Support x16464201739"), "");
+	});
+
+	it("a digit fragment is refused rather than prefixed", () => {
+		// A fragment with a `+` in front is a real number belonging to someone.
+		assert.equal(normalizeE164("2"), "");
+		assert.equal(normalizeE164("12345"), "");
+	});
+
+	it("an over-long digit run is refused", () => {
+		// E.164 caps at 15 digits; longer is an id, an order number, anything.
+		assert.equal(normalizeE164("12345678901234567890"), "");
+	});
+
+	it("genuine numbers still normalise", () => {
+		assert.equal(normalizeE164("+1 (646) 420-1739"), "+16464201739");
+		assert.equal(normalizeE164("+16464201739"), "+16464201739");
+		assert.equal(normalizeE164("555-123-4567"), "+5551234567");
+	});
+
+	it("an email is not a phone number", () => {
+		assert.equal(normalizeE164("me@example.com"), "");
+	});
+
+	it("a handle that is not a phone falls through intact", () => {
+		// The caller treats "" as "try the other handle shapes", so a name must
+		// survive normalisation rather than being mangled into a number.
+		assert.equal(normalizeIMessageHandle("Line 2"), "Line2");
+		assert.equal(normalizeIMessageHandle("me@Example.com"), "me@example.com");
+	});
+});

--- a/src/agents/channels/imessage/targets.ts
+++ b/src/agents/channels/imessage/targets.ts
@@ -56,15 +56,51 @@ function stripPrefix(value: string, prefix: string): string {
 }
 
 /**
- * Normalise a phone-ish string to E.164. Strips a leading `scheme:`, removes
- * everything but digits and `+`, and prepends `+` when missing.
+ * Normalise a phone-ish string to E.164, or return "" when it is not a phone
+ * number at all.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THE "IS THIS EVEN A PHONE NUMBER" CHECK EXISTS
+ * ─────────────────────────────────────────────────────────────────────────
+ * This used to strip every non-digit and prepend `+` unconditionally, which
+ * means it did not decide whether the input WAS a phone number — it just made
+ * one. `"Line 2"` became `"+2"`. A contact-ish string with a stray digit was
+ * silently converted into a phone number and dialled, and the operator's
+ * message went to whoever answers at that number. Sending a private
+ * conversation to the wrong recipient is the worst outcome this channel has,
+ * and it took one plausible typo.
+ *
+ * So: letters disqualify. A string with any alphabetic character is not a
+ * phone number and gets "" back, which callers already treat as "not a phone,
+ * try the other handle shapes" (`normalizeIMessageHandle` falls through to the
+ * whitespace-stripped form).
+ *
+ * A minimum digit count is also required. Real E.164 numbers are 7-15 digits;
+ * anything shorter is a fragment, and a fragment prepended with `+` is a
+ * number belonging to someone else. Short codes exist, but they are not
+ * addressable over iMessage, so refusing them costs nothing real.
+ *
+ * NOT fixed here, and deliberately: a national-format number without a country
+ * code (`555-123-4567`) still gets a bare `+` and no region applied. The
+ * account's `region` is known only to the bridge, and stamping `+` here is
+ * what prevents the bridge from applying it. That needs the region threaded
+ * into this call, which is a wider change than this guard — but it now fails
+ * as a wrong number rather than as a wrong PERSON, because a name can no
+ * longer reach this path at all.
  */
+const MIN_E164_DIGITS = 7;
+const MAX_E164_DIGITS = 15;
+
 export function normalizeE164(raw: string): string {
-	let v = raw.trim().replace(/^[a-z][a-z0-9-]*:/i, "");
-	v = v.replace(/[^0-9+]/g, "");
+	const stripped = raw.trim().replace(/^[a-z][a-z0-9-]*:/i, "").trim();
+	if (!stripped) return "";
+	// Letters mean this is a name, an alias, or a handle — never a phone.
+	if (/[a-z]/i.test(stripped)) return "";
+	const v = stripped.replace(/[^0-9+]/g, "");
 	if (!v) return "";
-	if (v.startsWith("+")) return `+${v.slice(1).replace(/\+/g, "")}`;
-	return `+${v.replace(/\+/g, "")}`;
+	const digits = v.replace(/\D/g, "");
+	if (digits.length < MIN_E164_DIGITS || digits.length > MAX_E164_DIGITS) return "";
+	return `+${digits}`;
 }
 
 /**

--- a/src/agents/content-quality-retry.test.ts
+++ b/src/agents/content-quality-retry.test.ts
@@ -358,3 +358,39 @@ describe("harness backends: the recovery tier must not re-run side effects", () 
 		assert.deepEqual(order, []);
 	});
 });
+
+describe("a cancelled turn is not a low-quality turn", () => {
+/* ─────────────────────────────────────────────────────────────────────────
+ * A cancelled turn is not a low-quality turn.
+ *
+ * Reported live: Ctrl+C, then immediately "empty — re-prompting for a usable
+ * answer" and a full billed reply to a question the operator had just
+ * withdrawn. An aborted turn leaves an empty assistant message, which every
+ * heuristic here reads as "the model said nothing".
+ * ───────────────────────────────────────────────────────────────────────── */
+
+it("an ABORTED turn is never treated as a quality problem", () => {
+	assert.equal(
+		detectContentIssue({ role: "assistant", content: [], stopReason: "aborted" }, false),
+		null,
+		"the operator asked for it to stop; re-prompting bills them for a withdrawn question",
+	);
+});
+
+it("an ERRORED turn is not re-prompted on top of its own failure", () => {
+	// The retry/fallback machinery upstream already handled it.
+	assert.equal(
+		detectContentIssue({ role: "assistant", content: [], stopReason: "error" }, false),
+		null,
+	);
+});
+
+it("a genuinely empty COMPLETED turn is still caught", () => {
+	// The guard must not blunt the check it is narrowing.
+	assert.equal(
+		detectContentIssue({ role: "assistant", content: [], stopReason: "stop" }, false),
+		"empty",
+	);
+	assert.equal(detectContentIssue({ role: "assistant", content: [] }, false), "empty");
+});
+});

--- a/src/agents/content-quality-retry.ts
+++ b/src/agents/content-quality-retry.ts
@@ -74,10 +74,25 @@ const STEER_FOR: Record<NonNullable<ContentQualityIssue>, string> = {
  * write the code" IS the deliverable).
  */
 export function detectContentIssue(
-	message: { role?: string; content?: unknown } | null | undefined,
+	message: { role?: string; content?: unknown; stopReason?: unknown } | null | undefined,
 	hadTools: boolean,
 ): ContentQualityIssue {
 	if (!message || message.role !== "assistant") return null;
+	// A CANCELLED TURN IS NOT A LOW-QUALITY TURN.
+	//
+	// An aborted turn leaves an empty or partial assistant message, which reads
+	// to every heuristic below as "the model said nothing" — so the operator
+	// pressed Ctrl+C and Brigade immediately re-prompted, producing a full,
+	// billed answer to a question they had just cancelled. Reported live: an
+	// abort followed instantly by "empty — re-prompting for a usable answer"
+	// and a long reply to an earlier message.
+	//
+	// `error` is excluded for the same reason from the other direction: a turn
+	// that failed has already been handled by the retry/fallback machinery
+	// upstream, and re-prompting on top of it doubles the damage rather than
+	// improving the answer. Neither is a QUALITY judgement, which is the only
+	// thing this function is entitled to make.
+	if (message.stopReason === "aborted" || message.stopReason === "error") return null;
 	const content = message.content;
 	if (!Array.isArray(content) || content.length === 0) return "empty";
 
@@ -161,6 +176,13 @@ export interface ContentQualityRetryOptions {
 	 * Omitted (every loop backend) => no-op; Pi's loop already persists tool calls.
 	 */
 	beforeRetry?: () => void;
+	/**
+	 * Was this turn cancelled by the operator?
+	 *
+	 * A cancelled turn must never be re-prompted: the operator asked for it to
+	 * STOP, and a retry bills them for an answer to a question they withdrew.
+	 */
+	aborted?: () => boolean;
 }
 
 /**
@@ -200,6 +222,14 @@ export async function runWithContentQualityRetry(
 
 	const issue = inspectLast();
 	if (!issue) return;
+
+	// The turn's signal, checked independently of the message.
+	//
+	// Belt to the `stopReason` brace above: Pi DELETES an aborted assistant
+	// message in some paths, so the "last assistant" we inspect can be an older,
+	// legitimately-empty one from before the abort. The signal is the fact that
+	// cannot be erased by whatever the transcript ends up holding.
+	if (options.aborted?.() === true) return;
 
 	// A harness backend ran tools out-of-band, so the assistant message cannot
 	// carry toolCall blocks and the recovery heuristics all misread it as "never

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -832,6 +832,71 @@ export async function wireConnectUi(
 		return "";
 	};
 
+	/**
+	 * Everything that must forget the old thread when the context changes.
+	 *
+	 * ─────────────────────────────────────────────────────────────────────────
+	 * WHY THIS IS ONE FUNCTION
+	 * ─────────────────────────────────────────────────────────────────────────
+	 * Four commands switch context — `/new`, `/session`, `/agent`, `/delete` —
+	 * and each maintained its own hand-written sequence. They diverged, exactly
+	 * as that arrangement guarantees: one cleared the transcript, another zeroed
+	 * the totals, a third did neither, and a whole set of per-thread values was
+	 * cleared by NONE of them.
+	 *
+	 * The ones nothing reset are the dangerous half, because they are read by
+	 * commands that then act on the wrong thread:
+	 *
+	 *   • `lastUserPrompt` / `lastUserAttachments` — `/switch` replays these, so
+	 *     it re-sent the PREVIOUS thread's message, with its attachments, into
+	 *     the new one. That does not merely mislead; it acts.
+	 *   • `toolCallInfo` — `/expand` with no argument is documented as "the
+	 *     result you just saw", and printed one from a thread whose transcript
+	 *     had been wiped off the screen.
+	 *   • `lastReplyText` — `/copy` copied the previous thread's reply and
+	 *     confirmed with a byte count, so it looked like it worked.
+	 *   • the queue chip and the running/elapsed state — the old lane's
+	 *     `agent_end` is dropped by the off-lane guard, so a `●` dot and a
+	 *     climbing timer sat over an idle thread while `/abort` insisted a turn
+	 *     was running and `/update` refused to run because of it.
+	 *
+	 * Adding a per-thread value now means adding it HERE, once, instead of
+	 * remembering four call sites.
+	 */
+	const switchContext = (what: string, opts: { zeroTotals?: boolean } = {}): void => {
+		clearTrayForContextSwitch(what);
+		// The collapsed-notice widget lives in the region about to be cleared.
+		lastSystemEventLine = undefined;
+		// Replay + "last thing" state. All of these answer "in this thread",
+		// and after a switch this thread has no answer yet.
+		lastUserPrompt = "";
+		lastUserAttachments = [];
+		lastReplyText = "";
+		toolCallInfo.clear();
+		// Turn state belongs to the lane we just left. Its terminal event will be
+		// filtered out as off-lane, so nothing else will ever clear these.
+		queuedSteering = [];
+		queuedFollowUp = [];
+		isAgentRunning = false;
+		agentStartedAt = null;
+		// Usage figures are per (agent, sessionKey) at the gateway, so a fresh
+		// binding WILL report zero — but only after `subscribe` round-trips.
+		// Zeroing here stops the previous thread's totals sitting under the new
+		// thread's banner in the meantime, which reads as context carrying over.
+		if (opts.zeroTotals !== false && lastSnapshot) {
+			lastSnapshot = {
+				...lastSnapshot,
+				totalTokensIn: 0,
+				totalTokensOut: 0,
+				totalCostUsd: 0,
+				contextUsagePercent: null,
+				contextTokens: null,
+				messageCount: 0,
+				reasoning: undefined,
+			} as typeof lastSnapshot;
+		}
+	};
+
 	/** Take the "thinking" spinner down. Called only when a paint is about to land. */
 	const dismissLoader = (): void => {
 		if (!activeLoader) return;
@@ -1444,7 +1509,17 @@ export async function wireConnectUi(
 	);
 
 	type AnyChild = Text | Markdown | CancellableLoader | BrigadeEditor | ApprovalPrompt;
+	/**
+	 * The last system-event line, kept so an identical CONSECUTIVE repeat can
+	 * update it in place instead of adding another row. Reset by any other
+	 * insert below, which is what makes "consecutive" mean consecutive — a
+	 * repeat after real activity is a new occurrence and must print anew,
+	 * rather than retroactively bumping a counter far up the scrollback.
+	 */
+	let lastSystemEventLine: { widget: Text; body: string; count: number } | undefined;
+
 	const insertBeforeEditor = (component: AnyChild): void => {
+		lastSystemEventLine = undefined;
 		const children = tui.children;
 		const editorIdx = children.indexOf(editor);
 		if (editorIdx < 0) {
@@ -1796,16 +1871,43 @@ export async function wireConnectUi(
 	const renderSystemEventLine = (event: EventPayload["system-event"]): void => {
 		const eventText = scrubRenderable(event.text);
 		const isCron = event.source === "cron" || event.jobName !== undefined;
+		let body: string;
 		if (isCron) {
 			const name = event.jobName ?? "cron";
 			const heading = brand.amber(`🦁 [cron "${name}"]`);
 			let suffix = "";
 			if (event.delivered === true) suffix = ` ${brand.dim("· delivered")}`;
 			else if (event.delivered === false) suffix = ` ${brand.dim("· not delivered (TUI only)")}`;
-			insertBeforeEditor(new Text(`${heading} ${eventText}${suffix}`, 0, 0));
+			body = `${heading} ${eventText}${suffix}`;
 		} else {
-			insertBeforeEditor(new Text(`${brand.amber("🦁")} ${eventText}`, 0, 0));
+			body = `${brand.amber("🦁")} ${eventText}`;
 		}
+
+		// COLLAPSE AN IDENTICAL REPEAT INSTEAD OF REPRINTING IT.
+		//
+		// A channel in a retry loop re-emits the same notice on every attempt.
+		// Observed: a WhatsApp socket stuck reconnecting printed "scan the QR
+		// code shown in the gateway logs" five times inside one turn, between
+		// the operator's own messages, burying the conversation it was
+		// interleaved with. The notice is worth showing; the fifth copy is not.
+		//
+		// Updating the EXISTING widget rather than appending keeps the count
+		// visible without consuming scrollback — the same discipline the live
+		// tool panes use. Only a CONSECUTIVE repeat collapses: an identical
+		// notice separated by real activity is genuinely new information about a
+		// second occurrence, and merging those would hide it.
+		if (lastSystemEventLine && lastSystemEventLine.body === body) {
+			lastSystemEventLine.count += 1;
+			lastSystemEventLine.widget.setText(
+				`${body} ${brand.dim(`(×${lastSystemEventLine.count})`)}`,
+			);
+			tui.requestRender();
+			return;
+		}
+
+		const widget = new Text(body, 0, 0);
+		insertBeforeEditor(widget);
+		lastSystemEventLine = { widget, body, count: 1 };
 		tui.requestRender();
 	};
 
@@ -3840,7 +3942,7 @@ export async function wireConnectUi(
 			);
 			// AFTER clearTranscriptRegion, or the notice is wiped along with the chips —
 			// which is precisely the silent-carry this call exists to prevent.
-			clearTrayForContextSwitch("the new thread");
+			switchContext("the new thread");
 			updateHeader();
 			void applySubscription();
 			return;
@@ -3884,7 +3986,7 @@ export async function wireConnectUi(
 			}
 
 			boundSessionKey = target;
-			clearTrayForContextSwitch("that thread");
+			switchContext("that thread");
 			insertBeforeEditor(
 				new Text(
 					`  ${brand.amber("✓")} ${brand.dim("bound to session")} ${brand.amber(target)}`,
@@ -4033,7 +4135,7 @@ export async function wireConnectUi(
 					// Omitting these left files staged for the DELETED thread armed to
 					// upload into the new one, and the connection still subscribed to a
 					// key that no longer exists — so the next turn streamed nothing.
-					clearTrayForContextSwitch("the new thread");
+					switchContext("the new thread");
 					updateHeader();
 					void applySubscription();
 				}
@@ -4281,7 +4383,21 @@ export async function wireConnectUi(
 				return;
 			}
 			boundAgentId = arg;
-			clearTrayForContextSwitch(`agent ${arg}`);
+			// DROP THE OLD AGENT'S SESSION KEY.
+			//
+			// This rebound the agent and left `boundSessionKey` pointing at the
+			// PREVIOUS agent's thread, so `withBinding()` emitted an incoherent
+			// pair — `{agentId: "research", sessionKey: "agent:main:t-abc"}`. The
+			// gateway resolves those independently: `resume` returned MAIN's
+			// transcript, and the next prompt ran research's runtime into main's
+			// thread. Nothing on screen revealed it, because the header renders
+			// the agent and `formatSessionLabel` returns nothing for a main key.
+			//
+			// `--agent X` at launch has always left the key undefined and let the
+			// gateway resolve that agent's own default session. Doing the same
+			// here makes the runtime path match the launch path.
+			boundSessionKey = undefined;
+			switchContext(`agent ${arg}`);
 			insertBeforeEditor(
 				new Text(
 					`  ${brand.amber("✓")} ${brand.dim("bound to agent")} ${brand.amber(arg)}`,
@@ -4695,6 +4811,19 @@ export async function wireConnectUi(
 					withBinding({ entryId: chosen.entryId }),
 				)) as SessionRewindResult;
 
+				// REBUILD THE VIEW BEFORE SAYING ANYTHING.
+				//
+				// The gateway moved the leaf, so the conversation on screen above
+				// this point is no longer the conversation the agent has. Leaving
+				// it there is the worst of the context-switch failures: the
+				// operator scrolls up, reads turns that were abandoned, and reasons
+				// and replies against them. `/new`, `/session`, `/agent` and
+				// `/delete` all rebuild — `/rewind` changes the history more than
+				// any of them and rebuilt nothing.
+				//
+				// Rebuilt FIRST so the confirmations below survive: a resume clears
+				// the region, which would wipe them if they were printed first.
+				await doResume();
 				insertBeforeEditor(
 					new Text(
 						`  ${brand.amber("✓")} ${brand.dim(`rewound to #${chosen.ordinal} — ${done.abandoned ?? 0} entries are no longer on the active path (nothing was deleted)`)}`,
@@ -4836,18 +4965,41 @@ export async function wireConnectUi(
 				}
 				const at = new Date();
 				const home = os.homedir();
+				// COUNT WHERE THE REDACTION ACTUALLY HAPPENS.
+				//
+				// Per-block redaction runs BEFORE truncation, because a PEM key
+				// clipped at 2000 chars loses the END marker its rule is anchored
+				// on. That fix was right and it broke the COUNT, which was still
+				// taken from a second pass over the already-redacted document —
+				// and five of the seven rules replace with text that cannot
+				// re-match them (`[redacted private key block]` contains no PEM
+				// header). So an export whose only secret was a key in a tool
+				// result reported `total: 0` and the banner said "no secrets
+				// matched" over a file that had just had a key removed from it.
+				//
+				// Accumulating here counts each redaction once, at the moment it
+				// is made. The document pass below still runs as defence in depth
+				// — for prose outside tool results — and its counts are merged.
+				const blockCounts: Record<string, number> = {};
 				const rendered = renderTranscriptMarkdown(messages, {
 					full,
 					sessionKey: boundSessionKey,
 					now: () => at,
-					// Per-block redaction BEFORE truncation. A PEM key clipped at 2000
-					// chars loses its END marker, and the rule that catches it stops
-					// matching — so the default export leaked key material while the
-					// banner said "no secrets matched". The whole-document pass below
-					// still runs, for the count and as defence in depth.
-					redact: (t) => redactForExport(t, { homeDir: home }).text,
+					redact: (t) => {
+						const r = redactForExport(t, { homeDir: home });
+						for (const [rule, n] of Object.entries(r.counts)) {
+							blockCounts[rule] = (blockCounts[rule] ?? 0) + n;
+						}
+						return r.text;
+					},
 				});
-				const { text, counts, total } = redactForExport(rendered, { homeDir: home });
+				const doc = redactForExport(rendered, { homeDir: home });
+				const text = doc.text;
+				const counts: Record<string, number> = { ...blockCounts };
+				for (const [rule, n] of Object.entries(doc.counts)) {
+					counts[rule] = (counts[rule] ?? 0) + n;
+				}
+				const total = Object.values(counts).reduce((a, b) => a + b, 0);
 				const dir = nodePath.join(resolveStateDir(), "exports");
 				// 0700 — the filenames embed session keys, so the directory listing is
 				// itself information. Matches the convention used for other sensitive

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -2016,9 +2016,38 @@ async function continueBoot(args: BootContinueArgs): Promise<ServerHandle> {
 			// under `anthropic`, so the provider id alone cannot tell a Pro/Max
 			// subscription turn from a metered API-key one; the credential's
 			// `type` can.
+			// PASS THE CREDENTIAL TYPE, WHICH IS THE WHOLE POINT OF THIS FUNCTION.
+			//
+			// `classifyBillingModeWithAuth` narrows metered → subscription only
+			// when `authType` says the credential is an OAuth/browser login — and
+			// no call site ever passed it, so this was a pure static catalog
+			// lookup. The catalog marks `anthropic` metered, so a Claude Pro/Max
+			// turn reported `metered`, `shouldRenderCost` returned true, and a
+			// confident dollar figure was printed for a subscription with no
+			// marginal cost. That is precisely the case this module exists to
+			// prevent, defeated by an unpassed argument.
+			//
+			// Resolved from the SAME provider and model this snapshot reports, so
+			// a session pinned to another provider is classified against the
+			// credential that will actually be charged.
 			billing: classifyBillingModeWithAuth({
-				provider: rt?.provider,
-				...(rt?.model?.cost ? { cost: rt.model.cost as { input?: number; output?: number } } : {}),
+				provider: snapshotProvider,
+				...(() => {
+					try {
+						const store = getAuthStorageForAgent(targetAgentId) as unknown as {
+							get?: (p: string) => { type?: string } | undefined;
+						};
+						const t = snapshotProvider ? store.get?.(snapshotProvider)?.type : undefined;
+						return t === "oauth" || t === "token" || t === "api_key" ? { authType: t } : {};
+					} catch {
+						// Never let a credential read break a snapshot; an absent
+						// type simply leaves the static classification in place.
+						return {};
+					}
+				})(),
+				...(effectiveModel?.cost
+					? { cost: effectiveModel.cost as { input?: number; output?: number } }
+					: {}),
 			}),
 			costComplete: snapshotUsage.costComplete,
 			// Wave K — per-agent live-session count. Was process-wide before,


### PR DESCRIPTION
Findings from six parallel audits plus live use. **Three of these are regressions introduced by earlier fixes in this same batch of work** — those are called out as such.

---

# iMessage did not work at all

Messaging your own Apple ID is the most obvious way to try the channel. It silently did nothing, for four independent reasons that had to be fixed in sequence — each one only became visible once the previous was gone.

### 1. Your replies were dropped before reaching the agent

In a self-thread **every row is `is_from_me = true`** — your replies included — so the adapter must tell "the agent sent this" from "the operator typed this". It did that with `destination_caller_id`, which the Messages DB frequently leaves **empty**. With the field absent the thread fell into an `isAmbiguousSelf` branch that dropped **unconditionally**. You saw your message delivered and read; Brigade never got it.

### 2. …and the first fix only covered half the input space

A Mac signed in with an Apple ID reports the **email** in `destination_caller_id` while `sender`/`chat_identifier` are the **phone** — populated but *different*, so it was neither "definitely self" nor "ambiguous", and the reply was dropped exactly as before.

The reliable signal doesn't depend on the DB's choice of alias: **a DM whose sender is the thread it arrived in can only be a thread with yourself.** `destination_caller_id` and `selfHandle` now corroborate, never gate.

### 3. The conversation muted itself on message 3

The loop rate limiter counted **Brigade's own echoes** as loop evidence. A self-thread produces one echo per turn by construction, so the 5-hit ceiling was reached after two exchanges and the third message was dropped `loop rate-limited`. Simulated before the fix: turn 1 dispatch, turn 2 dispatch, **turn 3 dropped**.

The same accounting muted **groups** — a chunked reply is one row per line, so a five-line answer exhausted the limiter on the very key real messages use.

### 4. The echo check couldn't recognise its own sends

The send returns the bridge's message id; the watch reports the chat.db row's id. Different namespaces, never correspond — and the cache's id-backed guard then **rejects an exact text match**. Harmless in a normal DM (`is_from_me` drops the echo anyway), but in a self-thread it's the difference between suppressing Brigade's message and answering it. **Fix #1 made that reachable**, so this closes an exposure I created.

Verified end to end: five turns, your messages dispatch, Brigade's echoes drop, no loop.

---

## A name could be dialled as a phone number

`normalizeE164` stripped every non-digit and prepended `+` — it never decided whether the input *was* a phone number, it manufactured one. **`"Line 2"` → `"+2"`.** A private conversation to whoever answers there. Sending to the wrong recipient is the worst outcome this channel has, and it took one plausible typo.

> Writing this test taught me something. My first version passed **even with the letter check deleted**, because the digit-count guard caught `"Line 2"` anyway. The case that actually needs it is a name carrying a full-length digit run — `"Room 5551234567"` — which becomes a real, dialable stranger's number. That case is now the test.

## A refused send was reported as delivered

The transport only rejects on a JSON-RPC `error` member, but the bridge reports refusals **inside** the result: `{ok:false, error:"no such handle"}` fell through to `messageId:"unknown"`, which every caller reads as success.

Explicit failures now throw with the bridge's own reason — and, more importantly, **absence of evidence is now failure**: no id and no acknowledgement means nothing confirmed the send.

## Internal scaffolding was delivered to the recipient

`sanitizeOutboundIMessageText` returned the **raw original** when stripping left nothing, reasoning in its own docstring that it's *"better to send something than confuse the recipient with silence"*. That is exactly backwards — the case where stripping empties the text is the case where the body was *entirely* internal, so "something" is the model's private reasoning going to another person.

Silence is correct: a recipient seeing nothing is a bug the operator can notice; a recipient seeing the model's reasoning cannot be taken back. Fixing it exposed the next one — an all-scaffolding reply produces no chunks, and the adapter returned `undefined`, which the plugin reports as `{ok:true}`.

## A failed start and a dead watch both reported healthy

`start()` captures the real failure — `authorization denied` with Full Disk Access off — into `closedReason`, and `health()` **discarded it** and said "not started yet", which reads as a transient boot state rather than a permission wall. That is why a denied FDA presented as the channel simply never answering.

Separately, a watch error was logged and nothing else: subprocess alive, socket fine, but the thing that **reads** chat.db is dead — so `isConnected()` stays true, health stays ok, and no message ever arrives again.

---

# Regression — "no secrets matched" over a file that had a key removed

The export fix moved redaction *before* truncation, which was right. But the **count** still ran a second pass over already-redacted text, and five of seven rules replace with strings that cannot re-match them (`[redacted private key block]` has no PEM header). An export whose only secret was a key in a tool result reported `total: 0`.

# Regression — a subscription turn reported as metered

`classifyBillingModeWithAuth` narrows metered→subscription only when `authType` is passed, and **no call site ever passed it**. So it was a static catalog lookup, `anthropic` is marked metered, and a confident dollar figure printed for a subscription with no marginal cost — the exact case that module exists to prevent.

# An aborted turn was answered anyway

Ctrl+C leaves an empty assistant message, which every content-quality heuristic reads as "the model said nothing" — so cancelling produced a full **billed** answer to a withdrawn question. Guarded on both the message's `stopReason` and the turn's own signal, because Pi deletes aborted assistant messages in some paths.

# One context switch, not four hand-written ones

`/new`, `/session`, `/agent` and `/delete` each maintained their own sequence and had diverged. The values **none** of them reset were the dangerous half:

| value | read by | what happened |
|---|---|---|
| `lastUserPrompt` / `lastUserAttachments` | `/switch` | **replayed the previous thread's message, with attachments, into the new one** |
| `toolCallInfo` | `/expand` | printed a result from a thread whose transcript was gone |
| `lastReplyText` | `/copy` | copied the previous thread's reply, with a byte count |
| queue / running / elapsed | footer, `/abort`, `/flush`, `/update` | a `●` dot and climbing timer over an idle thread |

**`/agent <id>` also kept the previous agent's session key**, so the gateway resolved the pair independently — `resume` returned the *old* agent's transcript and the next prompt ran the new agent's runtime into the old agent's thread.

**`/rewind` rebuilt nothing**, so you'd read turns the agent no longer had.

# Repeated channel notices are collapsed

A stuck WhatsApp socket printed *"scan the QR code"* five times inside one turn, between the operator's own messages. Consecutive identical notices now update one line with a count — strictly consecutive, because a repeat after real activity is a second occurrence.

---

## Verification

**6,603 tests · 65/72 mutation claims defended · typecheck and build clean.**

## Known-remaining, deliberately not in this PR

From the same audits, real but not silent-data-loss: the close/reconnect race that can leak an `imsg` subprocess and double-deliver; the `sms:`/`imessage:` target prefix that can never take effect (always overridden by the account default); `allowFrom` matching verbatim so the wizard-advertised `chat_id:` form can never match; and `dmHistoryLimit`, resolved and never read.