### PR TITLE
fix(validation): constrain provider data before saving probe evidence

### DIFF
--- a/scripts/lib/tideline-live-report-validation.mjs
+++ b/scripts/lib/tideline-live-report-validation.mjs
@@ -1,0 +1,80 @@
+/** Project provider metadata onto a bounded report schema before writing it. */
+// Sanity bounds for reporting; the caller separately enforces its request budget.
+const MAX_TOKENS = 2_000_000;
+const MAX_COST = 100;
+const MAX_ANSWER_LENGTH = 16_384;
+const FINISH_REASONS = ["stop", "length", "tool_calls", "function_call", "content_filter", "error"];
+
+function invalid(field) {
+  // Never put a rejected provider value in an error that the report may persist.
+  throw new TypeError(`Invalid provider report field: ${field}`);
+}
+
+function record(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) invalid(field);
+  return value;
+}
+
+function amount(value, field, maximum, integer = false) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > maximum || (integer && !Number.isSafeInteger(value))) invalid(field);
+  return value;
+}
+
+function allowed(value, candidates, field) {
+  // Return the local canonical value, not an unchecked provider string.
+  const match = candidates.find(candidate => candidate === value);
+  if (match === undefined) invalid(field);
+  return match;
+}
+
+function optionalAmounts(source, fields, maximum, integer, label) {
+  const result = {};
+  for (const field of fields) {
+    if (Object.hasOwn(source, field)) result[field] = amount(source[field], `${label}.${field}`, maximum, integer);
+  }
+  return result;
+}
+
+export function validateProviderReportMetadata(data, { models, providers }) {
+  record(data, "response");
+  if (typeof data.id !== "string" || data.id.length > 128 || !/^[A-Za-z0-9]/.test(data.id) || /[^A-Za-z0-9._:-]/.test(data.id)) invalid("id");
+  const source = record(data.usage, "usage");
+  const usage = {
+    prompt_tokens: amount(source.prompt_tokens, "usage.prompt_tokens", MAX_TOKENS, true),
+    completion_tokens: amount(source.completion_tokens, "usage.completion_tokens", MAX_TOKENS, true),
+    cost: amount(source.cost, "usage.cost", MAX_COST),
+    ...optionalAmounts(source, ["total_tokens"], MAX_TOKENS, true, "usage"),
+  };
+  if (Object.hasOwn(source, "is_byok")) {
+    if (typeof source.is_byok !== "boolean") invalid("usage.is_byok");
+    usage.is_byok = source.is_byok;
+  }
+  for (const [field, keys] of [
+    ["prompt_tokens_details", ["cached_tokens", "cache_write_tokens", "audio_tokens", "video_tokens"]],
+    ["completion_tokens_details", ["reasoning_tokens", "audio_tokens", "image_tokens", "accepted_prediction_tokens", "rejected_prediction_tokens"]],
+  ]) {
+    if (Object.hasOwn(source, field)) usage[field] = optionalAmounts(record(source[field], `usage.${field}`), keys, MAX_TOKENS, true, `usage.${field}`);
+  }
+  if (Object.hasOwn(source, "cost_details")) {
+    usage.cost_details = optionalAmounts(record(source.cost_details, "usage.cost_details"),
+      ["upstream_inference_cost", "upstream_inference_prompt_cost", "upstream_inference_completions_cost"], MAX_COST, false, "usage.cost_details");
+  }
+  return {
+    generationId: data.id,
+    returnedModel: allowed(data.model, models, "model"),
+    provider: allowed(data.provider, providers, "provider"),
+    usage,
+    finishReason: allowed(data.choices?.[0]?.finish_reason, FINISH_REASONS, "finish_reason"),
+  };
+}
+
+export function validateProviderAnswerText(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string" || value.length > MAX_ANSWER_LENGTH) invalid("answer");
+  return value;
+}
+
+export function providerReportErrorCategory(error) {
+  return ["Error", "TypeError", "SyntaxError", "AbortError", "TimeoutError", "AssertionError"]
+    .find(name => name === error?.name) ?? "UnknownError";
+}

--- a/scripts/test-tideline-live-convex.mjs
+++ b/scripts/test-tideline-live-convex.mjs
@@ -8,7 +8,9 @@
  * TIDELINE_CONVEX_BACKEND may supply the binary instead of --backend. This does
  * not use convex:dev, contact Convex Cloud, load provider credentials, change
  * repository environment files, or retain backend data/keys. Only redacted
- * results and logs remain in the printed temporary artifact directory. This is
+ * results and logs remain in the printed temporary artifact directory. Error
+ * details are printed to the console; reports retain fixed failure categories
+ * and local operation phases only. This is
  * a correctness/recovery probe with bounded load, not a scalability benchmark.
  */
 import assert from "node:assert/strict";
@@ -69,12 +71,21 @@ let ctx;
 let resetRuntimeContext;
 let activeChild;
 let cleaning;
+let phase = "setup";
 const sensitive = () => [instanceSecret, adminKey, safeEnv.BRIGADE_ENCRYPTION_KEY].filter(Boolean);
 const redact = (value) => sensitive().reduce((out, token) => out.split(token).join("[redacted]"), String(value));
 const envFiles = [".env.local", ".env"].map((file) => path.join(ROOT, file));
 const hashEnv = () => envFiles.map((file) => fs.existsSync(file) ? createHash("sha256").update(fs.readFileSync(file)).digest("hex") : null);
 const beforeEnv = hashEnv();
 const check = (name) => { results.checks.push(name); console.log(`PASS ${name}`); };
+
+// Error messages/stacks can contain network response data. Persist only fixed
+// categories; their full redacted diagnostics remain available in the console.
+const failureCategory = (error) => {
+  if (error?.name === "AssertionError") return "assertion";
+  if (error?.name === "TimeoutError" || error?.name === "AbortError") return "timeout";
+  return "operation";
+};
 
 function platformAsset() {
   const platforms = {
@@ -185,7 +196,9 @@ for (const [signal, code] of [["SIGINT", 130], ["SIGTERM", 143]]) {
 try {
   fs.mkdirSync(project, { recursive: true, mode: 0o700 });
   fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  phase = "resolving-backend";
   await resolveBinary();
+  phase = "preparing-backend";
   fs.cpSync(path.join(ROOT, "convex"), path.join(project, "convex"), { recursive: true, filter: (source) => {
     const rel = path.relative(path.join(ROOT, "convex"), source);
     // Keep generated API bindings; omit tsc's root-level JS/declaration copies
@@ -205,6 +218,7 @@ try {
   const envFile = path.join(project, "probe.env");
   fs.writeFileSync(envFile, `CONVEX_SELF_HOSTED_URL=${url}\nCONVEX_SELF_HOSTED_ADMIN_KEY=${adminKey}\n`, { mode: 0o600 });
   await startBackend();
+  phase = "deploying-functions";
   console.log("Backend ready on isolated loopback ports; deploying current copied functions.");
   const deploy = await run(process.execPath, [path.join(ROOT, "node_modules", "convex", "bin", "main.js"), "deploy", "--yes", "--env-file", envFile, "--typecheck", "disable", "--codegen", "disable"]);
   fs.writeFileSync(path.join(WORK, "deploy.log"), deploy);
@@ -230,6 +244,7 @@ try {
   const peer = { kind: "channel", channelId: "chat", conversationId: "room", sessionKey: "session" };
   const template = seedStore.write({ content: "Amber release gate is Friday.", segment: "project", sourceType: "owner_message", createdBy: owner, metadata: { approved: "amber-proof" } });
   const rootRecord = { ...template, memoryId: "root-record" };
+  phase = "encryption-origin-isolation";
   await memory.upsertFactRecordRaw("workspace-a", rootRecord);
   await memory.upsertFactRecordRaw("workspace-a", { ...template, memoryId: "peer-record", content: "Amber private channel gate is Monday.", createdBy: peer });
   await memory.upsertFactRecordRaw("workspace-b", { ...template, memoryId: "other-workspace", content: "Amber other workspace gate is Tuesday." });
@@ -243,6 +258,7 @@ try {
   for (const field of ["channelId", "conversationId", "sessionKey"]) assert.deepEqual(await memory.listFacts({ origin: { ...peer, [field]: "other" } }), []);
   check("real stored bytes encrypted; metadata encrypted; workspace and exact-origin reads isolated");
 
+  phase = "cold-hydration";
   ctx = await runtime.createRuntimeContext({ override: { mode: "convex", convexUrl: url }, stateDir });
   runtime.setRuntimeContext(ctx);
   const hostWorkspace = path.join(stateDir, "agents", "probe-a", "workspace");
@@ -255,6 +271,7 @@ try {
   assert.equal(cache.getFactsHydrationState(workspaceId).status, "ready");
   check("cold host store fails pending, explicitly hydrates and recalls durable evidence");
 
+  phase = "bounded-load";
   const count = 240;
   const started = performance.now();
   let cursor = 0;
@@ -271,6 +288,7 @@ try {
   assert.equal((await memory.listAllFactRecordsRaw("workspace-b")).length, 1);
   check("240 bounded writes at concurrency 8; hydration and selective-origin reads complete beyond 200 rows");
 
+  phase = "durable-write-recovery";
   await stopBackend("SIGKILL");
   const pending = host.write({ content: "Cobalt recovery milestone is Thursday.", segment: "project", createdBy: owner });
   await assert.rejects(host.flush());
@@ -281,6 +299,7 @@ try {
   assert.equal((await memory.listAllFactRecordsRaw("workspace-a")).length, 242);
   check("SIGKILL restart preserves accepted rows and retry flush persists retained pending write");
 
+  phase = "hydration-recovery";
   cache.__resetFactsCacheForTests();
   await stopBackend("SIGKILL");
   const cold = new HostFactStore(hostWorkspace);
@@ -294,8 +313,8 @@ try {
   results.status = "passed";
 } catch (error) {
   results.status = "failed";
-  results.error = redact(error?.stack ?? error);
-  console.error(results.error);
+  results.error = { phase, category: failureCategory(error) };
+  console.error(redact(error?.stack ?? error));
   process.exitCode = 1;
 } finally {
   try {
@@ -304,8 +323,8 @@ try {
     check("repository .env/.env.local unchanged; backend stopped; ephemeral keys and database removed");
   } catch (error) {
     results.status = "failed";
-    results.cleanupError = redact(error?.stack ?? error);
-    console.error(results.cleanupError);
+    results.cleanupError = { phase: "cleanup", category: failureCategory(error) };
+    console.error(redact(error?.stack ?? error));
     process.exitCode = 1;
   }
   results.finished = new Date().toISOString();

--- a/scripts/test-tideline-live-models.mjs
+++ b/scripts/test-tideline-live-models.mjs
@@ -11,6 +11,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { providerReportErrorCategory, validateProviderAnswerText, validateProviderReportMetadata } from "./lib/tideline-live-report-validation.mjs";
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), "tideline-live-models-"));
 const state = path.join(root, "state");
@@ -67,16 +68,18 @@ async function complete(model, messages, label, extra = {}) {
    body: JSON.stringify(request), signal: AbortSignal.timeout(55000),
   });
   const data = await response.json();
-  Object.assign(entry, { httpStatus: response.status, latencyMs: Date.now() - started, generationId: data.id,
-   returnedModel: data.model, provider: data.provider, usage: data.usage, finishReason: data.choices?.[0]?.finish_reason });
+  Object.assign(entry, { httpStatus: response.status, latencyMs: Date.now() - started });
   // Error payloads may contain provider request details; never log/store them.
-  if (!response.ok || data.error || !data.choices?.[0]?.message) throw new Error(`provider response failed (${response.status})`);
+  if (!response.ok || data?.error || !data?.choices?.[0]?.message) throw new Error(`provider response failed (${response.status})`);
+  const metadata = validateProviderReportMetadata(data, { models: supportedModels, providers: Object.values(providerNames) });
+  Object.assign(entry, metadata);
   saveReport();
-  return { message: data.choices[0].message, usage: data.usage, requestId: id, finishReason: data.choices[0].finish_reason };
+  return { message: data.choices[0].message, usage: metadata.usage, requestId: id, finishReason: metadata.finishReason };
  } catch (error) {
-  Object.assign(entry, { failed: true, error: error.name, latencyMs: Date.now() - started });
+  const category = providerReportErrorCategory(error);
+  Object.assign(entry, { failed: true, error: category, latencyMs: Date.now() - started });
   saveReport();
-  throw new Error(`Live request ${id} (${label}) failed: ${error.name}`);
+  throw new Error(`Live request ${id} (${label}) failed: ${category}`);
  }
 }
 
@@ -111,10 +114,8 @@ function normalizeAnswer(content) {
 }
 
 async function modelToolRoundTrip(model, workspace) {
- const toolStore = new FactStore(workspace);
- let memory = Tideline.over(toolStore, { threatScan: { scan: scanForThreats } });
  for (const stage of ["write", "recall"]) {
-  memory = Tideline.over(new FactStore(workspace), { threatScan: { scan: scanForThreats } });
+  const memory = Tideline.over(new FactStore(workspace), { threatScan: { scan: scanForThreats } });
   const localTools = memoryMcpTools(memory, { origin: owner });
   const name = stage === "write" ? "memory_add" : "memory_search";
   const messages = [{ role: "system", content: "Use the memory tool to complete the request. After the tool result, answer briefly using its data." },
@@ -191,8 +192,9 @@ try {
        response_format: { type: "json_schema", json_schema: { name: "memory_answer", strict: true,
         schema: { type: "object", properties: { answer: { type: "string" } }, required: ["answer"], additionalProperties: false } } },
       });
-     const actual = normalizeAnswer(answer.message.content ?? "");
-     report.answers.push({ model, caseId: fixture.id, repetition, arm, expected: fixture.answer, actual, rawAnswer: answer.message.content ?? null, correct: actual === fixture.answer && answer.finishReason === "stop", finishReason: answer.finishReason, requestId: answer.requestId, usage: answer.usage });
+     const rawAnswer = validateProviderAnswerText(answer.message.content);
+     const actual = normalizeAnswer(rawAnswer ?? "");
+     report.answers.push({ model, caseId: fixture.id, repetition, arm, expected: fixture.answer, actual, rawAnswer, correct: actual === fixture.answer && answer.finishReason === "stop", finishReason: answer.finishReason, requestId: answer.requestId, usage: answer.usage });
      saveReport();
     }
    }
@@ -227,9 +229,12 @@ try {
  if (!report.passed) process.exitCode = 1;
 } catch (error) {
  report.failed = true;
- report.failure = error.message.replace(/sk-or-[\w-]+/g, "[REDACTED]");
+ // Exceptions can contain provider text (for example invalid tool JSON). Keep
+ // only a local category in the artifact, just like the response metadata.
+ report.failure = "Live model validation failed";
+ report.failureCategory = providerReportErrorCategory(error);
  saveReport();
- console.error(JSON.stringify({ failure: report.failure, reportFile }));
+ console.error(JSON.stringify({ failure: report.failure, failureCategory: report.failureCategory, reportFile }));
  process.exitCode = 1;
 } finally {
  apiKey = undefined;

--- a/src/agents/memory/extract.ts
+++ b/src/agents/memory/extract.ts
@@ -25,7 +25,6 @@ import type { AgentSession } from "@earendil-works/pi-coding-agent";
 
 import { createSubsystemLogger } from "../../logging/subsystem-logger.js";
 import { pickInitialThinkingLevel } from "../../core/model-caps.js";
-import { workspaceIdFromDir } from "../../storage/facts-cache.js";
 import { tryGetRuntimeContext } from "../../storage/runtime-context.js";
 import { applyPersonaOverrideToSession } from "../../system-prompt/pi-injection.js";
 import { wrapStreamFnWithPayloadMutations } from "../payload-mutators.js";

--- a/src/tideline/exports/vault.ts
+++ b/src/tideline/exports/vault.ts
@@ -32,7 +32,6 @@ import { renameWithRetry } from "../../infra/fs/atomic-rename.js";
 import { cosine, getDefaultEmbedder } from "../embeddings/embedder.js";
 import { linksFrom, type MemoryLink, type MemoryLinkKind } from "../graph/links.js";
 import { originBucketKey, type MemoryRecord, type MemorySegment } from "../store/records.js";
-import { tokenize } from "../retrieval/scoring.js";
 
 const PIN_OPEN = "%% pinned %%";
 const PIN_CLOSE = "%% /pinned %%";

--- a/src/tideline/tests/live-convex-report.test.ts
+++ b/src/tideline/tests/live-convex-report.test.ts
@@ -12,7 +12,7 @@ test("Convex probe persists fixed failure evidence without network-controlled er
   const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tideline-convex-report-test-"));
   const networkText = "network-controlled-report-canary";
   const preload = "data:text/javascript," + encodeURIComponent(
-    `globalThis.fetch = async () => ({ ok: false, status: ${JSON.stringify(networkText)} });`,
+    'globalThis.fetch = async () => ({ ok: false, status: "network-controlled-report-canary" });',
   );
   try {
     // Download fails before any backend, imports or deployment. The injected

--- a/src/tideline/tests/live-convex-report.test.ts
+++ b/src/tideline/tests/live-convex-report.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const probe = fileURLToPath(new URL("../../../scripts/test-tideline-live-convex.mjs", import.meta.url));
+
+test("Convex probe persists fixed failure evidence without network-controlled error text", () => {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tideline-convex-report-test-"));
+  const networkText = "network-controlled-report-canary";
+  const preload = "data:text/javascript," + encodeURIComponent(
+    `globalThis.fetch = async () => ({ ok: false, status: ${JSON.stringify(networkText)} });`,
+  );
+  try {
+    // Download fails before any backend, imports or deployment. The injected
+    // response tests the complete catch/cleanup/report path without a network.
+    const child = spawnSync(process.execPath, ["--import", preload, probe, "--download"], {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        TMPDIR: temporaryRoot,
+        TMP: temporaryRoot,
+        TEMP: temporaryRoot,
+      },
+    });
+    assert.equal(child.status, 1, child.stderr);
+    const [artifact] = fs.readdirSync(temporaryRoot);
+    assert.ok(artifact);
+    assert.ok(artifact.startsWith("brigade-live-convex-"));
+    const artifactDir = path.join(temporaryRoot, artifact);
+    const resultText = fs.readFileSync(path.join(artifactDir, "result.json"), "utf8");
+    const result = JSON.parse(resultText) as { status: string; error: { phase: string; category: string }; checks: string[] };
+    assert.equal(result.status, "failed");
+    assert.deepEqual(result.error, { phase: "resolving-backend", category: "operation" });
+    assert.ok(result.checks.some((check) => check.includes("ephemeral keys and database removed")));
+    assert.equal(fs.existsSync(path.join(artifactDir, "runtime")), false);
+    for (const file of fs.readdirSync(artifactDir)) {
+      assert.equal(fs.readFileSync(path.join(artifactDir, file), "utf8").includes(networkText), false);
+    }
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+});

--- a/src/tideline/tests/live-report-validation.test.ts
+++ b/src/tideline/tests/live-report-validation.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+// @ts-expect-error The opt-in live-probe helper is JavaScript outside src.
+import { providerReportErrorCategory, validateProviderAnswerText, validateProviderReportMetadata } from "../../../scripts/lib/tideline-live-report-validation.mjs";
+
+const routes = { models: ["example/model"], providers: ["Example Provider"] };
+function response() {
+  return {
+    id: "gen-123-fixture",
+    model: "example/model",
+    provider: "Example Provider",
+    choices: [{ finish_reason: "stop" }],
+    usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120, cost: 0.0003, is_byok: false,
+      prompt_tokens_details: { cached_tokens: 60, cache_write_tokens: 15 },
+      completion_tokens_details: { reasoning_tokens: 5 },
+      cost_details: { upstream_inference_cost: 0.0002, upstream_inference_prompt_cost: 0.0001, upstream_inference_completions_cost: 0.0001 } },
+  };
+}
+
+test("retains token, cache and cost accounting while discarding unknown provider data", () => {
+  const clean = response();
+  const data = { ...clean, debug: { request: "untrusted-fixture" }, usage: {
+    ...clean.usage, arbitrary: { payload: "x".repeat(100_000) },
+    prompt_tokens_details: { ...clean.usage.prompt_tokens_details, unexpected: "untrusted-fixture" },
+    cost_details: { ...clean.usage.cost_details, debug: "untrusted-fixture" },
+  } };
+  const result = validateProviderReportMetadata(data, routes);
+  assert.deepEqual(result, { generationId: clean.id, returnedModel: clean.model, provider: clean.provider, usage: clean.usage, finishReason: "stop" });
+  assert.doesNotMatch(JSON.stringify(result), /arbitrary|unexpected|untrusted-fixture|debug/);
+  data.usage.prompt_tokens_details.cached_tokens = 0;
+  assert.equal(result.usage.prompt_tokens_details.cached_tokens, 60, "report must not share provider objects");
+});
+
+test("rejects malformed and oversized identity, routing and finish metadata without echoing values", () => {
+  for (const data of [
+    { ...response(), id: "../untrusted-fixture" },
+    { ...response(), id: "gen-untrusted-fixture\n" },
+    { ...response(), id: "x".repeat(129) },
+    { ...response(), id: { nested: "untrusted-fixture" } },
+    { ...response(), model: "untrusted-fixture" },
+    { ...response(), provider: "untrusted-fixture".repeat(10_000) },
+    { ...response(), choices: [{ finish_reason: { payload: "untrusted-fixture" } }] },
+    { ...response(), choices: [{ finish_reason: "untrusted-fixture" }] },
+  ]) {
+    assert.throws(() => validateProviderReportMetadata(data, routes), (error: unknown) => {
+      assert.ok(error instanceof TypeError);
+      assert.doesNotMatch(error.message, /untrusted-fixture/);
+      return true;
+    });
+  }
+});
+
+test("rejects nonnumeric, negative, fractional and excessive accounting", () => {
+  for (const value of ["100", {}, [], null, Number.NaN, Infinity, -1, 1.5, 2_000_001]) {
+    const data = { ...response(), usage: { ...response().usage, prompt_tokens: value } };
+    assert.throws(() => validateProviderReportMetadata(data, routes), /usage.prompt_tokens/);
+  }
+  for (const value of ["0.01", null, -0.1, Number.NaN, Infinity, 101]) {
+    const data = { ...response(), usage: { ...response().usage, cost: value } };
+    assert.throws(() => validateProviderReportMetadata(data, routes), /usage.cost/);
+  }
+  assert.throws(() => validateProviderReportMetadata({ ...response(), usage: { ...response().usage, prompt_tokens_details: { cached_tokens: "60" } } }, routes), /cached_tokens/);
+  assert.throws(() => validateProviderReportMetadata({ ...response(), usage: { ...response().usage, prompt_tokens_details: [] } }, routes), /prompt_tokens_details/);
+  assert.throws(() => validateProviderReportMetadata({ ...response(), usage: null }, routes), /usage/);
+});
+
+test("preserves zero cost and absent optional accounting without inventing cache hits", () => {
+  const data = { ...response(), usage: { prompt_tokens: 0, completion_tokens: 0, cost: 0 }, choices: [{ finish_reason: "length" }] };
+  assert.deepEqual(validateProviderReportMetadata(data, routes).usage, data.usage);
+  assert.equal(validateProviderReportMetadata(data, routes).finishReason, "length");
+});
+
+test("only bounded answer text can reach report serialization", () => {
+  assert.equal(validateProviderAnswerText('{"answer":"UNKNOWN"}'), '{"answer":"UNKNOWN"}');
+  assert.equal(validateProviderAnswerText(null), null);
+  for (const value of [{ answer: "untrusted-fixture" }, ["untrusted-fixture"], 42, "x".repeat(16_385)]) {
+    assert.throws(() => validateProviderAnswerText(value), /Invalid provider report field: answer/);
+  }
+});
+
+test("report failures retain only known error categories, never external exception text", () => {
+  assert.equal(providerReportErrorCategory(new TypeError("untrusted-fixture")), "TypeError");
+  assert.equal(providerReportErrorCategory({ name: "untrusted-fixture", message: "untrusted-fixture" }), "UnknownError");
+  assert.equal(providerReportErrorCategory(null), "UnknownError");
+});
+
+test("malformed provider metadata never reaches a saved live-probe report", () => {
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "tideline-live-report-test-"));
+  const repository = fileURLToPath(new URL("../../../", import.meta.url));
+  const canary = "untrusted-provider-report-canary";
+  const childSource = `
+    globalThis.fetch = async input => {
+      if (String(input) === "https://openrouter.ai/api/v1/models") return Response.json({ data: [
+        { id: "google/gemini-2.5-flash", pricing: { prompt: "0.0000001", completion: "0.000001" } }
+      ] });
+      if (String(input) !== "https://openrouter.ai/api/v1/chat/completions") throw new Error("Unexpected network access");
+      return Response.json({ id: "gen-valid-fixture", model: "google/gemini-2.5-flash", provider: "Google AI Studio",
+        usage: { prompt_tokens: 100, completion_tokens: 1, cost: { untrusted: ${JSON.stringify(canary)} } },
+        choices: [{ finish_reason: "stop", message: { role: "assistant", content: "{}" } }] });
+    };
+    process.argv = [process.execPath, "scripts/test-tideline-live-models.mjs", "--models=google/gemini-2.5-flash", "--credential-stdin"];
+    await import("./scripts/test-tideline-live-models.mjs");
+  `;
+  try {
+    const child = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", childSource], {
+      cwd: repository,
+      env: { PATH: process.env.PATH, SYSTEMROOT: process.env.SYSTEMROOT, TMPDIR: temporary, TMP: temporary, TEMP: temporary },
+      input: "inert-test-credential\n", encoding: "utf8", timeout: 30_000,
+    });
+    assert.equal(child.status, 1, child.stderr);
+    const directories = fs.readdirSync(temporary).filter(name => name.startsWith("tideline-live-models-"));
+    assert.equal(directories.length, 1);
+    const text = fs.readFileSync(path.join(temporary, directories[0]!, "results.json"), "utf8");
+    assert.doesNotMatch(text, new RegExp(canary));
+    const report = JSON.parse(text);
+    assert.equal(report.failed, true);
+    assert.equal(report.requests[0].failed, true);
+    assert.equal(report.requests[0].error, "TypeError");
+    assert.equal(report.requests[0].usage, undefined);
+    assert.equal(report.requests[0].generationId, undefined, "reject metadata before mutating the report entry");
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to merged PR #165. The migration remains intact; this addresses its review findings in a new PR.

- Remove unused imports in extraction and vault code and the dead memory initializer in the model probe.
- Project provider response metadata into a bounded schema before persistence, preserving token/cache/cost accounting and rejecting malformed known fields.
- Keep only fixed failure categories and local operation phases in saved model/Convex reports instead of arbitrary external error text.
- Add eight CI-discovered regressions, including subprocess probes proving malformed provider metadata cannot enter saved artifacts.

## Validation

- Full local suite passed, including these regressions and local benchmark-helper tests.
- Typecheck, build and isolated standalone-package verification passed.
- All eight focused report regressions passed after final file organization.
- Model-probe dry run passed without paid calls.
- No production memory behavior, origin gates or backend semantics changed.

The new public-dataset benchmark pipeline is separate work and is not included in this corrective PR. No benchmark score or customer billing claim is added. No auto-merge is requested.
