### PR TITLE
fix(channels): four dead settings, a DM/group misclassification, and the missing iMessage typing indicator

### DIFF
--- a/src/agents/channels/access-control/access-control.test.ts
+++ b/src/agents/channels/access-control/access-control.test.ts
@@ -429,3 +429,67 @@ describe("pairing store", () => {
 		assert.equal(revokePairingCode("wa", code), false); // gone
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// `senderAliases` generalises the WhatsApp `senderLid` identity overlap so a
+// channel can supply canonical spellings of the same sender. It must stay
+// ADDITIVE: a channel that supplies none keeps verbatim matching exactly as
+// before, because a fuzzy allow-list is how the wrong person gets admitted.
+// ─────────────────────────────────────────────────────────────────────────
+describe("evaluateAccess — senderAliases stays additive", () => {
+	it("changes nothing for a channel that supplies no aliases", () => {
+		// WhatsApp/Telegram/Discord/Slack shape: exact ids, no aliases.
+		assert.equal(
+			evaluateAccess({ policy: "allowlist", senderId: "1555@s.whatsapp.net", allowFrom: ["1555@s.whatsapp.net"] })
+				.kind,
+			"allow",
+		);
+		assert.equal(
+			evaluateAccess({ policy: "allowlist", senderId: "1555@s.whatsapp.net", allowFrom: ["1999@s.whatsapp.net"] })
+				.kind,
+			"block",
+		);
+		// A near-miss is still a miss — no normalisation is applied for them.
+		assert.equal(
+			evaluateAccess({ policy: "allowlist", senderId: "1555@s.whatsapp.net", allowFrom: ["1555"] }).kind,
+			"block",
+		);
+	});
+
+	it("an empty alias list cannot admit anyone", () => {
+		assert.equal(
+			evaluateAccess({ policy: "allowlist", senderId: "a", allowFrom: ["b"], senderAliases: [] }).kind,
+			"block",
+		);
+	});
+
+	it("an alias matches only when the list actually carries it", () => {
+		assert.equal(
+			evaluateAccess({
+				policy: "allowlist",
+				senderId: "+1 (555) 123-4567",
+				allowFrom: ["+15551234567"],
+				senderAliases: ["+15551234567"],
+			}).kind,
+			"allow",
+		);
+		assert.equal(
+			evaluateAccess({
+				policy: "allowlist",
+				senderId: "+1 (555) 123-4567",
+				allowFrom: ["+15559999999"],
+				senderAliases: ["+15551234567"],
+			}).kind,
+			"block",
+		);
+	});
+
+	it("an empty-string alias never matches an empty-string entry", () => {
+		// Defensive: a channel that emits "" for an unknown handle must not be
+		// able to match a stray empty allow-list entry.
+		assert.equal(
+			evaluateAccess({ policy: "allowlist", senderId: "x", allowFrom: [""], senderAliases: [""] }).kind,
+			"block",
+		);
+	});
+});

--- a/src/agents/channels/access-control/policy.ts
+++ b/src/agents/channels/access-control/policy.ts
@@ -22,6 +22,12 @@ export interface EvaluateAccessArgs {
 	 * vice-versa.
 	 */
 	senderLid?: string;
+	/**
+	 * Additional canonical spellings of the same sender (and, where a channel
+	 * supports conversation-scoped entries, of the conversation). Matched by the
+	 * same exact equality as `senderId` — see `InboundMessage.senderAliases`.
+	 */
+	senderAliases?: ReadonlyArray<string>;
 	/** The linked-self id, when known (operator messaging themselves → allow). */
 	selfId?: string;
 	/** Approved senders for this channel (from `allow-from.json` + config). */
@@ -80,11 +86,20 @@ function isOnAllowList(
 	senderId: string,
 	allowFrom: ReadonlyArray<string>,
 	senderLid?: string,
+	senderAliases?: ReadonlyArray<string>,
 ): boolean {
 	for (const entry of allowFrom) if (entry === "*") return true;
-	// Identity overlap — a sender matches if the list carries EITHER of their
-	// stable handles (phone number OR `@lid` privacy alias).
-	return allowFrom.includes(senderId) || (senderLid !== undefined && allowFrom.includes(senderLid));
+	// Identity overlap — a sender matches if the list carries ANY of their
+	// stable handles: the primary id, a `@lid` privacy alias, or a canonical
+	// spelling the channel supplied. Still exact equality on every candidate.
+	if (allowFrom.includes(senderId)) return true;
+	if (senderLid !== undefined && allowFrom.includes(senderLid)) return true;
+	if (senderAliases) {
+		for (const alias of senderAliases) {
+			if (alias && allowFrom.includes(alias)) return true;
+		}
+	}
+	return false;
 }
 
 /**
@@ -146,7 +161,7 @@ export function evaluateAccess(args: EvaluateAccessArgs): AccessDecision {
 		// self-tags — a self-tag is just a mention of the operator's own number
 		// (which IS the bot's id) and must never become a summon backdoor. A `*`
 		// in the list is a wildcard and matches everyone (still mention-gated below).
-		const senderAllowed = isOnAllowList(args.senderId, allow, args.senderLid);
+		const senderAllowed = isOnAllowList(args.senderId, allow, args.senderLid, args.senderAliases);
 		if (!senderAllowed) return { kind: "block", reason: "group:not-allowlisted" };
 		return addressed
 			? {
@@ -172,11 +187,11 @@ export function evaluateAccess(args: EvaluateAccessArgs): AccessDecision {
 		case "disabled":
 			return { kind: "block", reason: "policy:disabled" };
 		case "allowlist":
-			return isOnAllowList(args.senderId, args.allowFrom, args.senderLid)
+			return isOnAllowList(args.senderId, args.allowFrom, args.senderLid, args.senderAliases)
 				? { kind: "allow", reason: "allow-from" }
 				: { kind: "block", reason: "not-allowlisted" };
 		case "pairing":
-			if (isOnAllowList(args.senderId, args.allowFrom, args.senderLid))
+			if (isOnAllowList(args.senderId, args.allowFrom, args.senderLid, args.senderAliases))
 				return { kind: "allow", reason: "allow-from" };
 			// Caller will mint/refresh the code via the store and send a reply.
 			return { kind: "challenge", code: "", reason: "needs-pairing" };

--- a/src/agents/channels/bluebubbles/adapter.test.ts
+++ b/src/agents/channels/bluebubbles/adapter.test.ts
@@ -358,3 +358,26 @@ describe("BlueBubbles adapter", () => {
 		assert.equal(fake.catchupRuns.count, 1);
 	});
 });
+
+// BlueBubbles carries the same Apple handles as the iMessage channel, so it has
+// the same allow-list spelling gap: the server reports what the chat database
+// stores, the operator types what the wizard showed them, and matching is exact.
+describe("BlueBubbles adapter — allow-list canonicalisation", () => {
+	const norm = (e: string): string => createBlueBubblesAdapter().normalizeAclEntry!(e);
+
+	it("canonicalises Apple handles the same way the iMessage channel does", () => {
+		assert.equal(norm("+1 (555) 123-4567"), norm("+15551234567"));
+		assert.equal(norm("User@Example.com"), norm("user@example.com"));
+	});
+
+	it("carries a chat guid through verbatim under one prefix", () => {
+		// Opaque server identifier — case and punctuation are significant.
+		assert.equal(norm("chat_guid:iMessage;-;+15551234567"), "chat_guid:iMessage;-;+15551234567");
+		assert.equal(norm("guid: iMessage;-;+15551234567"), "chat_guid:iMessage;-;+15551234567");
+	});
+
+	it("does not collapse two different identities", () => {
+		assert.notEqual(norm("+15551234567"), norm("+15559999999"));
+		assert.notEqual(norm("chat_guid:A"), norm("chat_guid:B"));
+	});
+});

--- a/src/agents/channels/bluebubbles/adapter.ts
+++ b/src/agents/channels/bluebubbles/adapter.ts
@@ -49,6 +49,39 @@ import {
 	type ConnectBlueBubblesArgs,
 } from "./connection.js";
 import { isMacOSEditUnsupported, probeBlueBubbles } from "./probe.js";
+import { normalizeIMessageAclEntry, normalizeIMessageHandle } from "../imessage/targets.js";
+
+/**
+ * The identities one inbound message can be allow-listed under.
+ *
+ * BlueBubbles carries the SAME Apple handles as the iMessage channel — the
+ * server hands back whatever the chat database stores (`+1 (555) 123-4567`,
+ * `User@Example.com`) while the operator types the form the wizard showed
+ * them, and the allow-list is matched by exact equality. Same identity space,
+ * so the same canonicalisation; the shared helper keeps the two channels from
+ * drifting apart.
+ *
+ * The thread identity is BlueBubbles' `chatGuid` — this channel has no numeric
+ * `chat_id` — so a conversation-scoped entry is written `chat_guid:<guid>`.
+ */
+function blueBubblesSenderAliases(msg: { from: string; chatGuid?: string }): string[] {
+	const out = new Set<string>();
+	const handle = normalizeIMessageHandle(msg.from);
+	if (handle) out.add(handle);
+	const guid = msg.chatGuid?.trim();
+	if (guid) out.add(`chat_guid:${guid}`);
+	return [...out];
+}
+
+/** Canonicalize a configured entry to the spelling `blueBubblesSenderAliases` emits. */
+function normalizeBlueBubblesAclEntry(entry: string): string {
+	const trimmed = (entry ?? "").trim();
+	const guid = /^(chat_guid|chatguid|guid):\s*(.+)$/i.exec(trimmed);
+	// A chat guid is an opaque server identifier — case and punctuation are
+	// significant, so it is carried through verbatim rather than normalised.
+	if (guid?.[2]) return `chat_guid:${guid[2].trim()}`;
+	return normalizeIMessageAclEntry(trimmed);
+}
 
 /** Practical per-message text limit for chunked sends (before bubble-splitting). */
 const BLUEBUBBLES_TEXT_LIMIT = 10_000;
@@ -170,6 +203,7 @@ export function createBlueBubblesAdapter(opts: CreateBlueBubblesAdapterOptions =
 							...(msg.messageGuid ? { messageId: msg.messageGuid } : {}),
 							...(msg.timestampMs !== undefined ? { messageTimestampMs: msg.timestampMs } : {}),
 							from: msg.from,
+							senderAliases: blueBubblesSenderAliases(msg),
 							...(msg.fromName !== undefined ? { fromName: msg.fromName } : {}),
 							text: msg.text,
 							chatType: msg.isGroup ? "group" : "direct",
@@ -296,6 +330,8 @@ export function createBlueBubblesAdapter(opts: CreateBlueBubblesAdapterOptions =
 
 		// The BlueBubbles bot runs AS the operator's signed-in Messages.app, so the
 		// pairing card uses the "account" label.
+		normalizeAclEntry: normalizeBlueBubblesAclEntry,
+
 		pairing: { idLabel: "account" as const },
 
 		setup: {
@@ -327,7 +363,10 @@ export function createBlueBubblesAdapter(opts: CreateBlueBubblesAdapterOptions =
 				{
 					key: "allowFrom",
 					prompt:
-						"Allowlist of senders for allowlist mode — handles or chat targets, comma-separated (e.g. +15555550123, user@example.com, chat_id:123). Leave blank for none.",
+						"Allowlist of senders for allowlist mode — handles or chat targets, comma-separated " +
+						// `chat_guid:`, NOT `chat_id:` — BlueBubbles threads have no numeric
+						// id, so the old example could never match anything an operator typed.
+						"(e.g. +15555550123, user@example.com, chat_guid:iMessage;-;+15555550123). Leave blank for none.",
 					secret: false,
 				},
 			],

--- a/src/agents/channels/imessage/adapter.test.ts
+++ b/src/agents/channels/imessage/adapter.test.ts
@@ -9,10 +9,18 @@ import type { ChannelStartContext, InboundMessage } from "../sdk.js";
 const cfg = { channels: { imessage: { enabled: true } } } as never;
 
 /** A fake connection that records sends + lets the test push inbound messages. */
-function fakeConnection(): IMessageConnection & { sentText: Array<{ to: string; text: string }> } {
+function fakeConnection(): IMessageConnection & {
+	sentText: Array<{ to: string; text: string }>;
+	typing: boolean[];
+} {
 	const sentText: Array<{ to: string; text: string }> = [];
+	const typing: boolean[] = [];
 	return {
 		sentText,
+		typing,
+		async setTyping(_conversationId: string, on: boolean): Promise<void> {
+			typing.push(on);
+		},
 		isConnected: () => true,
 	lastWatchError: () => undefined,
 		connectedAt: () => Date.now(),
@@ -218,5 +226,18 @@ describe("IMessageRpcClient (test-env guard)", () => {
 			if (prev === undefined) delete process.env.NODE_ENV;
 			else process.env.NODE_ENV = prev;
 		}
+	});
+});
+
+// iMessage was the only channel without a typing indicator — every other one
+// implements `setComposing`, so a thread just sat silent until the reply landed.
+describe("iMessage adapter — typing indicator", () => {
+	it("maps composing/paused onto the connection's typing call", async () => {
+		const conn = fakeConnection();
+		const adapter = createIMessageAdapter({ connectImpl: async () => conn });
+		await adapter.start(startCtx(async () => {}));
+		await adapter.setComposing!("+15551234567", "composing");
+		await adapter.setComposing!("+15551234567", "paused");
+		assert.deepEqual(conn.typing, [true, false]);
 	});
 });

--- a/src/agents/channels/imessage/adapter.ts
+++ b/src/agents/channels/imessage/adapter.ts
@@ -328,6 +328,21 @@ export function createIMessageAdapter(opts: CreateIMessageAdapterOptions = {}): 
 		// iMessage senders are phone numbers / emails on the operator's own device;
 		// the bot runs AS the operator (Messages.app), so the pairing card uses the
 		// "account" label and ownership is NOT bootstrapped from a separate bot.
+		/**
+		 * Typing indicator while the agent thinks.
+		 *
+		 * iMessage was the only channel without one — Discord, Telegram, Slack,
+		 * WhatsApp and BlueBubbles all implement this slot, so a conversation on
+		 * iMessage simply sat silent until the reply landed. The bridge supports
+		 * it through IMCore, which not every Mac allows; the connection treats it
+		 * as strictly cosmetic and never throws, so a Mac that cannot show the
+		 * bubble behaves exactly as it does today.
+		 */
+		async setComposing(conversationId: string, state: "composing" | "paused"): Promise<void> {
+			if (!connection) return;
+			await connection.setTyping(conversationId, state === "composing");
+		},
+
 		pairing: { idLabel: "account" as const },
 
 		/**

--- a/src/agents/channels/imessage/adapter.ts
+++ b/src/agents/channels/imessage/adapter.ts
@@ -49,6 +49,35 @@ import {
 	type IMessageInboundMessage,
 } from "./connection.js";
 import { markdownToIMessageText } from "./format.js";
+import { normalizeIMessageAclEntry, normalizeIMessageHandle } from "./targets.js";
+
+/**
+ * The identities one inbound message can be allow-listed under.
+ *
+ * `from` is whatever the chat database stores — `+1 (555) 123-4567`,
+ * `User@Example.com`, sometimes an `iMessage;-;` service-prefixed handle. The
+ * operator types what the setup wizard showed them. Exact matching between
+ * those two spellings fails, so the sender is refused despite being listed.
+ *
+ * The wizard also documents `chat_id:123`, which describes the THREAD, not the
+ * sender, and so could never equal `from` under any spelling. It is listed here
+ * so allow-listing a conversation does what the wizard says it does.
+ */
+function imessageSenderAliases(msg: {
+	from: string;
+	chatId?: number;
+	chatIdentifier?: string;
+}): string[] {
+	const out = new Set<string>();
+	const handle = normalizeIMessageHandle(msg.from);
+	if (handle) out.add(handle);
+	if (typeof msg.chatId === "number" && Number.isFinite(msg.chatId)) {
+		out.add(`chat_id:${msg.chatId}`);
+	}
+	const ident = normalizeIMessageHandle(msg.chatIdentifier ?? "");
+	if (ident) out.add(`chat_identifier:${ident}`);
+	return [...out];
+}
 
 /** iMessage's practical per-message text limit for chunked sends (default; config can override). */
 const IMESSAGE_TEXT_LIMIT = DEFAULT_IMESSAGE_TEXT_CHUNK_LIMIT;
@@ -162,6 +191,7 @@ export function createIMessageAdapter(opts: CreateIMessageAdapterOptions = {}): 
 							...(msg.messageId ? { messageId: msg.messageId } : {}),
 							...(msg.createdAtMs !== undefined ? { messageTimestampMs: msg.createdAtMs } : {}),
 							from: msg.from,
+							senderAliases: imessageSenderAliases(msg),
 							...(msg.fromName !== undefined ? { fromName: msg.fromName } : {}),
 							text: body,
 							chatType: msg.isGroup ? "group" : "direct",
@@ -299,6 +329,18 @@ export function createIMessageAdapter(opts: CreateIMessageAdapterOptions = {}): 
 		// the bot runs AS the operator (Messages.app), so the pairing card uses the
 		// "account" label and ownership is NOT bootstrapped from a separate bot.
 		pairing: { idLabel: "account" as const },
+
+		/**
+		 * Canonicalize the operator's allow-list entries to the same spelling
+		 * `imessageSenderAliases` produces, so exact matching can succeed.
+		 *
+		 * `chat_id:` / `chat_identifier:` entries keep their prefix — they are
+		 * conversation identities, matched against the thread rather than the
+		 * sender. Everything else is a handle: an email lowercases, a phone
+		 * becomes E.164. Neither mapping can collide two real identities, so the
+		 * allow-list is not widened.
+		 */
+		normalizeAclEntry: normalizeIMessageAclEntry,
 
 		// iMessage has no bot token — the `imsg` binary path + Messages.app sign-in
 		// are the auth. `brigade channels add imessage` walks: cliPath → dmPolicy →

--- a/src/agents/channels/imessage/connection.test.ts
+++ b/src/agents/channels/imessage/connection.test.ts
@@ -384,3 +384,183 @@ describe("connectIMessage — remote-host attachment fetch (Fix 4)", () => {
 		await conn.close();
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Close during an in-flight subscribe.
+//
+// The guard used to be checked only BEFORE the two awaits (spawn, then
+// `watch.subscribe`). `close()` landing in between saw `client === null` and
+// stopped nothing, and the resolved client was then published into a closed
+// connection: a live `imsg` subprocess no code path can reach, still streaming
+// rows. Reconnecting the account delivered every message twice.
+// ─────────────────────────────────────────────────────────────────────────
+describe("connectIMessage — abort during an in-flight subscribe", () => {
+	it("stops the orphaned client instead of publishing it", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((r) => {
+			release = r;
+		});
+		let stops = 0;
+		let built = 0;
+		const ac = new AbortController();
+
+		class SlowClient implements IMessageRpcLike {
+			async start(): Promise<void> {}
+			async stop(): Promise<void> {
+				stops += 1;
+			}
+			async request<T = unknown>(): Promise<T> {
+				// Hold `watch.subscribe` open so the abort lands mid-flight — the
+				// window the old check-then-await guard could not see.
+				await gate;
+				return {} as T;
+			}
+			waitForClose(): Promise<void> {
+				return new Promise<void>(() => {});
+			}
+		}
+
+		const connecting = connectIMessage({
+			account: account(),
+			loadConfig: () => ({}) as unknown as BrigadeConfig,
+			log: () => {},
+			onMessage: () => {},
+			signal: ac.signal,
+			clientFactory: async () => {
+				built += 1;
+				return new SlowClient();
+			},
+			probeImpl: async () => ({ ok: true, elapsedMs: 0 }),
+			sleepImpl: async () => {},
+		});
+
+		// Let the factory run and the subscribe genuinely block.
+		await new Promise<void>((r) => setImmediate(r));
+		assert.equal(built, 1, "a client exists but the subscribe has not resolved");
+
+		// Abort NOW — mid-subscribe. The old code re-checked nothing after the
+		// await, so this client was published into an already-closed connection
+		// and never stopped: a live `imsg` subprocess streaming rows that a
+		// later reconnect would then duplicate.
+		ac.abort();
+		release();
+		const conn = await connecting;
+
+		assert.equal(stops, 1, "the client built during the abort was stopped exactly once");
+		assert.equal(conn.isConnected(), false, "an aborted connection never reports connected");
+		await conn.close();
+	});
+});
+
+describe("connectIMessage — a closed connection delivers nothing", () => {
+	it("drops notifications that arrive after close", async () => {
+		const delivered: string[] = [];
+		let notify: ((m: IMessageRpcNotification) => void) | undefined;
+		const conn = await connectIMessage({
+			account: account(),
+			loadConfig: () => ({}) as unknown as BrigadeConfig,
+			log: () => {},
+			onMessage: (m) => delivered.push(m.text),
+			clientFactory: async (opts) => {
+				notify = opts.onNotification;
+				return new FakeClient();
+			},
+			probeImpl: async () => ({ ok: true, elapsedMs: 0 }),
+			sleepImpl: async () => {},
+		});
+		const push = (text: string) =>
+			notify?.({
+				method: "message",
+				params: { message: { sender: "+15551234567", text, is_from_me: false } },
+			} as unknown as IMessageRpcNotification);
+
+		push("before");
+		await new Promise<void>((r) => setImmediate(r));
+		assert.deepEqual(delivered, ["before"]);
+
+		await conn.close();
+		// A subscribe that was still in flight at close keeps a live client
+		// pointed at this handler. Without the guard those rows reach the agent
+		// after close — and once the account reconnects, the operator is
+		// answered twice for the same message.
+		push("after");
+		await new Promise<void>((r) => setImmediate(r));
+		assert.deepEqual(delivered, ["before"], "nothing is delivered after close");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// `dmHistoryLimit` was resolved, documented, and never read — only
+// `historyLimit` was, gated on the message being a group. Setting it did
+// nothing. `record` was group-only too, so honouring the limit alone would
+// have read a buffer nothing ever wrote to.
+// ─────────────────────────────────────────────────────────────────────────
+describe("connectIMessage — dmHistoryLimit", () => {
+	const dmNotification = (text: string): IMessageRpcNotification =>
+		({
+			method: "message",
+			params: {
+				message: {
+					sender: "+15551234567",
+					text,
+					chat_identifier: "+15551234567",
+					is_group: false,
+					is_from_me: false,
+					chat_id: 7,
+				},
+			},
+		}) as unknown as IMessageRpcNotification;
+
+	it("attaches DM history once dmHistoryLimit is set", async () => {
+		const seen: Array<{ text: string; ctx?: string }> = [];
+		let notify: ((m: IMessageRpcNotification) => void) | undefined;
+		const conn = await connectIMessage({
+			account: account({ dmHistoryLimit: 5 }),
+			loadConfig: () => ({}) as unknown as BrigadeConfig,
+			log: () => {},
+			onMessage: (m) =>
+				seen.push({
+					text: m.text,
+					...((m as { historyContext?: string }).historyContext !== undefined
+						? { ctx: (m as { historyContext?: string }).historyContext }
+						: {}),
+				}),
+			clientFactory: async (opts) => {
+				notify = opts.onNotification;
+				return new FakeClient();
+			},
+			probeImpl: async () => ({ ok: true, elapsedMs: 0 }),
+			sleepImpl: async () => {},
+		});
+		notify?.(dmNotification("first"));
+		notify?.(dmNotification("second"));
+		await new Promise<void>((r) => setImmediate(r));
+		assert.equal(seen.length, 2);
+		assert.equal(seen[0]?.ctx, undefined, "nothing buffered yet for the first message");
+		assert.ok(seen[1]?.ctx, "the second DM carries the first as context");
+		assert.match(String(seen[1]?.ctx), /first/);
+		await conn.close();
+	});
+
+	it("buffers nothing for DMs when the limit is left at its default", async () => {
+		const seen: Array<string | undefined> = [];
+		let notify: ((m: IMessageRpcNotification) => void) | undefined;
+		const conn = await connectIMessage({
+			account: account(),
+			loadConfig: () => ({}) as unknown as BrigadeConfig,
+			log: () => {},
+			onMessage: (m) => seen.push((m as { historyContext?: string }).historyContext),
+			clientFactory: async (opts) => {
+				notify = opts.onNotification;
+				return new FakeClient();
+			},
+			probeImpl: async () => ({ ok: true, elapsedMs: 0 }),
+			sleepImpl: async () => {},
+		});
+		notify?.(dmNotification("first"));
+		notify?.(dmNotification("second"));
+		await new Promise<void>((r) => setImmediate(r));
+		assert.deepEqual(seen, [undefined, undefined]);
+		await conn.close();
+	});
+});

--- a/src/agents/channels/imessage/connection.test.ts
+++ b/src/agents/channels/imessage/connection.test.ts
@@ -11,7 +11,7 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 
-import { connectIMessage } from "./connection.js";
+import { connectIMessage, isTypingPermanentlyUnavailable } from "./connection.js";
 import type { IMessageRpcLike, IMessageRpcNotification } from "./client.js";
 import type { ResolvedIMessageAccount } from "./account-config.js";
 import type { BrigadeConfig } from "../sdk.js";
@@ -561,6 +561,97 @@ describe("connectIMessage — dmHistoryLimit", () => {
 		notify?.(dmNotification("second"));
 		await new Promise<void>((r) => setImmediate(r));
 		assert.deepEqual(seen, [undefined, undefined]);
+		await conn.close();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Typing indicators go through IMCore, which a stock Mac (SIP enabled) does
+// not allow. That must cost nothing: never fail a turn, and never log twice.
+// ─────────────────────────────────────────────────────────────────────────
+describe("isTypingPermanentlyUnavailable", () => {
+	it("recognises the bridge's own unavailability wording", () => {
+		assert.equal(
+			isTypingPermanentlyUnavailable(
+				"Typing indicator failed: Failed to connect to imagent (Messages daemon) for IMCore typing indicators.",
+			),
+			true,
+		);
+		assert.equal(isTypingPermanentlyUnavailable("Method not found"), true);
+		assert.equal(isTypingPermanentlyUnavailable("Messages.app blocked it via library validation"), true);
+	});
+
+	it("treats anything else as transient, so a blip does not cost the feature", () => {
+		assert.equal(isTypingPermanentlyUnavailable("request timed out"), false);
+		assert.equal(isTypingPermanentlyUnavailable("socket hang up"), false);
+	});
+});
+
+describe("connectIMessage — setTyping", () => {
+	class TypingClient implements IMessageRpcLike {
+		calls: Array<Record<string, unknown>> = [];
+		constructor(private readonly fail?: string) {}
+		async start(): Promise<void> {}
+		async stop(): Promise<void> {}
+		async request<T = unknown>(method: string, params?: unknown): Promise<T> {
+			if (method === "typing") {
+				this.calls.push((params ?? {}) as Record<string, unknown>);
+				if (this.fail) throw new Error(this.fail);
+			}
+			return {} as T;
+		}
+		waitForClose(): Promise<void> {
+			return new Promise<void>(() => {});
+		}
+	}
+
+	const connect = async (client: IMessageRpcLike, logs: string[]) =>
+		connectIMessage({
+			account: account(),
+			loadConfig: () => ({}) as unknown as BrigadeConfig,
+			log: (m) => logs.push(m),
+			onMessage: () => {},
+			clientFactory: async () => client,
+			probeImpl: async () => ({ ok: true, elapsedMs: 0 }),
+			sleepImpl: async () => {},
+		});
+
+	it("uses the same conversation-id mapping the sender does", async () => {
+		const client = new TypingClient();
+		const conn = await connect(client, []);
+		await conn.setTyping("chat:7", true);
+		await conn.setTyping("+15551234567", false);
+		assert.equal(client.calls[0]?.chat_id, 7);
+		assert.equal(client.calls[0]?.stop, undefined, "starting typing sends no stop flag");
+		assert.equal(client.calls[1]?.to, "+15551234567");
+		assert.equal(client.calls[1]?.stop, true);
+		await conn.close();
+	});
+
+	it("never throws, and stops asking once the Mac says it cannot", async () => {
+		const logs: string[] = [];
+		const client = new TypingClient(
+			"Typing indicator failed: Failed to connect to imagent (Messages daemon) for IMCore typing indicators.",
+		);
+		const conn = await connect(client, logs);
+		await assert.doesNotReject(() => conn.setTyping("chat:7", true));
+		await conn.setTyping("chat:7", false);
+		await conn.setTyping("chat:7", true);
+		assert.equal(client.calls.length, 1, "latched off after the first refusal");
+		assert.equal(
+			logs.filter((l) => l.includes("typing indicators unavailable")).length,
+			1,
+			"said so exactly once",
+		);
+		await conn.close();
+	});
+
+	it("keeps trying after a transient failure", async () => {
+		const client = new TypingClient("socket hang up");
+		const conn = await connect(client, []);
+		await conn.setTyping("chat:7", true);
+		await conn.setTyping("chat:7", true);
+		assert.equal(client.calls.length, 2, "a blip does not disable the feature");
 		await conn.close();
 	});
 });

--- a/src/agents/channels/imessage/connection.ts
+++ b/src/agents/channels/imessage/connection.ts
@@ -199,6 +199,14 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 	}
 
 	const handleNotification = (msg: IMessageRpcNotification): void => {
+		// A CLOSED CONNECTION DELIVERS NOTHING.
+		//
+		// `close()` can land while a `watch.subscribe` is still in flight, and the
+		// client it was building stays subscribed and keeps calling this. Without
+		// this line those rows reach `onMessage` after close — and if the account
+		// has since reconnected, the operator is answered twice for one message.
+		// `subscribeOnce` tears the orphan down; this closes the window before it.
+		if (closed || args.signal?.aborted) return;
 		// Wrap the whole handler so a synchronous throw (malformed payload, a
 		// decideInbound bug, a downstream onMessage error) can NEVER escape into the
 		// RPC client's notification loop and wedge the watch / crash the gateway.
@@ -244,14 +252,26 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 			// then record THIS message for the next turn. iMessage's `imsg rpc`
 			// transport exposes no history method, so this is a pure in-memory buffer
 			// of messages the monitor has already seen (mirrors the upstream monitor).
-			const isUntaggedGroup =
-				normalized.isGroup && (!normalized.mentions || normalized.mentions.length === 0) && !normalized.replyTo;
-			if (account.historyLimit > 0 && isUntaggedGroup && normalized.text.trim()) {
-				const entries = history.recent(normalized.conversationId, account.historyLimit);
+			//
+			// GROUPS USE `historyLimit`, DMs USE `dmHistoryLimit`. Both are
+			// resolved by `account-config`, documented, and settable — but only
+			// the group one was ever read here, so setting `dmHistoryLimit` did
+			// nothing at all. (BlueBubbles' `historyLimitFor` has always honoured
+			// both; this is the same rule.)
+			const untagged =
+				(!normalized.mentions || normalized.mentions.length === 0) && !normalized.replyTo;
+			const historyLimit = normalized.isGroup ? account.historyLimit : account.dmHistoryLimit;
+			if (historyLimit > 0 && untagged && normalized.text.trim()) {
+				const entries = history.recent(normalized.conversationId, historyLimit);
 				const block = renderIMessageHistoryBlock(entries);
 				if (block) (normalized as IMessageInboundMessage).historyContext = block;
 			}
-			if (normalized.isGroup) {
+			// RECORD WHEREVER WE MIGHT LATER READ. This was `if (isGroup)`, so
+			// enabling `dmHistoryLimit` alone would have read a buffer nothing
+			// ever wrote to — the setting would still look inert, just one layer
+			// deeper. Gated on the limit so an install that leaves DM history off
+			// (the default) buffers nothing for its DMs, as before.
+			if (historyLimit > 0 || normalized.isGroup) {
 				history.record(normalized.conversationId, {
 					sender: normalized.fromName || normalized.from || "Unknown",
 					body: normalized.text,
@@ -328,7 +348,26 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 		for (let i = 1; i <= WATCH_SUBSCRIBE_MAX_ATTEMPTS; i++) {
 			if (closed || args.signal?.aborted) return;
 			try {
-				client = await subscribeAttempt();
+				const c = await subscribeAttempt();
+				// RE-CHECK AFTER THE AWAIT, NOT ONLY BEFORE IT.
+				//
+				// The guard at the top of this loop runs before two awaits (spawn,
+				// then `watch.subscribe`). `close()` during either one saw
+				// `client === null` and stopped nothing, and then this line
+				// published a live, subscribed client into a connection that had
+				// already been closed — a leaked `imsg` subprocess that no code
+				// path can reach to stop, still streaming rows. Reconnecting the
+				// account then delivered every message twice: once from the orphan,
+				// once from its replacement.
+				if (closed || args.signal?.aborted) {
+					try {
+						await c.stop();
+					} catch {
+						/* best-effort; the process is already unreachable */
+					}
+					return;
+				}
+				client = c;
 				connected = true;
 				connectedAtMs = Date.now();
 				attempt = 0;

--- a/src/agents/channels/imessage/connection.ts
+++ b/src/agents/channels/imessage/connection.ts
@@ -46,6 +46,7 @@ import {
 	type ReadFileLike,
 } from "./remote-attachments.js";
 import { sendMessageIMessage, type IMessageSendResult } from "./send.js";
+import { parseIMessageTarget } from "./targets.js";
 import { sanitizeIMessageWatchErrorPayload } from "./watch-error.js";
 import type { BrigadeConfig } from "../sdk.js";
 import type { OutboundMedia, OutboundSendOptions, InboundMediaAttachment } from "../sdk.js";
@@ -121,6 +122,28 @@ export interface ConnectIMessageArgs {
 }
 
 /** The live connection handle the adapter drives. */
+/**
+ * Does a typing failure mean this Mac cannot do typing indicators AT ALL, as
+ * opposed to a one-off hiccup?
+ *
+ * Matched on the bridge's own wording — it names `imagent`, IMCore and library
+ * validation when the private path is closed to it. A method the bridge does
+ * not expose is the same conclusion: stop asking. Anything else is treated as
+ * transient, because latching off on a blip would silently cost the feature for
+ * the rest of the process's life.
+ */
+export function isTypingPermanentlyUnavailable(message: string): boolean {
+	const m = message.toLowerCase();
+	return (
+		m.includes("imagent") ||
+		m.includes("imcore") ||
+		m.includes("library validation") ||
+		m.includes("method not found") ||
+		m.includes("not supported") ||
+		m.includes("entitlement")
+	);
+}
+
 export interface IMessageConnection {
 	isConnected(): boolean;
 	connectedAt(): number | null;
@@ -135,6 +158,11 @@ export interface IMessageConnection {
 	lastWatchError(): string | undefined;
 	/** Send text; returns the bridge message id when available. */
 	sendText(conversationId: string, text: string, opts?: OutboundSendOptions): Promise<{ messageId?: string }>;
+	/**
+	 * Show or clear the "typing…" bubble in Messages.app. Best-effort — see
+	 * `setTyping` in the implementation for why this can never throw.
+	 */
+	setTyping(conversationId: string, on: boolean): Promise<void>;
 	/** Send media; returns the bridge message id when available. */
 	sendMedia(conversationId: string, media: OutboundMedia): Promise<{ messageId?: string }>;
 	/** Tear down the subprocess + stop reconnecting. */
@@ -465,6 +493,15 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 		else args.signal.addEventListener("abort", () => void close(), { once: true });
 	}
 
+	/**
+	 * Does this error mean the IMCore typing path is unavailable on this machine,
+	 * as opposed to a one-off failure?
+	 *
+	 * Matched on the bridge's own wording. A method the bridge does not expose at
+	 * all ("method not found") is the same conclusion: stop asking.
+	 */
+	let typingUnavailable = false;
+
 	const remember = (conversationId: string, sent: IMessageSendResult): void => {
 		// Build the same scope the inbound poll keys on so the echo is suppressed.
 		const numericChat = conversationId.startsWith("chat:") ? Number.parseInt(conversationId.slice(5), 10) : NaN;
@@ -492,6 +529,59 @@ export async function connectIMessage(args: ConnectIMessageArgs): Promise<IMessa
 		isConnected: () => connected,
 		lastWatchError: () => lastWatchError,
 		connectedAt: () => connectedAtMs,
+		/**
+		 * Typing indicator.
+		 *
+		 * ─────────────────────────────────────────────────────────────────────
+		 * WHY THIS IS BEST-EFFORT, AND WHY IT GOES QUIET
+		 * ─────────────────────────────────────────────────────────────────────
+		 * Every other channel Brigade speaks shows a typing indicator while the
+		 * agent thinks; iMessage was the only one that did not, because the
+		 * adapter never implemented `setComposing`. The bridge does support it —
+		 * `imsg`'s `typing` RPC — but ONLY through IMCore, which needs SIP
+		 * disabled and Messages launched with `imsg launch`. On a stock Mac it
+		 * fails every time:
+		 *
+		 *   "Failed to connect to imagent (Messages daemon) … imagent can reject
+		 *    third-party clients without Apple-private entitlements"
+		 *
+		 * So two rules. It NEVER throws — a cosmetic bubble must not be able to
+		 * fail a turn that is otherwise fine. And it LATCHES OFF after the first
+		 * unavailability, logging once with the remedy, because the alternative
+		 * is two failures per turn forever in the operator's log, which trains
+		 * people to ignore the log. A transient failure does not latch — only
+		 * the answer that means "this Mac cannot do this at all".
+		 */
+		async setTyping(conversationId, on): Promise<void> {
+			if (typingUnavailable || !connected) return;
+			const c = client;
+			if (!c) return;
+			try {
+				const params: Record<string, unknown> = { service: account.service || "auto" };
+				// Same conversation-id → wire-param mapping the sender uses, so a
+				// thread that can be sent to can always be typed into.
+				const target = parseIMessageTarget(conversationId);
+				if (target.kind === "chat_id") params.chat_id = target.chatId;
+				else if (target.kind === "chat_guid") params.chat_guid = target.chatGuid;
+				else if (target.kind === "chat_identifier") params.chat_identifier = target.chatIdentifier;
+				else params.to = target.to;
+				if (!on) params.stop = true;
+				await c.request("typing", params, { timeoutMs: account.probeTimeoutMs });
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				if (isTypingPermanentlyUnavailable(msg)) {
+					typingUnavailable = true;
+					args.log(
+						"imessage: typing indicators unavailable on this Mac — they need IMCore " +
+							"(SIP disabled + `imsg launch`). Everything else is unaffected; not retrying.",
+					);
+					return;
+				}
+				// Transient — stay enabled, and keep it at debug volume.
+				if (account.verbose) args.log(`imessage: typing indicator failed (transient): ${msg}`);
+			}
+		},
+
 		async sendText(conversationId, text, opts): Promise<{ messageId?: string }> {
 			const result = await sendFn(conversationId, text, {
 				cliPath: account.cliPath,

--- a/src/agents/channels/imessage/monitor.test.ts
+++ b/src/agents/channels/imessage/monitor.test.ts
@@ -373,3 +373,41 @@ describe("normalizeHandle / echoScope agreement", () => {
 		assert.equal(echoScope("default", { chat_id: 21, sender: "whoever" }), "default:chat_id:21");
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// `chat_id` is the conversation's row id — every thread has one, DMs
+// included — so treating it as proof of a group put ordinary DMs behind the
+// group requireMention gate and the group allow-list.
+// ─────────────────────────────────────────────────────────────────────────
+describe("normalizeIMessageMessage — group classification", () => {
+	it("a DM carrying a chat_id is still a DM", () => {
+		const out = normalizeIMessageMessage({
+			sender: "+15551234567",
+			text: "hi",
+			chat_id: 7,
+			is_group: false,
+		});
+		assert.equal(out.isGroup, false);
+		assert.equal(out.chatId, 7, "the chat id is still carried through");
+	});
+
+	it("an explicit is_group:true is a group", () => {
+		assert.equal(
+			normalizeIMessageMessage({ sender: "+1555", text: "hi", chat_id: 7, is_group: true }).isGroup,
+			true,
+		);
+	});
+
+	it("falls back to participant count when is_group is absent", () => {
+		assert.equal(
+			normalizeIMessageMessage({ sender: "+1555", text: "hi", participants: ["+1555", "+1666"] })
+				.isGroup,
+			true,
+		);
+		assert.equal(
+			normalizeIMessageMessage({ sender: "+1555", text: "hi", participants: ["+1555"] }).isGroup,
+			false,
+		);
+		assert.equal(normalizeIMessageMessage({ sender: "+1555", text: "hi", chat_id: 9 }).isGroup, false);
+	});
+});

--- a/src/agents/channels/imessage/monitor.ts
+++ b/src/agents/channels/imessage/monitor.ts
@@ -189,7 +189,23 @@ export function conversationIdFor(payload: IMessagePayload): string {
  * central group requireMention gate can fire.
  */
 export function normalizeIMessageMessage(payload: IMessagePayload, selfHandle?: string): NormalizedIMessage {
-	const isGroup = Boolean(payload.is_group) || typeof payload.chat_id === "number";
+	// A `chat_id` IS NOT EVIDENCE OF A GROUP.
+	//
+	// This was `is_group || typeof chat_id === "number"`, and `chat_id` is the
+	// chat.db row id of the CONVERSATION — every thread has one, DMs included.
+	// So any DM whose payload carried a chat id was classified as a group, which
+	// put it behind the group `requireMention` gate (a plain DM ignored unless it
+	// named the bot), matched it against `groupAllowFrom` instead of `allowFrom`,
+	// and sent it down the `historyLimit` path instead of `dmHistoryLimit`.
+	//
+	// `is_group` is authoritative in BOTH directions when the bridge sends it —
+	// an explicit `false` now means not-a-group rather than being overridden.
+	// `participants` is the fallback when it is absent: more than one other party
+	// in the thread is what actually makes a room a room.
+	const isGroup =
+		typeof payload.is_group === "boolean"
+			? payload.is_group
+			: Array.isArray(payload.participants) && payload.participants.length > 1;
 	const createdAtMs = payload.created_at ? Date.parse(payload.created_at) : NaN;
 	const messageId = payload.guid?.trim() || (typeof payload.id === "number" ? String(payload.id) : undefined);
 	const out: NormalizedIMessage = {

--- a/src/agents/channels/imessage/send.test.ts
+++ b/src/agents/channels/imessage/send.test.ts
@@ -39,6 +39,31 @@ describe("sendMessageIMessage", () => {
 		assert.equal(client.stopped, false);
 	});
 
+	// THE CASE THE ORIGINAL PREFIX TEST MISSED.
+	//
+	// The test below passes no `opts.service`, so the old
+	// `opts.service ?? target.service` fell through to the prefix and looked
+	// right. Production ALWAYS passes `opts.service` — `account.service` is a
+	// required field that `coerceIMessageService` defaults to "auto" — so the
+	// left side never fell through and every prefix was silently discarded.
+	it("a service prefix beats the account default", async () => {
+		const client = new FakeRpcClient();
+		await sendMessageIMessage("sms:+15551234567", "hi", { client, service: "imessage" });
+		assert.equal(client.lastParams?.service, "sms");
+	});
+
+	it("an explicit auto: prefix beats an account pinned to sms", async () => {
+		const client = new FakeRpcClient();
+		await sendMessageIMessage("auto:+15551234567", "hi", { client, service: "sms" });
+		assert.equal(client.lastParams?.service, "auto");
+	});
+
+	it("a bare handle still takes the account default", async () => {
+		const client = new FakeRpcClient();
+		await sendMessageIMessage("+15551234567", "hi", { client, service: "sms" });
+		assert.equal(client.lastParams?.service, "sms");
+	});
+
 	it("inherits the service from a service-prefixed handle", async () => {
 		const client = new FakeRpcClient();
 		await sendMessageIMessage("sms:+15551234567", "hi", { client });

--- a/src/agents/channels/imessage/send.ts
+++ b/src/agents/channels/imessage/send.ts
@@ -92,9 +92,20 @@ export async function sendMessageIMessage(
 	// Target — an explicit chatId wins, else parse the `to` string.
 	const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
 
-	// Service — explicit opt → the handle's parsed service → the account default.
-	const service: IMessageService =
-		opts.service ?? (target.kind === "handle" ? target.service : undefined) ?? "auto";
+	// Service — the target's own prefix, then the account default, then `auto`.
+	//
+	// THE ORDER USED TO BE BACKWARDS AND THAT MADE THE PREFIX DEAD. This read
+	// `opts.service ?? target.service`, and `opts.service` is the ACCOUNT DEFAULT,
+	// which `coerceIMessageService` always resolves to a real value — so the left
+	// side never fell through and the right side was unreachable. Every documented
+	// `sms:+1555…` / `imessage:…` prefix parsed correctly and was then discarded,
+	// sending over whatever the account was configured for.
+	//
+	// `serviceExplicit` rather than `service !== "auto"`, because a deliberate
+	// `auto:` on an account pinned to `sms` is a real instruction too.
+	const targetService: IMessageService | undefined =
+		target.kind === "handle" && target.serviceExplicit ? target.service : undefined;
+	const service: IMessageService = targetService ?? opts.service ?? "auto";
 	const region = opts.region?.trim() || "US";
 	const maxBytes = typeof opts.maxBytes === "number" ? opts.maxBytes : 16 * 1024 * 1024;
 

--- a/src/agents/channels/imessage/targets.test.ts
+++ b/src/agents/channels/imessage/targets.test.ts
@@ -5,6 +5,7 @@ import {
 	formatIMessageChatTarget,
 	inferIMessageTargetChatType,
 	isAllowedIMessageSender,
+	normalizeIMessageAclEntry,
 	normalizeE164,
 	normalizeIMessageHandle,
 	parseIMessageAllowTarget,
@@ -182,5 +183,41 @@ describe("normalizeE164 — refuses to invent a number", () => {
 		// survive normalisation rather than being mangled into a number.
 		assert.equal(normalizeIMessageHandle("Line 2"), "Line2");
 		assert.equal(normalizeIMessageHandle("me@Example.com"), "me@example.com");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// The allow-list spelling gap.
+//
+// `evaluateAccess` matches by exact string equality — correct, and only safe
+// when both sides are spelled the same way. iMessage delivers whatever the
+// chat database stores while the operator types what the wizard showed them,
+// so the two sides disagreed and listed senders were refused. These pin the
+// canonicalisation that closes the gap without loosening the comparison.
+// ─────────────────────────────────────────────────────────────────────────
+describe("iMessage allow-list canonicalisation", () => {
+	const norm = normalizeIMessageAclEntry;
+
+	it("a punctuated phone and the stored form canonicalise to one string", () => {
+		assert.equal(norm("+1 (555) 123-4567"), normalizeIMessageHandle("+15551234567"));
+	});
+
+	it("email case does not decide access", () => {
+		assert.equal(norm("User@Example.com"), normalizeIMessageHandle("user@example.com"));
+	});
+
+	it("every chat_id spelling the parser accepts lands on one form", () => {
+		assert.equal(norm("chat_id:42"), "chat_id:42");
+		assert.equal(norm("chatid: 42"), "chat_id:42");
+		assert.equal(norm("chat:42"), "chat_id:42");
+	});
+
+	it("does NOT collapse two different identities onto one entry", () => {
+		// The whole reason matching stays exact. If canonicalisation ever mapped
+		// distinct people to the same string it would widen the allow-list
+		// silently, which is worse than the bug it fixes.
+		assert.notEqual(norm("+15551234567"), norm("+15559999999"));
+		assert.notEqual(norm("a@example.com"), norm("b@example.com"));
+		assert.notEqual(norm("chat_id:42"), norm("chat_id:43"));
 	});
 });

--- a/src/agents/channels/imessage/targets.ts
+++ b/src/agents/channels/imessage/targets.ts
@@ -29,7 +29,21 @@ export type IMessageTarget =
 	| { kind: "chat_id"; chatId: number }
 	| { kind: "chat_guid"; chatGuid: string }
 	| { kind: "chat_identifier"; chatIdentifier: string }
-	| { kind: "handle"; to: string; service: IMessageService };
+	| {
+			kind: "handle";
+			to: string;
+			service: IMessageService;
+			/**
+			 * True when the caller wrote the service prefix themselves.
+			 *
+			 * Needed because `auto` is BOTH the parse of an explicit `auto:` and
+			 * the value a bare handle gets, so `service` alone cannot say whether
+			 * anyone chose it. Senders use this to let a per-target prefix beat the
+			 * account default — including `auto:` beating an account pinned to
+			 * `sms`, which is otherwise unexpressible.
+			 */
+			serviceExplicit: boolean;
+	  };
 
 /** A parsed allow-list target (lenient — a bare handle string is the fallback). */
 export type IMessageAllowTarget =
@@ -197,12 +211,12 @@ export function parseIMessageTarget(raw: string): IMessageTarget {
 			if (!remainder) throw new Error(`${prefix} target is required`);
 			const chat = parseChatTargetStrict(remainder, remainder.toLowerCase());
 			if (chat) return chat;
-			return { kind: "handle", to: remainder, service };
+			return { kind: "handle", to: remainder, service, serviceExplicit: true };
 		}
 	}
 	const chat = parseChatTargetStrict(trimmed, lower);
 	if (chat) return chat;
-	return { kind: "handle", to: trimmed, service: "auto" };
+	return { kind: "handle", to: trimmed, service: "auto", serviceExplicit: false };
 }
 
 /** Parse an allow-list target (LENIENT). A bare/unparseable string is a normalized handle. */
@@ -283,4 +297,36 @@ export function isAllowedIMessageSender(params: {
 		}
 	}
 	return false;
+}
+
+/**
+ * Canonicalize one configured allow-list entry into the spelling
+ * `InboundMessage.senderAliases` uses for this channel.
+ *
+ * Allow-list matching is exact string equality and stays that way — a fuzzy
+ * comparison on an access-control list is how the wrong person gets admitted.
+ * This makes both sides agree on SPELLING first: iMessage delivers whatever the
+ * chat database stores (`+1 (555) 123-4567`, `User@Example.com`) while the
+ * operator types the form the setup wizard showed them.
+ *
+ * `chat_id:` / `chat_identifier:` keep their prefix — they identify the THREAD,
+ * not the sender, and are matched against the conversation. The wizard has
+ * always documented `chat_id:123` as a valid entry; before this it could never
+ * match anything, because `from` is a handle and never equals `chat_id:N`.
+ *
+ * Two genuinely different identities never map onto one string here, so the
+ * allow-list is not widened. `*` is the caller's responsibility to pass through
+ * — it is the wildcard, not an identity.
+ */
+export function normalizeIMessageAclEntry(entry: string): string {
+	const trimmed = (entry ?? "").trim();
+	if (!trimmed) return trimmed;
+	const chat = /^(chat_id|chatid|chat):\s*(\d+)$/i.exec(trimmed);
+	if (chat?.[2]) return `chat_id:${Number.parseInt(chat[2], 10)}`;
+	const ident = /^(chat_identifier|chatidentifier|chatident):\s*(.+)$/i.exec(trimmed);
+	if (ident?.[2]) {
+		const norm = normalizeIMessageHandle(ident[2]);
+		return norm ? `chat_identifier:${norm}` : trimmed;
+	}
+	return normalizeIMessageHandle(trimmed) || trimmed;
 }

--- a/src/agents/channels/inbound-pipeline.ts
+++ b/src/agents/channels/inbound-pipeline.ts
@@ -646,9 +646,21 @@ export async function runChannelInboundPipeline(
 		// file via the path resolver's default branch.
 		const aclAccountId = msg.accountId?.trim() || undefined;
 		const storeAllow = dmPolicy === "allowlist" ? [] : readAllowFrom(adapter.id, aclAccountId);
-		const allowFrom = [...new Set([...storeAllow, ...configIds(cfgEntry.allowFrom)])];
+		// Canonicalize the operator's side to the spelling the channel reports.
+		// Both sides are still compared by exact equality — see
+		// `ChannelAdapter.normalizeAclEntry`. Adapters without the hook are
+		// untouched, so JID/numeric-id channels keep verbatim matching.
+		const normAcl = (entry: string): string =>
+			entry === "*" ? entry : (adapter.normalizeAclEntry?.(entry) ?? entry);
+		const allowFrom = [
+			...new Set([...storeAllow, ...configIds(cfgEntry.allowFrom)].map(normAcl)),
+		];
 		const groupAllowFrom = [
-			...new Set([...readGroupAllowFrom(adapter.id, aclAccountId), ...configIds(cfgEntry.groupAllowFrom)]),
+			...new Set(
+				[...readGroupAllowFrom(adapter.id, aclAccountId), ...configIds(cfgEntry.groupAllowFrom)].map(
+					normAcl,
+				),
+			),
 		];
 		// Per-group full-trust list (respond untagged in these groups). Config-only.
 		const groupAllowJids = configIds(cfgEntry.groupAllowJids);
@@ -684,6 +696,7 @@ export async function runChannelInboundPipeline(
 					groupPolicy,
 					senderId: msg.from,
 					...(msg.senderLid !== undefined ? { senderLid: msg.senderLid } : {}),
+					...(msg.senderAliases !== undefined ? { senderAliases: msg.senderAliases } : {}),
 					selfId,
 					allowFrom,
 					groupAllowFrom,

--- a/src/agents/extensions/types.ts
+++ b/src/agents/extensions/types.ts
@@ -127,6 +127,24 @@ export interface InboundMessage {
 	 * alias.
 	 */
 	senderLid?: string;
+	/**
+	 * Further identities this message may be allow-listed under, beyond `from`
+	 * and `senderLid`.
+	 *
+	 * The allow-list is matched by EXACT STRING EQUALITY, deliberately — a
+	 * fuzzy match on an access-control list is how someone gets admitted who
+	 * should not be. That is safe only when both sides are spelled the same
+	 * way, and on some channels they are not: iMessage delivers whatever the
+	 * chat database stores (`+1 (555) 123-4567`, `User@Example.com`) while the
+	 * operator types the form the setup wizard showed them. A channel supplies
+	 * the canonical spellings of the SAME sender here; the config side is
+	 * canonicalized by the adapter's `normalizeAclEntry`. Matching stays exact.
+	 *
+	 * This is also how a conversation-scoped entry works — iMessage's wizard
+	 * documents `chat_id:123`, which is a property of the thread rather than of
+	 * the sender and so could never equal `from`.
+	 */
+	senderAliases?: ReadonlyArray<string>;
 	/** Plain text of the message (may be empty when media has no caption). */
 	text: string;
 	/** Optional display name of the sender. */
@@ -497,6 +515,23 @@ export interface ChannelAdapter {
 	 * `undefined` before the first successful connection.
 	 */
 	selfId?(): string | undefined;
+	/**
+	 * Canonicalize one configured allow-list entry into the spelling this
+	 * channel's `InboundMessage.senderAliases` use.
+	 *
+	 * Allow-list matching is exact equality on both sides. That is only correct
+	 * when both sides agree on spelling, and an operator typing into a setup
+	 * wizard does not know how the channel's backing store punctuates a phone
+	 * number or cases an email. This canonicalizes the operator's side; the
+	 * channel canonicalizes its own via `senderAliases`.
+	 *
+	 * MUST pass `*` through unchanged — it is the wildcard, not an identity —
+	 * and MUST NOT map two genuinely different identities onto one string, which
+	 * would silently widen the allow-list. Channels whose ids are already
+	 * canonical (WhatsApp JIDs, Telegram numeric ids) leave this undefined and
+	 * keep verbatim matching.
+	 */
+	normalizeAclEntry?(entry: string): string;
 	/**
 	 * Epoch-ms of the channel's most recent successful connection. The manager
 	 * uses this with `InboundMessage.messageTimestampMs` to detect "queued


### PR DESCRIPTION
Closes the remaining audit findings. Each was a setting the docs and setup wizard advertise, that parsed correctly and was then discarded — plus one larger bug found by the tests written for them.

### Reconnect race → leaked subprocess + double delivery
`subscribeOnce` checked `closed` before two awaits and never after. A close landing in between saw `client === null`, stopped nothing, then published the resolved client into an already-closed connection: a live `imsg` process no code path can reach, still streaming rows. Reconnecting answered the operator **twice** for one message.

### Service prefix never took effect
`opts.service ?? target.service` — and `opts.service` is the *account default*, which always resolves to a real value, so the right side was unreachable. Every documented `sms:` / `imessage:` prefix was parsed and thrown away. The existing test passed no account default, which is exactly why this survived.

### Allow-list matched verbatim across two spellings
Matching is exact equality — deliberately, a fuzzy ACL is how the wrong person gets admitted — but the two sides were spelled differently: the chat database stores `+1 (555) 123-4567` / `User@Example.com`, the operator types what the wizard showed them. **Listed senders were refused.** The wizard's own `chat_id:123` example could never match anything. `isAllowedIMessageSender` handled all of it and had zero callers.

### `dmHistoryLimit` resolved and never read
Only `historyLimit` was, gated on the message being a group. `record` was group-only too, so honouring the limit alone would have read a buffer nothing ever wrote to.

### DMs were classified as groups — found while testing the above
`isGroup` was `is_group || typeof chat_id === "number"`, and `chat_id` is the conversation's row id, which **every thread has**. Any DM carrying one sat behind the group requireMention gate (a plain DM ignored unless it named the bot), matched `groupAllowFrom` instead of `allowFrom`, and took the group history path.

### Typing indicator
The only channel without one. `imsg`'s `typing` RPC verified against the installed binary; it needs IMCore, so it never throws, latches off after the first "this Mac cannot", and logs once.

### Channel-agnostic by construction
`senderAliases` generalises the WhatsApp `senderLid` identity overlap that was already there; `normalizeAclEntry` is opt-in. **WhatsApp, Discord, Slack and Telegram supply neither and keep verbatim matching unchanged** — pinned by a test so a later change cannot loosen it quietly. BlueBubbles shares iMessage's identity space and had the identical gap, so it opts in through the same shared helper; its wizard advertised `chat_id:` for threads keyed by guid, which is corrected.

---

6646 tests, typecheck and build clean. Eleven mutation checks: reverting any single claim fails a test.