### PR TITLE
fix(catalog): OrcaRouter entry was missing the required billing field

### DIFF
--- a/src/agents/usage/billing-mode.test.ts
+++ b/src/agents/usage/billing-mode.test.ts
@@ -17,6 +17,8 @@ const EXPECTED: Record<string, ReturnType<typeof classifyBillingMode>> = {
 	openai: "metered",
 	google: "metered",
 	openrouter: "metered",
+	// BYOK gateway — passes each provider's published rate through.
+	orcarouter: "metered",
 	groq: "metered",
 	cerebras: "metered",
 	xai: "metered",

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -186,13 +186,20 @@ export const PROVIDERS: ProviderInfo[] = [
 		id: "orcarouter",
 		name: "OrcaRouter",
 		description: "Multi-model AI gateway with routing, failover, guardrails",
-		keyUrl: "https://www.orcarouter.ai",
+		// The console keys page, matching every sibling — onboarding opens this
+		// URL, and the site root does not get an operator to a key.
+		keyUrl: "https://www.orcarouter.ai/console/keys",
 		envVar: "ORCAROUTER_API_KEY",
 		envVarFallbacks: ["ORCA_API_KEY"],
 		custom: true,
 		liveModels: true, // models fetched live from /v1/models at onboarding
 		api: "openai-completions",
 		baseUrl: "https://api.orcarouter.ai/v1",
+		// BYOK gateway: it passes each provider's published rate through, so a
+		// turn costs real money and the cost must render. `ProviderInfo` requires
+		// this field; the entry landed without it because the contributing branch
+		// predated it, which is what broke the build.
+		billing: "metered",
 	},
 	{
 		id: "groq",


### PR DESCRIPTION
`main` does not compile. The OrcaRouter entry merged from #141 lacks `ProviderInfo.billing`, which is required — the contributing branch predated the field, so it merged cleanly (only added lines) and then failed to build.

My merge, my miss: I noticed the branch was based on an older catalog and reasoned that adding lines cannot conflict. True, and not the same as the result type-checking.

- `billing: "metered"` — OrcaRouter is BYOK and passes each provider's published rate through, so a turn costs real money. Without the field `classifyBillingMode` also returns nothing usable and cost renders as absent for a provider that charges.
- `keyUrl` → the console keys page, matching every sibling. Onboarding opens that URL; the site root does not get an operator to a key.

6619 tests, typecheck and build clean.