### PR TITLE
fix(connect): nine slash commands were unusable mid-turn

### DIFF
--- a/src/cli/commands/connect-slash-commands.test.ts
+++ b/src/cli/commands/connect-slash-commands.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The slash-command registry must cover every command the TUI dispatches.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHY THIS IS A TEST AND NOT A CODE REVIEW NOTE
+ * ─────────────────────────────────────────────────────────────────────────
+ * `connect.ts` carries three lists that describe the same set of commands:
+ * the handler chain that dispatches them, `SLASH_COMMANDS` (which drives
+ * autocomplete AND `isKnownSlashCommand`), and the hand-written `/help` text.
+ * Nothing tied them together, so they drifted — nine commands were dispatched
+ * without being registered, and `isKnownSlashCommand` is the gate deciding
+ * whether mid-turn input is a COMMAND or steering text for the model. An
+ * unregistered command does not merely lack autocomplete: it stops working
+ * mid-turn and is delivered to the model as prose.
+ *
+ * Reading the source is the only way to catch that, because the drift is
+ * between two literals in one file — there is no runtime moment where the two
+ * disagree observably until an operator types the command at the wrong time.
+ */
+
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const SOURCE = readFileSync(
+	path.join(path.dirname(fileURLToPath(import.meta.url)), "connect.ts"),
+	"utf8",
+);
+
+/** Commands the handler chain actually dispatches on. */
+function dispatchedCommands(): Set<string> {
+	const out = new Set<string>();
+	for (const m of SOURCE.matchAll(/trimmed === "\/([a-z][a-z-]*)"/g)) out.add(m[1]!);
+	for (const m of SOURCE.matchAll(/trimmed\.startsWith\("\/([a-z][a-z-]*) "\)/g)) out.add(m[1]!);
+	return out;
+}
+
+/** Commands registered in `SLASH_COMMANDS`. */
+function registeredCommands(): Set<string> {
+	const start = SOURCE.indexOf("const SLASH_COMMANDS: SlashCommand[] = [");
+	assert.ok(start > 0, "SLASH_COMMANDS literal not found — this test needs updating");
+	// Stop at the closing bracket of the array literal.
+	const end = SOURCE.indexOf("\n\t];", start);
+	assert.ok(end > start, "could not find the end of the SLASH_COMMANDS literal");
+	const body = SOURCE.slice(start, end);
+	const out = new Set<string>();
+	for (const m of body.matchAll(/name: "([a-z][a-z-]*)"/g)) out.add(m[1]!);
+	return out;
+}
+
+describe("connect — slash command registry", () => {
+	it("finds both lists (guards the parser itself)", () => {
+		// If either extraction silently returned nothing, the real assertion
+		// below would pass vacuously and this test would protect nothing.
+		assert.ok(dispatchedCommands().size > 20, "expected the handler chain to dispatch many commands");
+		assert.ok(registeredCommands().size > 20, "expected SLASH_COMMANDS to register many commands");
+	});
+
+	it("registers every command the handler chain dispatches", () => {
+		const dispatched = dispatchedCommands();
+		const registered = registeredCommands();
+		const missing = [...dispatched].filter((c) => !registered.has(c)).sort();
+		assert.deepEqual(
+			missing,
+			[],
+			`These commands are dispatched but not in SLASH_COMMANDS, so they have no ` +
+				`autocomplete and are treated as steering text mid-turn: ${missing.join(", ")}`,
+		);
+	});
+});

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -1276,8 +1276,39 @@ export async function wireConnectUi(
 	// Pi-TUI's slash-command spec: `name` is the command WITHOUT the leading
 	// `/`. Pi adds the `/` itself on accept; including it here produces
 	// `//reasoning` instead of `/reasoning`.
+	// ─────────────────────────────────────────────────────────────────────────
+	// THIS LIST IS NOT COSMETIC.
+	//
+	// It drives autocomplete AND `isKnownSlashCommand`, which is the gate that
+	// decides whether something typed mid-turn is a COMMAND or is steering text
+	// for the model. A handled command missing from here is therefore not merely
+	// undiscoverable — it stops working mid-turn, silently, and gets delivered
+	// to the model as prose instead.
+	//
+	// Nine commands were in exactly that state: `/switch`, `/clip` and `/cancel`
+	// appeared in no list at all, and `/agents`, `/delete`, `/mute`, `/org`,
+	// `/rename` and `/sessions` were documented in `/help` while absent here —
+	// advertised, and unusable at the moment an operator would reach for them.
+	//
+	// `connect-slash-commands.test.ts` reads the handler chain out of this file
+	// and fails if any command it dispatches is not registered here, so the
+	// three lists cannot drift apart again unnoticed.
+	// ─────────────────────────────────────────────────────────────────────────
 	const SLASH_COMMANDS: SlashCommand[] = [
 		{ name: "help", description: "show all slash commands" },
+		{ name: "switch", description: "switch the TUI to another session", argumentHint: "<session-key>" },
+		{ name: "cancel", description: "cancel the pending prompt (provider key entry)" },
+		{ name: "clip", description: "copy the last reply to your clipboard (alias of /clipboard)" },
+		{ name: "agents", description: "list every agent the gateway knows about" },
+		{ name: "sessions", description: "list live sessions (bound agent or all)", argumentHint: "[--all]" },
+		{ name: "rename", description: "name this thread (no argument clears the name)", argumentHint: "[<name>]" },
+		{
+			name: "delete",
+			description: "permanently delete a thread + transcript (repeat to confirm)",
+			argumentHint: "<session-key>",
+		},
+		{ name: "mute", description: "unsubscribe from an agent id or session key", argumentHint: "<id|key>" },
+		{ name: "org", description: "show the Pride hierarchy chart", argumentHint: "[<agent-id>|--departments]" },
 		{ name: "exit", description: "quit Brigade connect" },
 		{ name: "quit", description: "quit Brigade connect" },
 		{ name: "abort", description: "abort the in-flight turn (same as Ctrl+C)" },


### PR DESCRIPTION
`SLASH_COMMANDS` drives autocomplete **and** `isKnownSlashCommand` — the gate deciding whether mid-turn input is a command or steering text for the model. A dispatched command missing from that list stops working mid-turn and is delivered to the model as prose.

Nine were in that state:
- `/switch`, `/clip`, `/cancel` — in no list at all
- `/agents`, `/delete`, `/mute`, `/org`, `/rename`, `/sessions` — documented in `/help`, absent from the registry

The cause is one file carrying three descriptions of the same set (handler chain, registry, hand-written `/help`) with nothing tying them together. The new test reads the handler chain out of the source and fails if anything it dispatches is unregistered — with a guard against its own extraction returning nothing, so it cannot pass vacuously. Verified by mutation: removing one entry fails it.

6648 tests, typecheck and build clean.