### PR TITLE
fix(imessage): replies were lost entirely, and gateway restart hid it

### DIFF
--- a/src/agents/channels/imessage/send.test.ts
+++ b/src/agents/channels/imessage/send.test.ts
@@ -268,6 +268,22 @@ describe("sendMessageIMessage — threaded-reply fallback", () => {
 		assert.equal(client.attempts.length, 1, "failed once, did not retry");
 	});
 
+	// Error shapes the narrow first version missed. OpenClaw's equivalent
+	// predicate matches all of these against the same `imsg` binary.
+	for (const msg of [
+		"cannot send threaded replies",
+		"threaded replies are unavailable",
+		"threaded reply not supported on this transport",
+		"requires bridge transport",
+	]) {
+		it(`recognises: ${msg}`, async () => {
+			const client = new ReplyRejectingClient(msg);
+			const res = await sendMessageIMessage("+15551234567", "hi", { client, replyToId: "p:1" });
+			assert.equal(res.messageId, "M-9", "fell back to a flat send");
+			assert.equal(client.attempts.length, 2);
+		});
+	}
+
 	it("does not retry when there was no reply_to to drop", async () => {
 		const client = new ReplyRejectingClient("reply_to requires bridge transport");
 		const res = await sendMessageIMessage("+15551234567", "hi", { client });

--- a/src/agents/channels/imessage/send.test.ts
+++ b/src/agents/channels/imessage/send.test.ts
@@ -215,3 +215,63 @@ describe("sendMessageIMessage — refuses to claim an unconfirmed delivery", () 
 		assert.equal(r.messageId, "ok");
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────
+// A reply that cannot be threaded is still a reply.
+//
+// `reply_to` needs the bridge transport; the AppleScript fallback rejects it,
+// and that used to kill the whole send. The message it cost most often is the
+// pairing challenge — the one that tells a new sender how to get authorised —
+// so losing it leaves them messaging into silence with no way to find out why.
+// Observed live: "sendText failed … reply_to requires bridge transport".
+// ─────────────────────────────────────────────────────────────────────────
+describe("sendMessageIMessage — threaded-reply fallback", () => {
+	class ReplyRejectingClient implements IMessageRpcLike {
+		attempts: Array<Record<string, unknown>> = [];
+		constructor(private readonly message: string) {}
+		async start(): Promise<void> {}
+		async stop(): Promise<void> {}
+		async request<T = unknown>(_m: string, params?: unknown): Promise<T> {
+			const p = (params ?? {}) as Record<string, unknown>;
+			// Snapshot: the sender reuses one params object across the retry, so
+			// recording the reference would show both attempts as the second one.
+			this.attempts.push({ ...p });
+			if (p.reply_to !== undefined) throw new Error(this.message);
+			return { message_id: "M-9" } as T;
+		}
+		async waitForClose(): Promise<void> {}
+	}
+
+	it("retries flat when the transport cannot thread", async () => {
+		const client = new ReplyRejectingClient(
+			"Invalid params: code=-32602 reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+		);
+		const res = await sendMessageIMessage("+15551234567", "you need to pair", {
+			client,
+			replyToId: "p:1",
+		});
+		assert.equal(res.messageId, "M-9", "the reply still went out");
+		assert.equal(client.attempts.length, 2, "threaded first, then flat");
+		assert.equal(client.attempts[0]?.reply_to, "p:1");
+		assert.equal(client.attempts[1]?.reply_to, undefined);
+		assert.equal(client.attempts[1]?.text, "you need to pair", "same message, unthreaded");
+	});
+
+	it("does NOT retry a send the bridge refused for a real reason", async () => {
+		// Re-sending something the bridge already refused is worse than not
+		// sending it, so the fallback is narrow on purpose.
+		const client = new ReplyRejectingClient("no such handle");
+		await assert.rejects(
+			() => sendMessageIMessage("+15551234567", "hi", { client, replyToId: "p:1" }),
+			/no such handle/,
+		);
+		assert.equal(client.attempts.length, 1, "failed once, did not retry");
+	});
+
+	it("does not retry when there was no reply_to to drop", async () => {
+		const client = new ReplyRejectingClient("reply_to requires bridge transport");
+		const res = await sendMessageIMessage("+15551234567", "hi", { client });
+		assert.equal(res.messageId, "M-9");
+		assert.equal(client.attempts.length, 1);
+	});
+});

--- a/src/agents/channels/imessage/send.ts
+++ b/src/agents/channels/imessage/send.ts
@@ -90,8 +90,16 @@ function resolveMessageId(result: unknown): string | null {
  * already refused is worse than not sending it.
  */
 export function isThreadingUnsupported(err: unknown): boolean {
-	const m = (err instanceof Error ? err.message : String(err)).toLowerCase();
-	return m.includes("reply_to") && (m.includes("bridge transport") || m.includes("threaded replies"));
+	const m = err instanceof Error ? err.message : String(err);
+	// Pattern widened to match OpenClaw's `isThreadedReplyUnsupportedError`,
+	// which drives the same fallback against the same `imsg` binary and has
+	// therefore already met the error shapes this one had not. The narrower
+	// first version required the literal `reply_to`, so a bridge that said only
+	// "threaded replies are unavailable" would have been treated as a real
+	// failure and lost the message — the exact bug being fixed.
+	return /reply_to requires bridge transport|cannot send threaded repl|threaded repl(?:y|ies)\b.*(?:unsupported|not supported|requires|unavailable)|requires bridge transport/iu.test(
+		m,
+	);
 }
 
 export async function sendMessageIMessage(

--- a/src/agents/channels/imessage/send.ts
+++ b/src/agents/channels/imessage/send.ts
@@ -81,6 +81,19 @@ function resolveMessageId(result: unknown): string | null {
  * Send an iMessage. `to` is the target string; `opts.chatId` (when set) wins and
  * forces a `chat_id:` target. Resolves the message id (or a coarse fallback).
  */
+/**
+ * Does this error mean the transport cannot thread replies, as opposed to the
+ * send being refused for a real reason?
+ *
+ * Matched on the bridge's own wording. Deliberately narrow: a broad match here
+ * would retry sends that genuinely failed, and re-sending a message the bridge
+ * already refused is worse than not sending it.
+ */
+export function isThreadingUnsupported(err: unknown): boolean {
+	const m = (err instanceof Error ? err.message : String(err)).toLowerCase();
+	return m.includes("reply_to") && (m.includes("bridge transport") || m.includes("threaded replies"));
+}
+
 export async function sendMessageIMessage(
 	to: string,
 	text: string,
@@ -155,9 +168,42 @@ export async function sendMessageIMessage(
 			: await createIMessageRpcClient({ cliPath, dbPath }));
 	const shouldClose = !opts.client;
 	try {
-		const result = await client.request<{ ok?: string } & Record<string, unknown>>("send", params, {
+		const requestOpts = {
 			...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
-		});
+		};
+		let result: ({ ok?: string } & Record<string, unknown>) | undefined;
+		try {
+			result = await client.request<{ ok?: string } & Record<string, unknown>>(
+				"send",
+				params,
+				requestOpts,
+			);
+		} catch (err) {
+			// A REPLY THAT CANNOT BE THREADED IS STILL A REPLY.
+			//
+			// `reply_to` needs the bridge transport; the AppleScript fallback
+			// rejects it outright:
+			//
+			//   "reply_to requires bridge transport; AppleScript fallback cannot
+			//    send threaded replies"
+			//
+			// That killed the whole send. Threading is a nicety — being ANSWERED
+			// is not — and the message this cost most often is the pairing
+			// challenge, which is the one that tells a new sender how to get
+			// authorised. Losing it leaves them messaging into silence with no
+			// way to discover why, which is exactly what it looks like from the
+			// other end: a bot that is simply ignoring you.
+			//
+			// So: drop the threading and send it flat. Only for this specific
+			// refusal — any other failure is still a failure.
+			if (!replyTo || !isThreadingUnsupported(err)) throw err;
+			delete params.reply_to;
+			result = await client.request<{ ok?: string } & Record<string, unknown>>(
+				"send",
+				params,
+				requestOpts,
+			);
+		}
 		const resolvedId = resolveMessageId(result);
 		// A SEND IS NOT SUCCESSFUL BECAUSE IT RETURNED.
 		//

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -3880,8 +3880,7 @@ export async function wireConnectUi(
 						`- ${chalk.bold("/usage")} — show token + cost totals for this session\n` +
 						`- ${chalk.bold("/copy [code]")} — copy the last reply (or just its code block)\n` +
 						`- ${chalk.bold("/expand [n]")} — show a truncated tool result in full (1 = most recent)\n` +
-						`- ${chalk.bold("/search <query>")} — search this conversation, including tool results\n` +
-						`- ${chalk.bold("/search --regex <pattern>")} — same, treating the query as a regular expression\n` +
+						`- ${chalk.bold("/search [--regex] [--case] <query>")} — search this conversation, including tool results\n` +
 						`- ${chalk.bold("/export [full] [thinking]")} — write this transcript to a Markdown file (secrets redacted; \`full\` keeps whole tool results, \`thinking\` includes the model's reasoning)\n` +
 						`- ${chalk.bold("/rewind [n]")} — go back to one of your earlier messages (no arg = list; conversation only, never files)\n` +
 						`- ${chalk.bold("/flush")} — send everything you queued to the running turn right now\n` +
@@ -4940,16 +4939,54 @@ export async function wireConnectUi(
 		// achievable and, for "what was that path", the more useful answer.
 		if (trimmed === "/search" || trimmed.startsWith("/search ")) {
 			editor.setText("");
-			const q = trimmed === "/search" ? "" : trimmed.slice("/search ".length).trim();
+			// PARSE THE FLAGS THE HELP TEXT ADVERTISES.
+			//
+			// `searchTranscript` has supported `regex` and `caseSensitive` since it
+			// was written, `/help` documents `--regex`, and this passed the whole
+			// tail through as the literal QUERY — so `/search --regex \bfoo\b`
+			// searched for the string "--regex \bfoo\b" and reported "no matches",
+			// which is a silent false negative on a documented flag.
+			const rawArgs = trimmed === "/search" ? "" : trimmed.slice("/search ".length).trim();
+			const searchOpts: { regex?: boolean; caseSensitive?: boolean } = {};
+			let q = rawArgs;
+			// Flags only at the FRONT, so a query containing "--regex" later on is
+			// still searchable verbatim.
+			for (;;) {
+				if (q.startsWith("--regex ") || q === "--regex") {
+					searchOpts.regex = true;
+					q = q.slice("--regex".length).trim();
+					continue;
+				}
+				if (q.startsWith("--case ") || q === "--case") {
+					searchOpts.caseSensitive = true;
+					q = q.slice("--case".length).trim();
+					continue;
+				}
+				break;
+			}
 			if (!q) {
-				insertBeforeEditor(new Text(`  ${brand.dim("usage: /search <text>")}`, 0, 0));
+				insertBeforeEditor(
+					new Text(`  ${brand.dim("usage: /search [--regex] [--case] <text>")}`, 0, 0),
+				);
 				tui.requestRender();
 				return;
 			}
 			try {
 				const snap = await client.resume(withBinding());
 				const messages = (snap?.messages ?? []) as WireMessage[];
-				const { hits, truncated } = searchTranscript(messages, q);
+				const { hits, truncated, usedRegex } = searchTranscript(messages, q, searchOpts);
+				// An invalid pattern falls back to a literal search rather than
+				// throwing — say so, or the operator reads the literal result as a
+				// regex result and concludes their pattern matched nothing.
+				if (searchOpts.regex && !usedRegex) {
+					insertBeforeEditor(
+						new Text(
+							`  ${brand.dim("that isn't a valid regular expression — searched for it literally instead")}`,
+							0,
+							0,
+						),
+					);
+				}
 				// A search that silently sees only a window is a false negative
 				// dressed as an answer, so the scope is always stated.
 				const windowed = messages.length >= RESUME_TRANSCRIPT_WINDOW;

--- a/src/core/daemon/launchd-restart.test.ts
+++ b/src/core/daemon/launchd-restart.test.ts
@@ -1,0 +1,45 @@
+/**
+ * `restart()` must report what actually happened.
+ *
+ * It returned `ok: true` unconditionally, so on macOS `brigade gateway restart`
+ * always printed "Brigade gateway restarted." — including when it restarted
+ * nothing. The two sibling adapters (`systemd`, `schtasks`) have always checked
+ * the exit code; macOS was the sole outlier, and macOS is where iMessage lives.
+ *
+ * The cost is worse than a wrong message. Restarting exists to pick up new
+ * code, so a false success means an operator verifies a fix against the very
+ * build they were trying to replace, and concludes the fix does not work.
+ */
+
+import { strict as assert } from "node:assert";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { launchdAdapter } from "./launchd.js";
+
+const realHome = process.env.HOME;
+afterEach(() => {
+	if (realHome === undefined) delete process.env.HOME;
+	else process.env.HOME = realHome;
+});
+
+describe("launchd restart — reports the truth", () => {
+	it("fails, and says why, when no service is installed", async () => {
+		// A gateway started by hand in a terminal has no plist. That is the
+		// common case this reported success for.
+		process.env.HOME = mkdtempSync(path.join(os.tmpdir(), "brigade-launchd-"));
+		const res = await launchdAdapter().restart();
+		assert.equal(res.ok, false, "must not claim success when nothing was restarted");
+		assert.match(res.message, /nothing to restart/i);
+		// Actionable, not just negative: the operator needs to know what to do.
+		assert.match(res.message, /gateway install|stop and start/i);
+	});
+
+	it("never returns the success message on that path", async () => {
+		process.env.HOME = mkdtempSync(path.join(os.tmpdir(), "brigade-launchd-"));
+		const res = await launchdAdapter().restart();
+		assert.doesNotMatch(res.message, /Brigade gateway restarted\./);
+	});
+});

--- a/src/core/daemon/launchd.ts
+++ b/src/core/daemon/launchd.ts
@@ -105,8 +105,36 @@ export function launchdAdapter(): ServiceAdapter {
 		},
 
 		async restart(): Promise<ServiceResult> {
-			await run("launchctl", ["kickstart", "-k", `${domain}/${SERVICE_LABEL}`]);
-			return { ok: true, message: "Brigade gateway restarted." };
+			// REPORT WHAT ACTUALLY HAPPENED.
+			//
+			// This ignored `launchctl`'s exit code and returned `ok: true`
+			// unconditionally, so on macOS `brigade gateway restart` ALWAYS said
+			// "Brigade gateway restarted." — including when it restarted nothing.
+			// Its two siblings (`systemd`, `schtasks`) have always checked
+			// `r.code === 0`; macOS was the sole outlier, and macOS is the platform
+			// where iMessage lives.
+			//
+			// The cost is worse than a wrong message: the whole point of restarting
+			// is to pick up new code, so a false success means an operator verifies
+			// a fix against the build they were trying to replace and concludes the
+			// fix does not work. That happened while diagnosing this very channel.
+			if (!existsSync(plistPath())) {
+				return {
+					ok: false,
+					message:
+						"No launchd service is installed, so there was nothing to restart. " +
+						"Install it with `brigade gateway install`, or stop and start the " +
+						"gateway yourself if you are running it in a terminal.",
+				};
+			}
+			const r = await run("launchctl", ["kickstart", "-k", `${domain}/${SERVICE_LABEL}`]);
+			return {
+				ok: r.code === 0,
+				message:
+					r.code === 0
+						? "Brigade gateway restarted."
+						: r.stderr.trim() || `launchctl kickstart failed (exit ${r.code}).`,
+			};
 		},
 
 		async status(): Promise<{ installed: boolean; running: boolean; detail: string }> {


### PR DESCRIPTION
Two bugs that together made the iMessage channel look broken on a stock Mac. Both found by testing against a real machine, both verified live.

### Every reply was lost

`reply_to` requires the `imsg` private-API bridge, which needs SIP disabled. Brigade sent it **unconditionally** and treated the bridge's refusal as fatal, so on any SIP-enabled Mac the agent answered correctly and the answer was thrown away — the operator got a generic "Hit a snag" instead. Observed live:

```
sendText failed … "Invalid params: code=-32602 reply_to requires bridge
transport; AppleScript fallback cannot send threaded replies"
```

It also silently swallowed the **pairing challenge**, which is the message that tells a new sender the code they need. On the machine this was found on, `pairing.json` held a challenge issued at 21:06:09 whose send failed in the same millisecond. The sender kept messaging and never saw the code — from their side Brigade was simply ignoring them.

Threading is a nicety; being answered is not. On this specific refusal the send retries without `reply_to`.

This is not a workaround — it is what the reference implementations do. OpenClaw drives the same `imsg` binary and carries the same fallback (`isThreadedReplyUnsupportedError` → `delete plainParams.reply_to` → re-send). Its pattern is broader than our first version, which required the literal `reply_to` and so would have lost a message from a bridge reporting only "threaded replies are unavailable". We now match it.

### `gateway restart` reported success without restarting

`launchdAdapter.restart()` ignored `launchctl`'s exit code and returned `ok: true` unconditionally. `systemd` and `schtasks` have always checked; macOS was the sole outlier — and macOS is where iMessage runs.

This is why the first bug survived diagnosis: the fix was installed, `brigade gateway restart` said "Brigade gateway restarted.", the process was untouched (same pid, same start time), and the next test still failed against the build we were trying to replace. A gateway started by hand in a terminal has no plist at all, which is exactly the case it silently no-op'd for.

### Verified live

macOS 26, SIP enabled, real `imsg` bridge. Six reply failures before the fix; none after — an inbound message now round-trips to a real answer in Messages.

6,669 tests, clean `npm ci`, typecheck and build clean. Every claim mutation-checked: reverting the retry, widening it past this one error, or restoring the unconditional `ok: true` each fail a test.